### PR TITLE
[WIP] refactor API

### DIFF
--- a/examples/MotorImagery/two_class_motor_imagery.py
+++ b/examples/MotorImagery/two_class_motor_imagery.py
@@ -9,7 +9,7 @@ from sklearn.svm import SVC
 
 from collections import OrderedDict
 from moabb.datasets import utils
-from moabb.viz import analyze
+from moabb.analysis import analyze
 
 import mne
 mne.set_log_level(False)
@@ -18,13 +18,17 @@ datasets = utils.dataset_search('imagery', events=['right_hand', 'left_hand'],
                                 has_all_events=True, min_subjects=2,
                                 multi_session=False)
 
+paradigm = LeftRightImagery()
+
+context = WithinSessionEvaluation(paradigm=paradigm,
+                                  datasets=datasets,
+                                  random_state=42)
+
 pipelines = OrderedDict()
 pipelines['TS'] = make_pipeline(Covariances('oas'), TSclassifier())
 pipelines['CSP+LDA'] = make_pipeline(Covariances('oas'), CSP(8), LDA())
 pipelines['CSP+SVM'] = make_pipeline(Covariances('oas'), CSP(8), SVC())  #
 
-context = LeftRightImagery(pipelines, WithinSessionEvaluation(), datasets)
-
-results = context.process()
+results = context.process(pipelines)
 
 analyze(results, './')

--- a/examples/MotorImagery/two_class_motor_imagery.py
+++ b/examples/MotorImagery/two_class_motor_imagery.py
@@ -14,6 +14,12 @@ from moabb.analysis import analyze
 import mne
 mne.set_log_level(False)
 
+import logging
+import coloredlogs
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger()
+coloredlogs.install(level=logging.INFO)
+
 datasets = utils.dataset_search('imagery', events=['right_hand', 'left_hand'],
                                 has_all_events=True, min_subjects=2,
                                 multi_session=False)

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 
 from sklearn.base import BaseEstimator
@@ -5,6 +6,8 @@ from sklearn.base import BaseEstimator
 from moabb.analysis import Results
 from moabb.datasets.base import BaseDataset
 from moabb.paradigms.base import BaseParadigm
+
+log = logging.getLogger()
 
 
 class BaseEvaluation(ABC):
@@ -80,7 +83,7 @@ class BaseEvaluation(ABC):
                           suffix=suffix)
 
         for dataset in self.datasets:
-            print('\n\nProcessing dataset: {}'.format(dataset.code))
+            log.info('Processing dataset: {}'.format(dataset.code))
             self.preprocess_data(dataset)
 
             for subject in dataset.subject_list:
@@ -91,10 +94,17 @@ class BaseEvaluation(ABC):
                 if len(run_pipes) > 0:
                     try:
                         res = self.evaluate(dataset, subject, run_pipes)
+                        for pipe in res:
+                            for r in res[pipe]:
+                                message = '{} | '.format(pipe)
+                                message += '{} | {} '.format(r['dataset'].code,
+                                                             r['id'])
+                                message += ': Score %.3f' % r['score']
+                            log.info(message)
                         results.add(res)
                     except Exception as e:
-                        print(e)
-                        print('Skipping subject {}'.format(subject))
+                        log.error(e)
+                        log.warning('Skipping subject {}'.format(subject))
         return results
 
     @abstractmethod

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -1,5 +1,10 @@
 from abc import ABC, abstractmethod
-import numpy as np
+
+from sklearn.base import BaseEstimator
+
+from moabb.analysis import Results
+from moabb.datasets.base import BaseDataset
+from moabb.paradigms.base import BaseParadigm
 
 
 class BaseEvaluation(ABC):
@@ -7,27 +12,100 @@ class BaseEvaluation(ABC):
     Evaluations determine what the train and test sets are and can implement
     additional data preprocessing steps for more complicated algorithms.
 
