### PR TITLE
Support for multi-bandpass filtering

### DIFF
--- a/examples/MotorImagery/two_class_motor_imagery.py
+++ b/examples/MotorImagery/two_class_motor_imagery.py
@@ -28,21 +28,24 @@ datasets = utils.dataset_search('imagery', events=['right_hand', 'left_hand'],
 for d in datasets:
     d.subject_list = d.subject_list[:10]
 
-paradigm = LeftRightImageryMultiPass(fbands=np.array([[8,12],
-                                                      [12,16],
-                                                      [16,20],
-                                                      [20,24],
-                                                      [24,28],
-                                                      [28,32]]))
+paradigm = LeftRightImageryMultiPass(fbands=np.array([[8, 12],
+                                                      [12, 16],
+                                                      [16, 20],
+                                                      [20, 24],
+                                                      [24, 28],
+                                                      [28, 32]]))
 
 context = WithinSessionEvaluation(paradigm=paradigm,
                                   datasets=datasets,
                                   random_state=42)
 
 pipelines = OrderedDict()
-pipelines['av+TS'] = make_pipeline(mp.AverageCovariance(estimator='oas'), TSclassifier())
-pipelines['av+CSP+LDA'] = make_pipeline(mp.AverageCovariance(estimator='oas'), CSP(8), LDA())
-pipelines['FBCSP+LDA'] = make_pipeline(mp.MultibandCovariances(estimator='oas'), mp.FBCSP(), LDA())  #
+pipelines['av+TS'] = make_pipeline(
+    mp.AverageCovariance(estimator='oas'), TSclassifier())
+pipelines['av+CSP+LDA'] = make_pipeline(
+    mp.AverageCovariance(estimator='oas'), CSP(8), LDA())
+pipelines['FBCSP+LDA'] = make_pipeline(
+    mp.MultibandCovariances(estimator='oas'), mp.FBCSP(), LDA())  #
 
 results = context.process(pipelines, overwrite=True)
 

--- a/examples/MotorImagery/two_class_motor_imagery.py
+++ b/examples/MotorImagery/two_class_motor_imagery.py
@@ -1,6 +1,6 @@
 from moabb.evaluations import WithinSessionEvaluation
-from moabb.paradigms.motor_imagery import LeftRightImagery
-from pyriemann.estimation import Covariances
+from moabb.paradigms.motor_imagery import LeftRightImageryMultiPass
+from moabb.pipelines import multi_pass as mp
 from pyriemann.spatialfilters import CSP
 from pyriemann.classification import TSclassifier
 from sklearn.pipeline import make_pipeline
@@ -12,29 +12,38 @@ from moabb.datasets import utils
 from moabb.analysis import analyze
 
 import mne
+import numpy as np
 mne.set_log_level(False)
 
 import logging
 import coloredlogs
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
-coloredlogs.install(level=logging.INFO)
+coloredlogs.install(level=logging.DEBUG)
 
 datasets = utils.dataset_search('imagery', events=['right_hand', 'left_hand'],
                                 has_all_events=True, min_subjects=2,
                                 multi_session=False)
 
-paradigm = LeftRightImagery()
+for d in datasets:
+    d.subject_list = d.subject_list[:10]
+
+paradigm = LeftRightImageryMultiPass(fbands=np.array([[8,12],
+                                                      [12,16],
+                                                      [16,20],
+                                                      [20,24],
+                                                      [24,28],
+                                                      [28,32]]))
 
 context = WithinSessionEvaluation(paradigm=paradigm,
                                   datasets=datasets,
                                   random_state=42)
 
 pipelines = OrderedDict()
-pipelines['TS'] = make_pipeline(Covariances('oas'), TSclassifier())
-pipelines['CSP+LDA'] = make_pipeline(Covariances('oas'), CSP(8), LDA())
-pipelines['CSP+SVM'] = make_pipeline(Covariances('oas'), CSP(8), SVC())  #
+pipelines['av+TS'] = make_pipeline(mp.AverageCovariance(estimator='oas'), TSclassifier())
+pipelines['av+CSP+LDA'] = make_pipeline(mp.AverageCovariance(estimator='oas'), CSP(8), LDA())
+pipelines['FBCSP+LDA'] = make_pipeline(mp.MultibandCovariances(estimator='oas'), mp.FBCSP(), LDA())  #
 
-results = context.process(pipelines)
+results = context.process(pipelines, overwrite=True)
 
 analyze(results, './')

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 from abc import ABC, abstractmethod
 
 from sklearn.base import BaseEstimator
@@ -104,6 +105,7 @@ class BaseEvaluation(ABC):
                         results.add(res, pipelines=pipelines)
                     except Exception as e:
                         log.error(e)
+                        log.debug(traceback.format_exc())
                         log.warning('Skipping subject {}'.format(subject))
         return results
 

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -1,13 +1,12 @@
-from time import time
-import numpy as np
 import logging
+from time import time
 
+import numpy as np
 from sklearn.model_selection import cross_val_score, LeaveOneGroupOut, StratifiedKFold
 from sklearn.preprocessing import LabelEncoder
 
-from mne.epochs import concatenate_epochs, equalize_epoch_counts
-
 from moabb.evaluations.base import BaseEvaluation
+
 
 log = logging.getLogger()
 

--- a/moabb/paradigms/__init__.py
+++ b/moabb/paradigms/__init__.py
@@ -1,1 +1,1 @@
-from moabb.paradigms.motor_imagery import LeftRightImagery, ImageryNClass
+from moabb.paradigms.motor_imagery import *

--- a/moabb/paradigms/motor_imagery.py
+++ b/moabb/paradigms/motor_imagery.py
@@ -2,9 +2,12 @@
 
 import mne
 import numpy as np
+import logging
 
 from moabb.paradigms.base import BaseParadigm
 from moabb.datasets import utils
+
+log = logging.getLogger()
 
 
 class BaseMotorImagery(BaseParadigm):
@@ -71,7 +74,7 @@ class BaseMotorImagery(BaseParadigm):
                                         verbose=False, picks=picks)
                     ep.append(epochs)
 
