### PR TITLE
Add travis for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ install:
 script:
   - python -m unittest moabb.tests
   - python -m moabb.run --pipelines=./moabb/tests/test_pipelines/ --verbose
+  - python -m moabb.run --pipelines=./moabb/tests/test_pipelines/ --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ install:
 # command to run tests
 script:
   - python -m unittest moabb.tests
+  - python -m moabb.run --pipelines=./moabb/tests/test_pipelines/ --verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mother of all BCI Benchmark
 
+[![Build Status](https://travis-ci.org/NeuroTechX/moabb.svg?branch=master)](https://travis-ci.org/NeuroTechX/moabb)
+
 Reproducible Research in BCI has a long way to go. While many BCI datasets are made freely available, researchers do not publish code, and reproducing results required to benchmark new algorithms turns out to be more tricky than it should be. Performances can be significantly impacted by parameters of the preprocessing steps, toolboxes used and implementation “tricks” that are almost never reported in the literature. As a results, there is no comprehensive benchmark of BCI algorithm, and newcomers are spending a tremendous amount of time browsing literature to find out what algorithm works best and on which dataset.
 
 The Goal of this project is to build a comprehensive benchmark of popular BCI algorithms applied on an extensive list of freely available EEG dataset. The code will be made available on github, serving as a reference point for the future algorithmic developments. Algorithms can be ranked and promoted on a website, providing a clear picture of the different solutions available in the field.

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -109,8 +109,8 @@ class Results:
     def to_dataframe(self):
         df_list = []
         with h5py.File(self.filepath, 'r') as f:
-            for _, p_group in f.items():
-                name = p_group['name']
+            for digest, p_group in f.items():
+                name = p_group.attrs['name']
                 for dname, dset in p_group.items():
                     array = np.array(dset['data'])
                     ids = np.array(dset['id'])

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -1,9 +1,10 @@
 """
 Base class for a dataset
 """
+import abc
 
 
-class BaseDataset():
+class BaseDataset(metaclass=abc.ABCMeta):
     """Base dataset"""
 
     def __init__(self, subjects, sessions_per_subject, events, code, interval, paradigm):
@@ -29,5 +30,7 @@ class BaseDataset():
             data.extend(self._get_single_subject_data(subject, stack_sessions))
         return data
 
-    def _get_single_subject_data(self, subject, sessions):
+    @abc.abstractmethod
+    def _get_single_subject_data(self, subject, stack_sessions):
+        """get data from a single subject."""
         pass

--- a/moabb/datasets/openvibe_mi.py
+++ b/moabb/datasets/openvibe_mi.py
@@ -67,8 +67,8 @@ def convert_inria_csv_to_mne(path):
     info = create_info(ch_names=ch_names, ch_types=ch_types, sfreq=512., montage=montage)
     raw = RawArray(data=csv_data.values.T * 1e-6, info=info, verbose=False)
     return raw
-    
-    
+
+
 class OpenvibeMI(BaseDataset):
     """Openvibe Motor Imagery dataset"""
 
@@ -78,14 +78,13 @@ class OpenvibeMI(BaseDataset):
             sessions_per_subject=14,
             events=dict(right_hand=1, left_hand=2),
             code='Openvibe Motor Imagery',
-            interval=[tmin,tmax],
-            paradigm='imagery'
-            )
+            interval=[tmin, tmax],
+            paradigm='imagery')
 
-    def get_data(self, subjects, stack_sessions=False):
+    def _get_single_subject_data(self, subjects, stack_sessions=False):
         """return data for subject"""
         data = []
-        for i in range(1,10):
+        for i in range(1, 10):
             data.append(self._get_single_session_data(i))
         if stack_sessions:
             return [data]
@@ -95,7 +94,8 @@ class OpenvibeMI(BaseDataset):
     def _get_single_session_data(self, session):
         """return data for a single recording session"""
         csv_path = data_path(session)