-    random_state: if not None, can guarantee same seed
-    n_jobs: 1; number of jobs for fitting of pipeline
+    Parameters
+    ----------
+    paradigm : Paradigm instance
+        the paradigm to use.
+    datasets : List of Dataset Instance.
+        The list of dataset to run the evaluation. If none, the list of
+        compatible dataset will be retrieved from the paradigm instance.
+    random_state:
+        if not None, can guarantee same seed
+    n_jobs: 1;
+        number of jobs for fitting of pipeline
 
     '''
 
-    def __init__(self, random_state=None, n_jobs=1):
+    def __init__(self, paradigm, datasets=None, random_state=None, n_jobs=1):
         """
         Init.
         """
-        if random_state is None:
-            self.random_state = np.random.randint(0, 1000, 1)[0]
+
+        self.random_state = random_state
         self.n_jobs = n_jobs
 
+        # check paradigm
+        if not isinstance(paradigm, BaseParadigm):
+            raise(ValueError("paradigm must be an Paradigm instance"))
+        self.paradigm = paradigm
+
+        # if no dataset provided, then we get the list from the paradigm
+        if datasets is None:
+            datasets = self.paradigm.datasets
+
+        if not isinstance(datasets, list):
+            if isinstance(datasets, BaseDataset):
+                datasets = [datasets]
+            else:
+                raise(ValueError("datasets must be a list or a dataset "
+                                 "instance"))
+
+        for dataset in datasets:
+            if not(isinstance(dataset, BaseDataset)):
+                raise(ValueError("datasets must only contains dataset "
+                                 "instance"))
+
+        for dataset in datasets:
+            self.paradigm.verify(dataset)
+
+        self.datasets = datasets
+
+    def process(self, pipelines, overwrite=False, suffix=''):
+        '''
+        Runs tasks on all given datasets.
+        '''
+
+        # check pipelines
+        if not isinstance(pipelines, dict):
+            raise(ValueError("pipelines must be a dict"))
+
+        for name, pipeline in pipelines.items():
+            if not(isinstance(pipeline, BaseEstimator)):
+                raise(ValueError("pipelines must only contains Pipelines "
+                                 "instance"))
+
+        results = Results(type(self),
+                          type(self.paradigm),
+                          overwrite=overwrite,
+                          suffix=suffix)
+
+        for dataset in self.datasets:
+            print('\n\nProcessing dataset: {}'.format(dataset.code))
+            self.preprocess_data(dataset)
+
+            for subject in dataset.subject_list:
+                # check if we already have result for this subject/pipeline
+                run_pipes = results.not_yet_computed(pipelines,
+                                                     dataset,
+                                                     subject)
+                if len(run_pipes) > 0:
+                    try:
+                        res = self.evaluate(dataset, subject, run_pipes)
+                        results.add(res)
+                    except Exception as e:
+                        print(e)
+                        print('Skipping subject {}'.format(subject))
+        return results
+
     @abstractmethod
-    def evaluate(self, dataset, subject, clf, paradigm):
+    def evaluate(self, dataset, subject, pipelines):
         '''
         Return results in a dict
         '''
         pass
 
-    def preprocess_data(self, dataset, paradigm):
+    @abstractmethod
+    def preprocess_data(self, dataset):
         '''
         Optional paramter if any sort of dataset-wide computation is needed
         per subject

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -1,5 +1,6 @@
 from time import time
 import numpy as np
+import logging
 
 from sklearn.model_selection import cross_val_score, LeaveOneGroupOut, KFold
 from sklearn.preprocessing import LabelEncoder
@@ -8,6 +9,7 @@ from mne.epochs import concatenate_epochs, equalize_epoch_counts
 
 from moabb.evaluations.base import BaseEvaluation
 