-        return ep
+        return {1: ep}
 
     @property
     def datasets(self):
@@ -82,43 +85,109 @@ class BaseMotorImagery(BaseParadigm):
         return 'accuracy'
 
 
-class ImageryNClass(BaseMotorImagery):
-    """Imagery for multi class classification
+class MotorImageryMultiPass(BaseMotorImagery):
 
-    Returns n-class imagery results, visualization agnostic but forces all
-    datasets to have exactly n classes. Uses 'accuracy' as metric
-
-    """
-
-    def __init__(self, n_classes, **kwargs):
-        self.n_classes = n_classes
+    def __init__(self, fbands=np.array([[8, 14], [20, 30]]),
+                 channels=None, **kwargs):
+        """init"""
         super().__init__(**kwargs)
-
-    def verify(self, d):
-        print('Warning: Assumes events have already been selected per dataset')
-        super().verify(d)
-        assert len(d.selected_events) == self.n_classes
+        self.fbands = fbands
+        self.channels = channels
 
 
-class LeftRightImagery(BaseMotorImagery):
-    """Motor Imagery for left hand/right hand classification
+    def _epochs(self, raws, event_dict, time):
+        '''Take list of raws and returns a list of epoch objects. Implements
+        imagery-specific processing as well
 
-    Metric is 'roc_auc'
+        '''
+        if type(raws) is not list:
+            raws = [raws]
+        ep = []
+        out_dict = {i:[] for i in range(self.fbands.shape[0])}
+        for raw in raws:
+            events = mne.find_events(raw, shortest_event=0, verbose=False)
+            channels = () if self.channels is None else self.channels
+            # picks channels
+            picks = mne.pick_types(raw.info, eeg=True, stim=False,
+                                   include=channels)
 
-    """
+            # ensure events are desired:
+            if len(events) > 0:
+                keep_events = {key: val for key, val in event_dict.items() if
+                               val in np.unique(events[:, 2])}
+                if len(keep_events) > 0:
+                    # copy before filtering, so we let raws intact.
+                    for band_ind, (bp_low, bp_high) in enumerate(self.fbands):
+                        raw_f = raw.copy().filter(bp_low, bp_high, method='iir',
+                                                picks=picks, verbose=False)
+                        epochs = mne.Epochs(raw_f, events, event_id=keep_events,
+                                            tmin=time[0], tmax=time[1], proj=False,
+                                            baseline=None, preload=True,
+                                            verbose=False, picks=picks)
+                        out_dict[band_ind].append(epochs)
 
-    def verify(self, d):
-        events = ['left_hand', 'right_hand']
-        super().verify(d)
-        assert set(events) <= set(d.event_id.keys())
-        d.selected_events = dict(zip(events, [d.event_id[s] for s in events]))
+        return out_dict
+    
+def ImageryNClassFactory(parent):
 