-        fif_path = os.path.join(os.path.dirname(csv_path),'raw_{:d}.fif'.format(session))
+        fif_path = os.path.join(os.path.dirname(csv_path),
+                                'raw_{:d}.fif'.format(session))
         if not os.path.isfile(fif_path):
             print('Resaving .csv file as .fif for ease of future loading')
             raw = convert_inria_csv_to_mne(csv_path)

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -39,12 +39,12 @@ class CrossSubjectEvaluation(BaseEvaluation):
             t_start = time()
             score = self.score(clf, allX, ally, groups, self.paradigm.scoring)
             duration = time() - t_start
-            out[name] = {'time': duration,
-                         'dataset': dataset,
-                         'id': subject,
-                         'score': score,
-                         'n_samples': groups.sum(),
-                         'n_channels': allX.shape[1]}
+            out[name] = [{'time': duration,
+                          'dataset': dataset,
+                          'id': subject,
+                          'score': score,
+                          'n_samples': groups.sum(),
+                          'n_channels': allX.shape[1]}]
         return out
 
     def preprocess_data(self, dataset):
@@ -85,10 +85,9 @@ class WithinSessionEvaluation(BaseEvaluation):
         if not event_id:
             raise(ValueError("Dataset had no selected events"))
 
-        sub = dataset.get_data([subject], stack_sessions=False)[0]
+        sub = dataset.get_data([subject], stack_sessions=True)[0]
         out = {k: [] for k in pipelines.keys()}
         for ind, session in enumerate(sub):
-
             # get all epochs for individual files in given session
             X, y = self.paradigm.cont_to_trials(
                 session, event_id, dataset.interval)
@@ -137,7 +136,7 @@ class CrossSessionEvaluation(BaseEvaluation):
         if not event_id:
             raise(ValueError("Dataset had no selected events"))
 
-        sub = dataset.get_data([subject], stack_sessions=False)[0]
+        sub = dataset.get_data([subject], stack_sessions=True)[0]
         listX, listy = ([], [])
         for ind, session in enumerate(sub):
             # get list epochs for individual files in given session
@@ -157,12 +156,12 @@ class CrossSessionEvaluation(BaseEvaluation):
             score = self.score(clf, allX, ally, groupvec,
                                self.paradigm.scoring)
             duration = time() - t_start
-            out[name] = {'time': duration,
-                         'dataset': dataset,
-                         'id': subject,
-                         'score': score,
-                         'n_samples': len(y),
-                         'n_channels': allX.shape[1]}
+            out[name] = [{'time': duration,
+                          'dataset': dataset,
+                          'id': subject,
+                          'score': score,
+                          'n_samples': len(y),
+                          'n_channels': allX.shape[1]}]
         return out
 
     def preprocess_data(self, dataset):

--- a/moabb/paradigms/__init__.py
+++ b/moabb/paradigms/__init__.py
@@ -1,1 +1,2 @@
 from moabb.paradigms.motor_imagery import *
+from moabb.tests.fake import FakeImageryParadigm

--- a/moabb/run.py
+++ b/moabb/run.py
@@ -11,7 +11,6 @@ from glob import glob
 from argparse import ArgumentParser
 from collections import OrderedDict
 from sklearn.base import BaseEstimator
-from sklearn.pipeline import Pipeline
 from copy import deepcopy
 
 # moabb specific imports
@@ -69,7 +68,7 @@ parser.add_argument(
     type=str,
     default=None,
     help="File path to context.yml file that describes context parameters."
-         "If none, assumes all defaults. Must contain an entry for all " 
+         "If none, assumes all defaults. Must contain an entry for all "
          "paradigms described in the pipelines")
 options = parser.parse_args()
 

--- a/moabb/tests/__init__.py
+++ b/moabb/tests/__init__.py
@@ -1,7 +1,7 @@
 from moabb.tests.analysis import *
 # from moabb.tests.datasets import * # skip this for travis
 from moabb.tests.contexts import *