+log = logging.getLogger()
 
 class TrainTestEvaluation(BaseEvaluation):
     '''
@@ -120,7 +122,7 @@ class WithinSessionEvaluation(TrainTestEvaluation):
             X, y = self.extract_data_from_cont(epochs, event_id)
             if len(np.unique(y)) > 1:
                 counts = np.unique(y,return_counts=True)[1]
-                print('score imbalance: {}'.format(counts))
+                log.debug('score imbalance: {}'.format(counts))
                 for name, clf in pipelines.items():
                     t_start = time()
                     score = self.score(clf, X, y, self.paradigm.scoring)

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -192,7 +192,7 @@ class CrossSessionEvaluation(TrainTestEvaluation):
                          'n_channels':allX.shape[1]}
         return out
 
-    def preprocess_data(self, dataset, paradigm):
+    def preprocess_data(self, dataset):
         assert dataset.n_sessions > 1, "Proposed dataset {} has only one session".format(
             dataset.code)
 

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -48,7 +48,7 @@ class CrossSubjectEvaluation(TrainTestEvaluation):
 
     """
 
-    def evaluate(self, dataset, subject, pipelines, paradigm):
+    def evaluate(self, dataset, subject, pipelines):
         # requires that subject be an int
         s = subject-1
         self.ind_cache[s] = self.ind_cache[s]*0
@@ -60,7 +60,7 @@ class CrossSubjectEvaluation(TrainTestEvaluation):
         out = {}
         for name, clf in pipelines.items():
             t_start = time()
-            score = self.score(clf, allX, ally, groups, paradigm.scoring)
+            score = self.score(clf, allX, ally, groups, self.paradigm.scoring)
             duration = time() - t_start
             out[name] = {'time': duration,
                          'dataset': dataset,
@@ -70,7 +70,7 @@ class CrossSubjectEvaluation(TrainTestEvaluation):
                          'n_channels': allX.shape[1]}
         return out
 
-    def preprocess_data(self, dataset, paradigm):
+    def preprocess_data(self, dataset):
         assert len(dataset.subject_list) > 1, "Dataset {} has only one subject".format(
             dataset.code)
         self.X_cache = []
@@ -82,7 +82,7 @@ class CrossSubjectEvaluation(TrainTestEvaluation):
         for s in dataset.subject_list:
             sub = dataset.get_data([s], stack_sessions=True)[0]
             # get all epochs for individual files in given subject
-            epochs = paradigm._epochs(sub, event_id, dataset.interval)
+            epochs = self.paradigm._epochs(sub, event_id, dataset.interval)
             # equalize events from different classes
             X, y = self.extract_data_from_cont(epochs, event_id)
             self.X_cache.append(X)
@@ -103,7 +103,7 @@ class WithinSessionEvaluation(TrainTestEvaluation):
 
     """
 
-    def evaluate(self, dataset, subject, pipelines, paradigm):
+    def evaluate(self, dataset, subject, pipelines):
         """Prepare data for classification."""
         event_id = dataset.selected_events
         if not event_id:
@@ -116,14 +116,14 @@ class WithinSessionEvaluation(TrainTestEvaluation):
             # sess_id = '{:03d}_{:d}'.format(subject, ind)
 
             # get all epochs for individual files in given session
-            epochs = paradigm._epochs(session, event_id, dataset.interval)
+            epochs = self.paradigm._epochs(session, event_id, dataset.interval)
             X, y = self.extract_data_from_cont(epochs, event_id)
             if len(np.unique(y)) > 1:
                 counts = np.unique(y,return_counts=True)[1]
                 print('score imbalance: {}'.format(counts))
                 for name, clf in pipelines.items():
                     t_start = time()
-                    score = self.score(clf, X, y, paradigm.scoring)
+                    score = self.score(clf, X, y, self.paradigm.scoring)
                     duration = time() - t_start
                     out[name].append({'time': duration,
                                       'dataset': dataset,
@@ -142,6 +142,13 @@ class WithinSessionEvaluation(TrainTestEvaluation):
                               scoring=scoring, n_jobs=self.n_jobs)
         return acc.mean()
 
+    def preprocess_data(self, dataset):
+        '''
+        Optional paramter if any sort of dataset-wide computation is needed
+        per subject
+        '''
+        pass
+
 
 class CrossSessionEvaluation(TrainTestEvaluation):
     """Cross session Context.
@@ -151,7 +158,7 @@ class CrossSessionEvaluation(TrainTestEvaluation):
 
     """
 
-    def evaluate(self, dataset, subject, pipelines, paradigm):
+    def evaluate(self, dataset, subject, pipelines):
         event_id = dataset.selected_events
         if not event_id:
             raise(ValueError("Dataset had no selected events"))
@@ -161,7 +168,7 @@ class CrossSessionEvaluation(TrainTestEvaluation):
         listX, listy = ([], [])
         for ind, session in enumerate(sub):
             # get list epochs for individual files in given session
-            epochs = paradigm._epochs(session, event_id, dataset.interval)
+            epochs = self.paradigm._epochs(session, event_id, dataset.interval)
             # equalize events from different classes
             X, y = self.extract_data_from_cont(epochs, event_id)
             listX.append(X)
@@ -175,7 +182,7 @@ class CrossSessionEvaluation(TrainTestEvaluation):
         out = {}
         for name, clf in pipelines.items():
             t_start = time()
-            score = self.score(clf, allX, ally, groupvec, paradigm.scoring)
+            score = self.score(clf, allX, ally, groupvec, self.paradigm.scoring)
             duration = time() - t_start
             out[name] = {'time': duration,
                          'dataset': dataset,

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -1,56 +1,13 @@
-from abc import ABC, abstractmethod, abstractproperty
-import numpy as np
-
-from sklearn.base import BaseEstimator
-
-from moabb.datasets.base import BaseDataset
-from moabb.datasets import utils
+from abc import ABC, abstractproperty, abstractmethod
 
 
 class BaseParadigm(ABC):
     """Base Context.
-
-    Parameters
-    ----------
-    datasets : List of Dataset instances, or None
-        List of dataset instances on which the pipelines will be evaluated.
-        If None, uses all datasets (and should break...)
-    pipelines : Dict of pipelines instances.
-        Dictionary of pipelines. Keys identifies pipeline names, and values
-        are scikit-learn pipelines instances.
-    evaluator: Evaluator instance
-        Instance that defines evaluation scheme
     """
 
-    def __init__(self, pipelines, evaluator, datasets=None):
+    def __init__(self):
         """init"""
-        self.evaluator = evaluator
-        if datasets is None:
-            datasets = utils.dataset_list
-        # check dataset
-        if not isinstance(datasets, list):
-            if isinstance(datasets, BaseDataset):
-                datasets = [datasets]
-            else:
-                raise(ValueError("datasets must be a list or a dataset "
-                                 "instance"))
-
-        for dataset in datasets:
-            if not(isinstance(dataset, BaseDataset)):
-                raise(ValueError("datasets must only contains dataset "
-                                 "instance"))
-
-        self.datasets = datasets
-
-        # check pipelines
-        if not isinstance(pipelines, dict):
-            raise(ValueError("pipelines must be a dict"))
-
-        for name, pipeline in pipelines.items():
-            if not(isinstance(pipeline, BaseEstimator)):
-                raise(ValueError("pipelines must only contains Pipelines "
-                                 "instance"))
-        self.pipelines = pipelines
+        pass
 
     @abstractproperty
     def scoring(self):
@@ -60,3 +17,16 @@ class BaseParadigm(ABC):
 
         '''
         pass