-    @property
-    def scoring(self):
-        return 'roc_auc'
+    class ImageryNClass(parent):
+        """Imagery for multi class classification
 
-    @property
-    def datasets(self):
-        return utils.dataset_search(paradigm='imagery',
-                                    events=['right_hand', 'left_hand'],
-                                    has_all_events=True)
+        Returns n-class imagery results, visualization agnostic but forces all
+        datasets to have exactly n classes. Uses 'accuracy' as metric
+
+        """
+
+        def __init__(self, n_classes, **kwargs):
+            self.n_classes = n_classes
+            super().__init__(**kwargs)
+
+        def verify(self, d):
+            log.warning(
+                'Assumes events have already been selected per dataset')
+            super().verify(d)
+            assert len(d.selected_events) == self.n_classes
+
+        @property
+        def datasets(self):
+            return utils.dataset_search(paradigm='imagery',
+                                        total_classes=self.n_classes,
+                                        has_all_events=True)
+
+    return ImageryNClass
+
+
+def LeftRightImageryFactory(parent):
+    class LeftRightImagery(parent):
+        """Motor Imagery for left hand/right hand classification
+
+        Metric is 'roc_auc'
+
+        """
+
+        def verify(self, d):
+            events = ['left_hand', 'right_hand']
+            super().verify(d)
+            assert set(events) <= set(d.event_id.keys())
+            d.selected_events = dict(
+                zip(events, [d.event_id[s] for s in events]))
+
+        @property
+        def scoring(self):
+            return 'roc_auc'
+
+        @property
+        def datasets(self):
+            return utils.dataset_search(paradigm='imagery',
+                                        events=['right_hand', 'left_hand'],
+                                        has_all_events=True)
+    return LeftRightImagery
+
+
+globals()['LeftRightImagerySinglePass'] = LeftRightImageryFactory(
+    BaseMotorImagery)
+globals()['ImageryNClassSinglePass'] = ImageryNClassFactory(BaseMotorImagery)
+globals()['LeftRightImageryMultiPass'] = LeftRightImageryFactory(
+    MotorImageryMultiPass)
+globals()['ImageryNClassMultiPass'] = ImageryNClassFactory(
+    MotorImageryMultiPass)

--- a/moabb/paradigms/motor_imagery.py
+++ b/moabb/paradigms/motor_imagery.py
@@ -51,6 +51,9 @@ class BaseMotorImagery(BaseParadigm):
             assert dataset.interval[1] > self.interval[1]
 
     def raw_to_trials(self, raw, events, picks, event_dict, time):