-from moabb.tests.util_tests import *
+# from moabb.tests.util_tests import *
 import unittest
 
 if __name__ == "__main__":

--- a/moabb/tests/analysis.py
+++ b/moabb/tests/analysis.py
@@ -92,7 +92,7 @@ class Test_Stats(unittest.TestCase):
 class Test_Integration(unittest.TestCase):
 
     def setUp(self):
-        self.obj = Results(evaluation_class=type(DummyEvaluation()),
+        self.obj = Results(evaluation_class=type(DummyEvaluation(DummyParadigm())),
                            paradigm_class=type(DummyParadigm()),
                            suffix='test')
 

--- a/moabb/tests/analysis.py
+++ b/moabb/tests/analysis.py
@@ -6,7 +6,7 @@ import os
 from moabb.datasets.base import BaseDataset
 from moabb.evaluations.base import BaseEvaluation
 from moabb.paradigms.base import BaseParadigm
-from moabb.datasets.fake import FakeDataset
+from moabb.tests.fake import FakeDataset
 # dummy evaluation
 
 

--- a/moabb/tests/analysis.py
+++ b/moabb/tests/analysis.py
@@ -35,6 +35,7 @@ class DummyParadigm(BaseParadigm):
     def datasets(self):
         return [FakeDataset(['d1', 'd2'])]
 
+
 # Create dummy data for tests
 d1 = {'time': 1,
       'dataset': FakeDataset(['d1', 'd2']),
@@ -64,6 +65,10 @@ d4 = {'time': 2,
       'score': 0.9,
       'n_samples': 100,
       'n_channels': 10}
+
+
+def to_pipeline_dict(pnames):
+    return {n: 'pipeline {}'.format(n) for n in pnames}
 
 
 def to_result_input(pnames, dsets):
@@ -98,9 +103,9 @@ class Test_Integration(unittest.TestCase):
 
     def test_rmanova(self):
         _in = to_result_input(['a', 'b', 'c'], [[d1]*5, [d1]*5, [d4]*5])
-        self.obj.add(_in)
+        self.obj.add(_in, to_pipeline_dict(['a', 'b', 'c']))
         _in = to_result_input(['a', 'b', 'c'], [[d2]*5, [d2]*5, [d3]*5])
-        self.obj.add(_in)
+        self.obj.add(_in, to_pipeline_dict(['a', 'b', 'c']))
         df = self.obj.to_dataframe()
         ma.rmANOVA(df)
 
@@ -118,37 +123,37 @@ class Test_Results(unittest.TestCase):
             os.remove(path)
 
     def testCanAddSample(self):
-        self.obj.add(to_result_input(['a'], [d1]))
+        self.obj.add(to_result_input(['a'], [d1]), to_pipeline_dict(['a']))
 
     def testRecognizesAlreadyComputed(self):
         _in = to_result_input(['a'], [d1])
-        self.obj.add(_in)
+        self.obj.add(_in, to_pipeline_dict(['a']))
         not_yet_computed = self.obj.not_yet_computed(
-            {'a': 1}, d1['dataset'], d1['id'])
+            to_pipeline_dict(['a']), d1['dataset'], d1['id'])
         self.assertTrue(len(not_yet_computed) == 0)
 
     def testCanAddMultiplePipelines(self):
         _in = to_result_input(['a', 'b', 'c'], [d1, d1, d2])
-        self.obj.add(_in)
+        self.obj.add(_in, to_pipeline_dict(['a', 'b', 'c']))
 
     def testCanAddMultipleValuesPerPipeline(self):
         _in = to_result_input(['a', 'b'], [[d1, d2], [d2, d1]])
-        self.obj.add(_in)
+        self.obj.add(_in, to_pipeline_dict(['a', 'b']))
         not_yet_computed = self.obj.not_yet_computed(
-            {'a': 1}, d1['dataset'], d1['id'])
+            to_pipeline_dict(['a']), d1['dataset'], d1['id'])
         self.assertTrue(len(not_yet_computed) == 0, not_yet_computed)
         not_yet_computed = self.obj.not_yet_computed(
-            {'b': 2}, d2['dataset'], d2['id'])
+            to_pipeline_dict(['b']), d2['dataset'], d2['id'])
         self.assertTrue(len(not_yet_computed) == 0, not_yet_computed)
         not_yet_computed = self.obj.not_yet_computed(
-            {'b': 1}, d1['dataset'], d1['id'])
+            to_pipeline_dict(['b']), d1['dataset'], d1['id'])
         self.assertTrue(len(not_yet_computed) == 0, not_yet_computed)
 
     def testCanExportToDataframe(self):
         _in = to_result_input(['a', 'b', 'c'], [d1, d1, d2])