+
+    @abstractproperty
+    def datasets(self):
+        '''Property that define the list of compatible datasets
+
+        '''
+        pass
+
+    @abstractmethod
+    def verify(self, dataset):
+        '''
+        Method that verifies dataset is correct for given parameters
+        '''

--- a/moabb/paradigms/motor_imagery.py
+++ b/moabb/paradigms/motor_imagery.py
@@ -121,4 +121,4 @@ class LeftRightImagery(BaseMotorImagery):
     def datasets(self):
         return utils.dataset_search(paradigm='imagery',
                                     events=['right_hand', 'left_hand'],
-                                    exact_events=True)
+                                    has_all_events=True)

--- a/moabb/tests/contexts.py
+++ b/moabb/tests/contexts.py
@@ -14,8 +14,9 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 
 pipelines = OrderedDict()
 pipelines['C'] = make_pipeline(Covariances('oas'), CSP(8), LDA())
-d = BNCI2014001()
-d.selected_events = {k: d.event_id[k] for k in ['left_hand', 'right_hand']}
+dataset = BNCI2014001()
+dataset.selected_events = {k: dataset.event_id[k]
+                           for k in ['left_hand', 'right_hand']}
 
 
 class Test_CrossSess(unittest.TestCase):
@@ -30,24 +31,22 @@ class Test_CrossSess(unittest.TestCase):
             os.remove('results.hd5')
 
     def return_eval(self):