+        '''
+        Given a single raw file turn it into a features matrix and labels
+        '''
         raw_f = raw.filter(self.fmin, self.fmax, method='iir', picks=picks,
                            verbose=False)
         epochs = mne.Epochs(raw_f, events, event_id=event_dict,

--- a/moabb/pipelines/features.py
+++ b/moabb/pipelines/features.py
@@ -1,13 +1,108 @@
+from sklearn.base import BaseEstimator, TransformerMixin, clone
+from pyriemann.spatialfilters import CSP
+from pyriemann.estimation import Covariances as Cov
+import functools
 import numpy as np
-from sklearn.base import BaseEstimator, TransformerMixin
+import logging
+
+log = logging.getLogger()
+
+class EEGFeatures(BaseEstimator, TransformerMixin):
+
+    def fit(self, X, y):
+        return self
+
+    def transform(self, X, y):
+        pass
 
 
-class LogVariance(BaseEstimator, TransformerMixin):
+class LogVariance(EEGFeatures):
 
     def fit(self, X, y):
         """fit."""
         return self
 
     def transform(self, X):
-        """transform."""
-        return np.log(np.var(X, -1))
+        """transform, concatenating all frequency bands."""
+        return np.concatenate([np.log(np.var(X[..., i], -1)) for i in range(X.shape[-1])],axis=1)
+
+
+class MultibandCovariances(EEGFeatures):
+
+    def __init__(self, estimator='scm', est=None):
+        """Init."""
+        if est is None:
+            self.est = Cov(estimator=estimator)
+        else:
+            self.est = est
+
+    def transform(self, X):
+        if X.shape[-1] == 1:
+            return self.est.transform(X[..., 0])[..., None]
+        else:
+            return np.stack([self.est.transform(X[..., i]) for i in range(X.shape[-1])], axis=3)
+
+
+class AverageCovariances(MultibandCovariances):
+
+    def transform(self, X):
+        return super().transform(X).mean(axis=-1)
+
+
+class FBCSP(BaseEstimator, TransformerMixin):
+    """Implementation of the CSP spatial Filtering with Covariance as input.
+
+    Implementation of the famous Common Spatial Pattern Algorithm, but with
+    covariance matrices as input. In addition, the implementation allow
+    different metric for the estimation of the class-related mean covariance
+    matrices, as described in [3].
+
+    This implementation support multiclass CSP by means of approximate joint
+    diagonalization. In this case, the spatial filter selection is achieved
+    according to [4].
+
+    Parameters
+    ----------
+    nfilter : int (default 10)
+        The number of components to decompose M/EEG signals.
+    metric : str (default "euclid")
+        The metric for the estimation of mean covariance matrices
+    log : bool (default True)
+        If true, return the log variance, otherwise return the spatially
+        filtered covariance matrices.
+
+    Attributes
+    ----------
+    filters_ : ndarray
+        If fit, the CSP spatial filters, else None.
+    patterns_ : ndarray
+        If fit, the CSP spatial patterns, else None.
+
+
+    See Also
+    --------
+    MDM, SPoC
+
+    References
+    ----------
+    """
+
+    def __init__(self, filter_obj, feature_selector):
+        """Init."""
+        self.filter_obj = filter_obj
+        self.feature_selector = feature_selector
+
+    def fit(self, X, y):
+        assert X.ndim == 4, 'insufficient dimensions in given data'
+        self.filters = [clone(self.filter_obj) for i in range(X.shape[-1])]
+        [self.filters[i].fit(X[..., i], y) for i in range(X.shape[-1])]
+        self.feature_selector.fit(self._transform(X), y)
+        return self
+
+    def _transform(self, X):
+        assert X.shape[-1] == len(self.filters), "given X has {} band passes while trained model has {}".format(X.shape[-1], len(self.filters))
+        return np.concatenate([self.filters[i].transform(X[..., i])
+                            for i in range(X.shape[-1])])
+
+    def transform(self, X):
+        return self.feature_selector.transform(self._transform(X))

--- a/moabb/pipelines/single_pass.py
+++ b/moabb/pipelines/single_pass.py
@@ -1,0 +1,14 @@
+from sklearn.base import BaseEstimator, TransformerMixin
+import numpy as np
+
+
+class LogVariance(BaseEstimator, TransformerMixin):
+
+    def fit(self, X, y):
+        """fit."""
+        return self
+
+    def transform(self, X):
+        """transform"""
+        assert X.ndim == 3
+        return np.log(np.var(X, -1))

--- a/pipelines/CSP.yml
+++ b/pipelines/CSP.yml
@@ -1,6 +1,6 @@
 name: CSP + LDA
 paradigms:
-  - LeftRightImagery
+  - LeftRightImagerySinglePass
 
 citations:
   - https://doi.org/10.1007/BF01129656

--- a/pipelines/CSP_SVM.yml
+++ b/pipelines/CSP_SVM.yml
@@ -1,6 +1,6 @@
 name: CSP + SVM
 paradigms:
-  - LeftRightImagery
+  - LeftRightImagerySinglePass
 
 citations:
   - https://doi.org/10.1007/BF01129656

--- a/pipelines/LogVar.yml
+++ b/pipelines/LogVar.yml
@@ -1,11 +1,11 @@
 name: Log Variance LDA
 
 paradigms:
-  - LeftRightImagery
+  - LeftRightImagerySinglePass
 
 pipeline:
   - name: LogVariance
-    from: moabb.pipelines.features
+    from: moabb.pipelines.single_pass
 
   - name: LinearDiscriminantAnalysis
     from: sklearn.discriminant_analysis

--- a/pipelines/LogVarSVM.yml
+++ b/pipelines/LogVarSVM.yml
@@ -1,11 +1,11 @@
 name: Log Variance SVM
 
 paradigms:
-  - LeftRightImagery
+  - LeftRightImagerySinglePass
 
 pipeline:
   - name: LogVariance
-    from: moabb.pipelines.features
+    from: moabb.pipelines.single_pass
 
   - name: SVC
     from: sklearn.svm

--- a/pipelines/MDM.yml
+++ b/pipelines/MDM.yml
@@ -1,6 +1,6 @@
 name: MDM
 paradigms:
-  - LeftRightImagery
+  - LeftRightImagerySinglePass
 
 citations:
   - https://doi.org/10.1109/TBME.2011.2172210

--- a/pipelines/TSLR.yml
+++ b/pipelines/TSLR.yml
@@ -1,7 +1,7 @@
 name: Tangent Space LR
 
 paradigms:
-  - LeftRightImagery
+  - LeftRightImagerySinglePass
 
 citations:
   - https://doi.org/10.1016/j.neucom.2012.12.039

--- a/pipelines/TSSVM.yml
+++ b/pipelines/TSSVM.yml
@@ -1,7 +1,7 @@
 name: Tangent Space SVM
 
 paradigms:
-  - LeftRightImagery
+  - LeftRightImagerySinglePass
 
 citations:
   - https://doi.org/10.1016/j.neucom.2012.12.039


### PR DESCRIPTION
Added a new set of paradigms and feature generators that deal with multiple bandpasses of the raw data in new paradigms. 

+ made paradigm factories to reflect differing base classes
+ Split features into single_pass and multi_pass for multiple frequency passes
+ rewrote epochs-to-trials function to deal with multiple time-series per trial (not great)