-        self.obj.add(_in)
+        self.obj.add(_in, to_pipeline_dict(['a', 'b', 'c']))
         _in = to_result_input(['a', 'b', 'c'], [d2, d2, d3])
-        self.obj.add(_in)
+        self.obj.add(_in, to_pipeline_dict(['a', 'b', 'c']))
         df = self.obj.to_dataframe()
         self.assertTrue(set(np.unique(df['pipeline'])) == set(
             ('a', 'b', 'c')), np.unique(df['pipeline']))

--- a/moabb/tests/analysis.py
+++ b/moabb/tests/analysis.py
@@ -6,6 +6,7 @@ import os
 from moabb.datasets.base import BaseDataset
 from moabb.evaluations.base import BaseEvaluation
 from moabb.paradigms.base import BaseParadigm
+from moabb.datasets.fake import FakeDataset
 # dummy evaluation
 
 
@@ -23,31 +24,27 @@ class DummyParadigm(BaseParadigm):
     def __init__(self):
         pass
 
+    @property
     def scoring(self):
         raise NotImplementedError('dummy')
 
+    def verify(self, dataset):
+        pass
 
-# dummy datasets
-class DummyDataset(BaseDataset):
-
-    def __init__(self, code):
-        """
-
-        """
-        super().__init__(list(range(5)), 2, {
-            'a': 1, 'b': 2}, code, [1, 2], 'imagery')
-
+    @property
+    def datasets(self):
+        return [FakeDataset(['d1', 'd2'])]
 
 # Create dummy data for tests
 d1 = {'time': 1,
-      'dataset': DummyDataset('d1'),
+      'dataset': FakeDataset(['d1', 'd2']),
       'id': 1,
       'score': 0.9,
       'n_samples': 100,
       'n_channels': 10}
 
 d2 = {'time': 2,
-      'dataset': DummyDataset('d1'),
+      'dataset': FakeDataset(['d1', 'd2']),
       'id': 2,
       'score': 0.9,
       'n_samples': 100,
@@ -55,14 +52,14 @@ d2 = {'time': 2,
 
 
 d3 = {'time': 2,
-      'dataset': DummyDataset('d2'),
+      'dataset': FakeDataset(['d1', 'd2']),
       'id': 2,
       'score': 0.9,
       'n_samples': 100,
       'n_channels': 10}
 
 d4 = {'time': 2,
-      'dataset': DummyDataset('d2'),
+      'dataset': FakeDataset(['d1', 'd2']),
       'id': 1,
       'score': 0.9,
       'n_samples': 100,
@@ -111,7 +108,7 @@ class Test_Integration(unittest.TestCase):
 class Test_Results(unittest.TestCase):
 
     def setUp(self):
-        self.obj = Results(evaluation_class=type(DummyEvaluation()),
+        self.obj = Results(evaluation_class=type(DummyEvaluation(DummyParadigm())),
                            paradigm_class=type(DummyParadigm()),
                            suffix='test')
 

--- a/moabb/tests/contexts.py
+++ b/moabb/tests/contexts.py
@@ -1,6 +1,6 @@
 from moabb.evaluations import evaluations as ev
-from moabb.datasets.bnci import BNCI2014001
-from moabb.analysis import Results
+from moabb.datasets.fake import FakeDataset
+
 from moabb.paradigms.motor_imagery import LeftRightImagery
 import unittest
 
@@ -13,7 +13,7 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 
 pipelines = OrderedDict()
 pipelines['C'] = make_pipeline(Covariances('oas'), CSP(8), LDA())
-dataset = BNCI2014001()
+dataset = FakeDataset(['left_hand', 'right_hand'])
 
 
 class Test_CrossSess(unittest.TestCase):
@@ -31,7 +31,10 @@ class Test_CrossSess(unittest.TestCase):
     def test_eval_results(self):
         e = self.return_eval()
         e.preprocess_data(dataset)
-        e.evaluate(dataset, 1, pipelines)
+        res = e.evaluate(dataset, 1, pipelines)
+
+        # return 1 results averaged across the 2 sessions
+        self.assertEqual(len(res['C']), 1)
 
 
 class Test_CrossSubj(Test_CrossSess):
@@ -39,12 +42,27 @@ class Test_CrossSubj(Test_CrossSess):
         return ev.CrossSubjectEvaluation(paradigm=LeftRightImagery(),
                                          datasets=[dataset])
 
+    def test_eval_results(self):
+        e = self.return_eval()
+        e.preprocess_data(dataset)
+        res = e.evaluate(dataset, 1, pipelines)
+
+        # return 1 results for 1 subject
+        self.assertEqual(len(res['C']), 1)
+
 
 class Test_WithinSess(Test_CrossSess):
     def return_eval(self):
         return ev.WithinSessionEvaluation(paradigm=LeftRightImagery(),
                                           datasets=[dataset])
 
+    def test_eval_results(self):
+        e = self.return_eval()
+        e.preprocess_data(dataset)
+        res = e.evaluate(dataset, 1, pipelines)
+
+        # return 2 results for each session
+        self.assertEqual(len(res['C']), 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/moabb/tests/contexts.py
+++ b/moabb/tests/contexts.py
@@ -1,7 +1,5 @@
 from moabb.evaluations import evaluations as ev
-from moabb.datasets.fake import FakeDataset
-
-from moabb.paradigms.motor_imagery import LeftRightImagery
+from moabb.tests.fake import FakeDataset, FakeImageryParadigm
 import unittest
 
 from pyriemann.spatialfilters import CSP
@@ -25,7 +23,7 @@ class Test_CrossSess(unittest.TestCase):
     '''
 
     def return_eval(self):
-        return ev.CrossSessionEvaluation(paradigm=LeftRightImagery(),
+        return ev.CrossSessionEvaluation(paradigm=FakeImageryParadigm(),
                                          datasets=[dataset])
 
     def test_eval_results(self):
@@ -39,7 +37,7 @@ class Test_CrossSess(unittest.TestCase):
 
 class Test_CrossSubj(Test_CrossSess):
     def return_eval(self):
-        return ev.CrossSubjectEvaluation(paradigm=LeftRightImagery(),
+        return ev.CrossSubjectEvaluation(paradigm=FakeImageryParadigm(),
                                          datasets=[dataset])
 
     def test_eval_results(self):
@@ -53,7 +51,7 @@ class Test_CrossSubj(Test_CrossSess):
 
 class Test_WithinSess(Test_CrossSess):
     def return_eval(self):
-        return ev.WithinSessionEvaluation(paradigm=LeftRightImagery(),
+        return ev.WithinSessionEvaluation(paradigm=FakeImageryParadigm(),
                                           datasets=[dataset])
 
     def test_eval_results(self):

--- a/moabb/tests/fake.py
+++ b/moabb/tests/fake.py
@@ -1,0 +1,72 @@
+from mne import create_info
+from mne.io import RawArray
+from mne.channels import read_montage
+import numpy as np
+
+from moabb.datasets.base import BaseDataset
+from moabb.paradigms.motor_imagery import BaseMotorImagery
+
+
+class FakeDataset(BaseDataset):
+    """Fake Dataset for test purpose.
+
+    The dataset has 2 sessions, 10 subjects, and 3 classes.
+
+    """
+
+    def __init__(self, event_list=['fake_c1', 'fake_c2', 'fake_c3']):
+        event_id = {ev: ii + 1 for ii, ev in enumerate(event_list)}
+        super().__init__(range(1, 3), 2, event_id,
+                         'FakeDataset', [1, 3], 'imagery')
+
+    def _get_single_subject_data(self, subject, stack_sessions):
+        data = [self._generate_raw(), self._generate_raw()]
+        if stack_sessions:
+            return [data]
+        else:
+            return [[data]]
+
+    def _generate_raw(self):
+
+        ch_names = ['C3', 'Cz', 'C4']
+
+        montage = read_montage('standard_1005')
+        sfreq = 128
+        duration = len(self.event_id)*60
+        eeg_data = 2e-5 * np.random.randn(duration * sfreq, len(ch_names))
+        y = np.zeros((duration * sfreq))
+        for ii, ev in enumerate(self.event_id):
+            y[((1 + 5*ii)*128)::(5*len(self.event_id)*128)] = self.event_id[ev]
+
+        ch_types = ['eeg'] * len(ch_names) + ['stim']
+        ch_names = ch_names + ['stim']
+
+        eeg_data = np.c_[eeg_data, y]
+
+        info = create_info(ch_names=ch_names, ch_types=ch_types,
+                           sfreq=sfreq, montage=montage)
+        raw = RawArray(data=eeg_data.T, info=info, verbose=False)
+        return raw
+
+
+class FakeImageryParadigm(BaseMotorImagery):
+    """fake Imagery for left hand/right hand classification
+
+    Metric is 'roc_auc'
+
+    """
+
+    def verify(self, d):
+        events = ['left_hand', 'right_hand']
+        super().verify(d)
+        assert set(events) <= set(d.event_id.keys())
+        d.selected_events = dict(
+            zip(events, [d.event_id[s] for s in events]))
+
+    @property
+    def scoring(self):
+        return 'roc_auc'
+
+    @property
+    def datasets(self):
+        return [FakeDataset(['left_hand', 'right_hand'])]

--- a/moabb/tests/test_pipelines/LogVar.yml
+++ b/moabb/tests/test_pipelines/LogVar.yml
@@ -1,0 +1,13 @@
+name: Log Variance LDA
+
+paradigms:
+  - FakeImageryParadigm
+
+pipeline:
+  - name: LogVariance
+    from: moabb.pipelines.features
+
+  - name: LinearDiscriminantAnalysis
+    from: sklearn.discriminant_analysis
+    parameters:
+      solver: svd

--- a/moabb/tests/util_tests.py
+++ b/moabb/tests/util_tests.py
@@ -26,10 +26,8 @@ class Test_Utils(unittest.TestCase):
         for out in l:
             print('two class: {}'.format(out.selected_events))
 
-
     def test_dataset_channel_search(self):
-        all_datasets = utils.dataset_list
-        chans = ['C3','Cz']
+        chans = ['C3', 'Cz']
         All = utils.dataset_search('imagery', events=[
             'right_hand', 'left_hand', 'feet', 'tongue', 'rest'])
         has_chans = utils.dataset_search('imagery', events=[


### PR DESCRIPTION
The master was broken, both test and run where not passing.

To avoid that in the future, It was time to add travis to the project. 
Travis run the tests + the moabb on a fake dataset (twice, for testing the cache).

- the analysis tests are not running and will be outdated soon ?
- I had to disable tests on datasets because travis can not download the whole thing every time. We might move them to another module that can be run locally.