-        return ev.CrossSessionEvaluation()
+        return ev.CrossSessionEvaluation(paradigm=LeftRightImagery())
 
     def test_eval_results(self):
         e = self.return_eval()
-        p = LeftRightImagery(pipelines, e, [d])
-        r = Results(evaluation_class=type(e), paradigm_class=type(p),
-                    suffix='test')
-        e.preprocess_data(d,p)
-        r.add(e.evaluate(d, 1,
-                         pipelines, p))
+        e.preprocess_data(dataset)
+        e.evaluate(dataset, 1, pipelines)
+
 
 class Test_CrossSubj(Test_CrossSess):
     def return_eval(self):
-        return ev.CrossSubjectEvaluation()
+        return ev.CrossSubjectEvaluation(paradigm=LeftRightImagery())
+
 
 class Test_WithinSess(Test_CrossSess):
     def return_eval(self):
-        return ev.WithinSessionEvaluation()
+        return ev.WithinSessionEvaluation(paradigm=LeftRightImagery())
 
 
 if __name__ == "__main__":

--- a/moabb/tests/contexts.py
+++ b/moabb/tests/contexts.py
@@ -7,7 +7,6 @@ import unittest
 from pyriemann.spatialfilters import CSP
 from pyriemann.estimation import Covariances
 from sklearn.pipeline import make_pipeline
-import os
 
 from collections import OrderedDict
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
@@ -15,8 +14,6 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 pipelines = OrderedDict()
 pipelines['C'] = make_pipeline(Covariances('oas'), CSP(8), LDA())
 dataset = BNCI2014001()
-dataset.selected_events = {k: dataset.event_id[k]
-                           for k in ['left_hand', 'right_hand']}
 
 
 class Test_CrossSess(unittest.TestCase):
@@ -26,12 +23,10 @@ class Test_CrossSess(unittest.TestCase):
     run it. Putting this on the future docket...
 
     '''
-    def tearDown(self):
-        if os.path.isfile('results.hd5'):
-            os.remove('results.hd5')
 
     def return_eval(self):
-        return ev.CrossSessionEvaluation(paradigm=LeftRightImagery())
+        return ev.CrossSessionEvaluation(paradigm=LeftRightImagery(),
+                                         datasets=[dataset])
 
     def test_eval_results(self):
         e = self.return_eval()
@@ -41,12 +36,14 @@ class Test_CrossSess(unittest.TestCase):
 
 class Test_CrossSubj(Test_CrossSess):
     def return_eval(self):
-        return ev.CrossSubjectEvaluation(paradigm=LeftRightImagery())
+        return ev.CrossSubjectEvaluation(paradigm=LeftRightImagery(),
+                                         datasets=[dataset])
 
 
 class Test_WithinSess(Test_CrossSess):
     def return_eval(self):
-        return ev.WithinSessionEvaluation(paradigm=LeftRightImagery())
+        return ev.WithinSessionEvaluation(paradigm=LeftRightImagery(),
+                                          datasets=[dataset])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When debugging, i found the API a little awkward in the sense that many classes where co-dependent.

major change are : 
- Evals are more generic than paradigm (because we can apply a same eval to different paradigm), so they are on top level
- pipelines are not passed to the constructor, but during process

So instead of : 
```python
context = LeftRightImagery(pipelines, WithinSessionEvaluation(), datasets)
results = context.process()
```
we now do : 
```python
context = WithinSessionEvaluation(paradigm=LeftRightImagery(), datasets=datasets)
results = context.process(pipelines)
```
This is still not ideal, and still not compatible with cross-dataset evaluation, but we will get there.