### PR TITLE
SSVEP Paradigm and SSVEPExo dataset

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -27,8 +27,8 @@ Motor Imagery Datasets
     Shin2017A
     Shin2017B
     Weibo2014
-	  Zhou2016
-	 SSVEPExo
+    Zhou2016
+    SSVEPExo
 
 ------------
 ERP Datasets

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -28,6 +28,7 @@ Motor Imagery Datasets
     Shin2017B
     Weibo2014
 	  Zhou2016
+	 SSVEPExo
 
 ------------
 ERP Datasets

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -133,10 +133,10 @@ class SSVEP_CCA(BaseEstimator, ClassifierMixin):
 
 # Loading the SSVEP paradigm and the SSVEP Exo dataset, restricting to
 # the first two classes (here 13 and 17 Hz) and the first 10 subjects.
-paradigm = BaseSSVEP(n_classes=2)
+paradigm = BaseSSVEP(n_classes=3)
 SSVEPExo().download(update_path=True, verbose=False)
 datasets = [SSVEPExo()]
-datasets[0].subject_list = datasets[0].subject_list[:10]
+datasets[0].subject_list = datasets[0].subject_list[:2]
 X, y, metadata = paradigm.get_data(dataset=datasets[0])
 interval = datasets[0].interval
 
@@ -197,6 +197,6 @@ sns.stripplot(data=results, y='score', x='pipeline', ax=ax, jitter=True,
 sns.pointplot(data=results, y='score', x='pipeline', ax=ax,
               zorder=1, palette="Set1")
 ax.set_ylabel('Accuracy')
-ax.set_ylim(0.3, 1.0)
+ax.set_ylim(0.1, 0.6)
 plt.savefig('ssvep.png')
 fig.show()

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -1,0 +1,194 @@
+"""
+===========================
+Cross Subject SSVEP
+===========================
+This Example shows how to perform a cross subject analysis on a SSVEP dataset.
+We will compare two pipelines :
+- Riemannian Geometry
+- CCA
+We will use the SSVEP paradigm, which uses the AUC as metric.
+"""
+# Authors: Sylvain Chevallier <sylvain.chevallier@uvsq.fr>
+#
+# License: BSD (3-clause)
+
+from sklearn.pipeline import make_pipeline
+from sklearn.cross_decomposition import CCA
+from sklearn.linear_model import LogisticRegression
+from sklearn.base import BaseEstimator, TransformerMixin, ClassifierMixin
+
+from pyriemann.tangentspace import TangentSpace
+from pyriemann.estimation import Covariances
+
+from moabb.evaluations import CrossSubjectEvaluation
+from moabb.paradigms import BaseSSVEP
+from moabb.datasets import SSVEPExo
+import moabb
+
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+import warnings
+
+# ------------------------------------------------------------------------------
+
+warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action='ignore', category=RuntimeWarning)
+moabb.set_log_level('info')
+
+# We will need some auxiliary transformers for filtering the signal appropriately.
+# The first auxiliary transformer allows to get only the signal filtered around
+# stim freq [f-0.5, f+0.5] Hz
+
+class FilteredSignal(BaseEstimator, TransformerMixin):
+
+    def __init__(self):
+        pass
+
+    def fit(self, X, y):
+        """fit."""
+        return self
+
+    def transform(self, X):
+        """transform. """
+        out = X[:, :, :, :-1].transpose((0, 3, 1, 2))
+        n_trials, n_freqs, n_channels, n_times = out.shape
+        out = out.reshape((n_trials, n_channels * n_freqs, n_times))
+        return out
+
+# This second auxiliary transformer apply a broadband filter (1-45 Hz) on the signal
+
+class BroadbandSignal(BaseEstimator, TransformerMixin):
+
+    def __init__(self):
+        pass
+
+    def fit(self, X, y):
+        """fit."""
+        return self
+
+    def transform(self, X):
+        """transform. """
+        return X[:, :, :, -1]
+
+# The following class define a SSVEP CCA classifier, where the CCA is computed
+# from the set of training signals and some pure sinusoids to act as reference.
+# Classification is made by taking the frequency with the max correlation.
+    
+class SSVEP_CCA(BaseEstimator, ClassifierMixin):
+
+    def __init__(self, interval, freqs, n_harmonics=3):
+        self.Yf = dict()
+        self.cca = CCA(n_components=1)
+        self.slen = interval[1] - interval[0]
+        self.freqs =  freqs 
+        self.n_harmonics = n_harmonics
+        self.one_hot = {}
+        for i, k in enumerate(freqs.keys()): self.one_hot[k] = i
+
+    def fit(self, X, y, sample_weight=None):
+        """fit."""
+        # n_trials, n_channels, n_times = X.shape
+        n_times = X.shape[2]
+        
+        for f in self.freqs:
+            if f.replace('.','',1).isnumeric():
+                freq = float(f)
+                yf = []
+                for h in range(1, self.n_harmonics+1):
+                    yf.append(np.sin(2*np.pi*freq*h*np.linspace(0, self.slen, n_times)))
+                    yf.append(np.cos(2*np.pi*freq*h*np.linspace(0, self.slen, n_times)))
+                self.Yf[f] = np.array(yf)
+        return self
+
+    def predict(self, X):
+        """predict"""
+        y = []
+        for i, x in enumerate(X):
+            corr_f = {}
+            for f in self.freqs:
+                if f.replace('.','',1).isnumeric():
+                    S_x, S_y = self.cca.fit_transform(x.T, self.Yf[f].T)
+                    corr_f[f] = np.corrcoef(S_x.T, S_y.T)[0,1]
+            y.append(self.one_hot[max(corr_f, key=lambda k: corr_f[k])])
+        return y
+
+    def predict_proba(self, X):
+        """predict proba"""
+        P = np.zeros(shape=(len(X), len(self.freqs)))
+        for i, x in enumerate(X):
+            for j, f in enumerate(self.freqs):
+                if f.replace('.','',1).isnumeric():
+                    S_x, S_y = self.cca.fit_transform(x.T, self.Yf[f].T)
+                    P[i, j] = np.corrcoef(S_x.T, S_y.T)[0,1]
+        return P / np.resize(P.sum(axis=1), P.T.shape).T
+
+
+# Loading the SSVEP paradigm and the SSVEP Exo dataset, restricting to
+# the first two classes (here 13 and 17 Hz) and the first 10 subjects.
+paradigm = BaseSSVEP(n_classes=2) 
+datasets = [SSVEPExo()]
+datasets[0].subject_list = datasets[0].subject_list[:10]
+X, y, metadata = paradigm.get_data(dataset=datasets[0])
+interval = datasets[0].interval
+
+# Classes are defined by the frequency of the stimulation, here we use
+# the first two frequencies of the dataset, 13 and 17 Hz.
+# The evaluation function uses a LabelEncoder, transforming them
+# to 0 and 1
+
+freqs = paradigm.used_freqs(datasets[0])
+
+##############################################################################
+# Create pipelines
+# ----------------
+#
+# Pipelines must be a dict of sklearn pipeline transformer.
+# The first pipeline uses Riemannian geometry, by building an extended
+# covariance matrices from the signal filtered around the considered
+# frequency and applying a logistic regression in the tangent plane.
+# The second pipeline reloes on the above defined CCA classifier.
+
+pipelines = {}
+pipelines['RG + LogReg'] = make_pipeline(
+    FilteredSignal(),
+    Covariances(estimator='lwf'),
+    TangentSpace(),
+    LogisticRegression(solver='lbfgs', multi_class='auto'))
+
+pipelines['CCA'] = make_pipeline(
+    BroadbandSignal(),
+    SSVEP_CCA(interval=interval, freqs=freqs, n_harmonics=3))
+
+##############################################################################
+# Evaluation
+# ----------
+#
+# We define the paradigm (SSVEP) and use the dataset available for it.
+# The evaluation will return a dataframe containing a single AUC score for
+# each subject / session of the dataset, and for each pipeline.
+#
+# Results are saved into the database, so that if you add a new pipeline, it
+# will not run again the evaluation unless a parameter has changed. Results can
+# be overwritten if necessary.
+
+overwrite = True  # set to True if we want to overwrite cached results
+evaluation = CrossSubjectEvaluation(paradigm=paradigm,
+                                    datasets=datasets, overwrite=overwrite)
+results = evaluation.process(pipelines)
+
+##############################################################################
+# Plot Results
+# ----------------
+#
+# Here we plot the results.
+
+fig, ax = plt.subplots(facecolor='white', figsize=[8, 4])
+sns.stripplot(data=results, y='score', x='pipeline', ax=ax, jitter=True,
+                                alpha=.5, zorder=1, palette="Set1")
+sns.pointplot(data=results, y='score', x='pipeline', ax=ax,
+                                zorder=1, palette="Set1")
+ax.set_ylabel('Accuracy')
+ax.set_ylim(0.3, 1.0)
+plt.savefig('ssvep.png')
+fig.show()

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -13,9 +13,7 @@ We will use the SSVEP paradigm, which uses the AUC as metric.
 # License: BSD (3-clause)
 
 from sklearn.pipeline import make_pipeline
-from sklearn.cross_decomposition import CCA
 from sklearn.linear_model import LogisticRegression
-from sklearn.base import BaseEstimator, TransformerMixin, ClassifierMixin
 
 from pyriemann.tangentspace import TangentSpace
 from pyriemann.estimation import Covariances
@@ -23,9 +21,9 @@ from pyriemann.estimation import Covariances
 from moabb.evaluations import CrossSubjectEvaluation
 from moabb.paradigms import SSVEP, FilterBankSSVEP
 from moabb.datasets import SSVEPExo
+from moabb.pipelines import SSVEP_CCA, ExtendedSSVEPSignal
 import moabb
 
-import numpy as np
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
@@ -36,94 +34,15 @@ warnings.simplefilter(action='ignore', category=RuntimeWarning)
 moabb.set_log_level('info')
 
 ###############################################################################
-# Auxiliary functions
-# -------------------
+# Loading dataset
+# ---------------
 #
-# We will need an auxiliary transformer for filtering the signal.
-# This auxiliary transformer allows to reshape the signal for building
-# extended covariances matrices
-
-
-class FilteredSignal(BaseEstimator, TransformerMixin):
-
-    def __init__(self):
-        pass
-
-    def fit(self, X, y):
-        """fit."""
-        return self
-
-    def transform(self, X):
-        """transform. """
-        out = X.transpose((0, 3, 1, 2))
-        n_trials, n_freqs, n_channels, n_times = out.shape
-        out = out.reshape((n_trials, n_channels * n_freqs, n_times))
-        return out
-
-###############################################################################
-# The following class defines a SSVEP CCA classifier, where the CCA is computed
-# from the set of training signals and some pure sinusoids to act as reference.
-# Classification is made by taking the frequency with the max correlation, as
-# proposed in Bin et al. (2009) https://doi.org/10.1088/1741-2560/6/4/046002
-
-
-class SSVEP_CCA(BaseEstimator, ClassifierMixin):
-
-    def __init__(self, interval, freqs, n_harmonics=3):
-        self.Yf = dict()
-        self.cca = CCA(n_components=1)
-        self.slen = interval[1] - interval[0]
-        self.freqs = freqs
-        self.n_harmonics = n_harmonics
-        self.one_hot = {}
-        for i, k in enumerate(freqs.keys()):
-            self.one_hot[k] = i
-
-    def fit(self, X, y, sample_weight=None):
-        """fit."""
-        n_times = X.shape[2]
-
-        for f in self.freqs:
-            if f.replace('.', '', 1).isnumeric():
-                freq = float(f)
-                yf = []
-                for h in range(1, self.n_harmonics + 1):
-                    yf.append(np.sin(2 * np.pi * freq * h *
-                                     np.linspace(0, self.slen, n_times)))
-                    yf.append(np.cos(2 * np.pi * freq * h *
-                                     np.linspace(0, self.slen, n_times)))
-                self.Yf[f] = np.array(yf)
-        return self
-
-    def predict(self, X):
-        """predict"""
-        y = []
-        for i, x in enumerate(X):
-            corr_f = {}
-            for f in self.freqs:
-                if f.replace('.', '', 1).isnumeric():
-                    S_x, S_y = self.cca.fit_transform(x.T, self.Yf[f].T)
-                    corr_f[f] = np.corrcoef(S_x.T, S_y.T)[0, 1]
-            y.append(self.one_hot[max(corr_f, key=lambda k: corr_f[k])])
-        return y
-
-    def predict_proba(self, X):
-        """predict proba"""
-        P = np.zeros(shape=(len(X), len(self.freqs)))
-        for i, x in enumerate(X):
-            for j, f in enumerate(self.freqs):
-                if f.replace('.', '', 1).isnumeric():
-                    S_x, S_y = self.cca.fit_transform(x.T, self.Yf[f].T)
-                    P[i, j] = np.corrcoef(S_x.T, S_y.T)[0, 1]
-        return P / np.resize(P.sum(axis=1), P.T.shape).T
-
-
-# Loading the SSVEP paradigm and the SSVEP Exo dataset, restricting to
-# the first three classes (here 13, 17 and 21 Hz) and the first 2 subjects.
-# Two paradigms are created, one for the CCA classification and another one
-# based on filter-bank decomposition for designing extended covariance
-# matrices.
-
+# We will load the data from the first 2 subjects of the SSVEP_Exo dataset
+# and compare two algorithms on this set. One of the algorithm could only
+# process class associated with a stimulation frequency, we will thus drop
+# the resting class. As the resting class is the last defined class, picking
+# the first three classes (out of four) allows to focus only on the stimulation
+# frequency.
 
 n_subject = 2
 for i in range(n_subject):
@@ -153,7 +72,7 @@ freqs = paradigm.used_events(dataset)
 
 pipelines_fb = {}
 pipelines_fb['RG + LogReg'] = make_pipeline(
-    FilteredSignal(),
+    ExtendedSSVEPSignal(),
     Covariances(estimator='lwf'),
     TangentSpace(),
     LogisticRegression(solver='lbfgs', multi_class='auto'))
@@ -161,7 +80,6 @@ pipelines_fb['RG + LogReg'] = make_pipeline(
 pipelines = {}
 pipelines['CCA'] = make_pipeline(
     SSVEP_CCA(interval=interval, freqs=freqs, n_harmonics=3))
-#    BroadbandSignal(),
 
 ##############################################################################
 # Evaluation

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -138,17 +138,17 @@ n_subject = 2
 for i in range(n_subject):
     SSVEPExo()._get_single_subject_data(i + 1)
 # SSVEPExo().download(update_path=True, verbose=False)
-datasets = [SSVEPExo()]
-datasets[0].subject_list = datasets[0].subject_list[:n_subject]
-X, y, metadata = paradigm.get_data(dataset=datasets[0])
-interval = datasets[0].interval
+datasets = SSVEPExo()
+datasets.subject_list = datasets.subject_list[:n_subject]
+X, y, metadata = paradigm.get_data(dataset=datasets)
+interval = datasets.interval
 
 # Classes are defined by the frequency of the stimulation, here we use
 # the first two frequencies of the dataset, 13 and 17 Hz.
 # The evaluation function uses a LabelEncoder, transforming them
 # to 0 and 1
 
-freqs = paradigm.used_freqs(datasets[0])
+freqs = paradigm.used_freqs(datasets)
 
 ##############################################################################
 # Create pipelines

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -43,6 +43,7 @@ moabb.set_log_level('info')
 # This auxiliary transformer allows to reshape the signal for building
 # extended covariances matrices
 
+
 class FilteredSignal(BaseEstimator, TransformerMixin):
 
     def __init__(self):
@@ -64,6 +65,7 @@ class FilteredSignal(BaseEstimator, TransformerMixin):
 # from the set of training signals and some pure sinusoids to act as reference.
 # Classification is made by taking the frequency with the max correlation, as
 # proposed in Bin et al. (2009) https://doi.org/10.1088/1741-2560/6/4/046002
+
 
 class SSVEP_CCA(BaseEstimator, ClassifierMixin):
 
@@ -182,7 +184,7 @@ results = evaluation.process(pipelines)
 # Filter bank processing, determine automatically the filter from the
 # stimulation frequency values of events.
 evaluation_fb = CrossSubjectEvaluation(paradigm=paradigm_fb,
-                                    datasets=dataset, overwrite=overwrite)
+                                       datasets=dataset, overwrite=overwrite)
 results_fb = evaluation_fb.process(pipelines_fb)
 
 ###############################################################################

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -134,9 +134,12 @@ class SSVEP_CCA(BaseEstimator, ClassifierMixin):
 # Loading the SSVEP paradigm and the SSVEP Exo dataset, restricting to
 # the first two classes (here 13 and 17 Hz) and the first 10 subjects.
 paradigm = BaseSSVEP(n_classes=3)
-SSVEPExo().download(update_path=True, verbose=False)
+n_subject = 2
+for i in range(n_subject):
+    SSVEPExo()._get_single_subject_data(i + 1)
+# SSVEPExo().download(update_path=True, verbose=False)
 datasets = [SSVEPExo()]
-datasets[0].subject_list = datasets[0].subject_list[:2]
+datasets[0].subject_list = datasets[0].subject_list[:n_subject]
 X, y, metadata = paradigm.get_data(dataset=datasets[0])
 interval = datasets[0].interval
 

--- a/moabb/datasets/__init__.py
+++ b/moabb/datasets/__init__.py
@@ -15,3 +15,4 @@ from .upper_limb import Ofner2017
 from .Weibo2014 import Weibo2014
 from .Zhou2016 import Zhou2016
 from .mpi_mi import MunichMI
+from .ssvep_exo import SSVEPExo

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -20,7 +20,7 @@ class BaseDataset(metaclass=abc.ABCMeta):
     sessions_per_subject: int
         Number of sessions per subject
 
-    events: dict of string: int
+    events: dict of strings
         String codes for events matched with labels in the stim channel.
         Currently imagery codes codes can include:
         - left_hand

--- a/moabb/datasets/fake.py
+++ b/moabb/datasets/fake.py
@@ -14,11 +14,11 @@ class FakeDataset(BaseDataset):
     """
 
     def __init__(self, event_list=('fake_c1', 'fake_c2', 'fake_c3'),
-                 n_sessions=2, n_runs=2, n_subjects=10):
+                 n_sessions=2, n_runs=2, n_subjects=10, paradigm='imagery'):
         self.n_runs = n_runs
         event_id = {ev: ii + 1 for ii, ev in enumerate(event_list)}
         super().__init__(list(range(1, n_subjects + 1)), n_sessions, event_id,
-                         'FakeDataset', [0, 3], 'imagery')
+                         'FakeDataset', [0, 3], paradigm)
 
     def _get_single_subject_data(self, subject):
 

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -1,0 +1,84 @@
+"""
+SSVEP Exoskeleton dataset.
+"""
+
+from .base import BaseDataset
+from mne.io import Raw
+
+from . import download as dl
+
+# SSVEPEXO_URL = 'https://github.com/sylvchev/dataset-ssvep-exoskeleton/raw/master/'
+SSVEPEXO_URL = 'https://zenodo.org/record/2392979/files/'
+
+class SSVEPExo(BaseDataset):
+    """SSVEP Exo dataset
+
+    SSVEP dataset from E. Kalunga PhD in University of Versailles [1]_.
+
+    The datasets contains recording from 12 male and female subjects aged
+    between 20 and 28 years. Informed consent was obtained from all subjects,
+    each one has signed a form attesting her or his consent. The subject sits
+    in an electric wheelchair, his right upper limb is resting on the 
+    exoskeleton. The exoskeleton is functional but is not used during the
+    recording of this experiment.
+
+    A panel of size 20x30 cm is attached on the left side of the chair, with 
+    3 groups of 4 LEDs blinking at different frequencies. Even if the panel
+    is on the left side, the user could see it without moving its head. The
+    subjects were asked to sit comfortably in the wheelchair and to follow the
+    auditory instructions, they could move and blink freely.
+
+    A sequence of trials is proposed to the user. A trial begin by an audio cue
+    indicating which LED to focus on, or to focus on a fixation point set at an
+    equal distance from all LEDs for the reject class. A trial lasts 5 seconds
+    and there is a 3 second pause between each trial. The evaluation is
+    conducted during a session consisting of 32 trials, with 8 trials for each
+    frequency (13Hz, 17Hz and 21Hz) and 8 trials for the reject class, i.e.
+    when the subject is not focusing on any specific blinking LED.
+
+    There is between 2 and 5 sessions for each user, recorded on different days,
+    by the same operators, on the same hardware and in the same conditions.
+
+    references
+    ----------
+    [1] Emmanuel K. Kalunga, Sylvain Chevallier, Quentin Barthelemy. _Online 
+    SSVEP-based BCI using Riemannian Geometry_. Neurocomputing, 2016. 
+    arXiv research report on arXiv:1501.03227.    
+    """
+
+    def __init__(self):
+        super().__init__(
+            subjects=list(range(1, 13)),
+            sessions_per_subject=2,
+            events={'13':2, '17':3, '21':4, 'rest':1},
+            code='SSVEP Exoskeleton',
+            interval=[2, 4],
+            paradigm='ssvep',
+            doi='10.1016/j.neucom.2016.01.007')
+
+    def _get_single_subject_data(self, subject):
+        """Return the data of a single subject"""
+
+        out = {}
+        paths = self.data_path(subject)
+        for ii, path in enumerate(paths):
+            raw = Raw(path, preload=True, verbose='ERROR')
+            out['run_%d' % ii] = raw
+        return {"session_0": out}
+
+    def data_path(self, subject, path=None, force_update=False,
+                  update_path=None, verbose=None):
+        
+        runs = {s+1:n for s, n in enumerate([2]*6+[3]+[2]*2+[4, 2, 5])}
+        
+        if subject not in self.subject_list:
+            raise(ValueError("Invalid subject number"))
+
+        paths = []
+        for run in range(runs[subject]):
+            url = '{:s}subject{:02d}_run{:d}_raw.fif'.format(SSVEPEXO_URL,
+                                                            subject, run+1)
+            p = dl.data_path(url, 'SSVEPEXO', path, force_update, update_path,
+                             verbose)
+            paths.append(p)
+        return paths

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -7,8 +7,8 @@ from mne.io import Raw
 
 from . import download as dl
 
-# SSVEPEXO_URL = 'https://github.com/sylvchev/dataset-ssvep-exoskeleton/raw/master/'
 SSVEPEXO_URL = 'https://zenodo.org/record/2392979/files/'
+
 
 class SSVEPExo(BaseDataset):
     """SSVEP Exo dataset
@@ -18,11 +18,11 @@ class SSVEPExo(BaseDataset):
     The datasets contains recording from 12 male and female subjects aged
     between 20 and 28 years. Informed consent was obtained from all subjects,
     each one has signed a form attesting her or his consent. The subject sits
-    in an electric wheelchair, his right upper limb is resting on the 
+    in an electric wheelchair, his right upper limb is resting on the
     exoskeleton. The exoskeleton is functional but is not used during the
     recording of this experiment.
 
-    A panel of size 20x30 cm is attached on the left side of the chair, with 
+    A panel of size 20x30 cm is attached on the left side of the chair, with
     3 groups of 4 LEDs blinking at different frequencies. Even if the panel
     is on the left side, the user could see it without moving its head. The
     subjects were asked to sit comfortably in the wheelchair and to follow the
@@ -41,16 +41,16 @@ class SSVEPExo(BaseDataset):
 
     references
     ----------
-    [1] Emmanuel K. Kalunga, Sylvain Chevallier, Quentin Barthelemy. _Online 
-    SSVEP-based BCI using Riemannian Geometry_. Neurocomputing, 2016. 
-    arXiv research report on arXiv:1501.03227.    
+    .. [1] Emmanuel K. Kalunga, Sylvain Chevallier, Quentin Barthelemy. "Online
+           SSVEP-based BCI using Riemannian Geometry". Neurocomputing, 2016.
+           arXiv research report on arXiv:1501.03227.
     """
 
     def __init__(self):
         super().__init__(
             subjects=list(range(1, 13)),
             sessions_per_subject=2,
-            events={'13':2, '17':3, '21':4, 'rest':1},
+            events={'13': 2, '17': 3, '21': 4, 'rest': 1},
             code='SSVEP Exoskeleton',
             interval=[2, 4],
             paradigm='ssvep',
@@ -68,16 +68,17 @@ class SSVEPExo(BaseDataset):
 
     def data_path(self, subject, path=None, force_update=False,
                   update_path=None, verbose=None):
-        
-        runs = {s+1:n for s, n in enumerate([2]*6+[3]+[2]*2+[4, 2, 5])}
-        
+
+        runs = {s + 1: n for s,
+                n in enumerate([2] * 6 + [3] + [2] * 2 + [4, 2, 5])}
+
         if subject not in self.subject_list:
             raise(ValueError("Invalid subject number"))
 
         paths = []
         for run in range(runs[subject]):
             url = '{:s}subject{:02d}_run{:d}_raw.fif'.format(SSVEPEXO_URL,
-                                                            subject, run+1)
+                                                             subject, run + 1)
             p = dl.data_path(url, 'SSVEPEXO', path, force_update, update_path,
                              verbose)
             paths.append(p)

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -36,8 +36,9 @@ class SSVEPExo(BaseDataset):
     frequency (13Hz, 17Hz and 21Hz) and 8 trials for the reject class, i.e.
     when the subject is not focusing on any specific blinking LED.
 
-    There is between 2 and 5 sessions for each user, recorded on different days,
-    by the same operators, on the same hardware and in the same conditions.
+    There is between 2 and 5 sessions for each user, recorded on different
+    days, by the same operators, on the same hardware and in the same
+    conditions.
 
     references
     ----------

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -61,7 +61,7 @@ class SSVEPExo(BaseDataset):
         """Return the data of a single subject"""
 
         out = {}
-        paths = self.data_path(subject)
+        paths = self.data_path(subject, update_path=True, verbose=False)
         for ii, path in enumerate(paths):
             raw = Raw(path, preload=True, verbose='ERROR')
             out['run_%d' % ii] = raw

--- a/moabb/datasets/utils.py
+++ b/moabb/datasets/utils.py
@@ -54,7 +54,7 @@ def dataset_search(paradigm, multi_session=False, events=None,
     n_classes = total_classes
     if events is not None and has_all_events:
         n_classes = len(events)
-    assert paradigm in ['imagery', 'p300']
+    assert paradigm in ['imagery', 'p300', 'ssvep']
     if paradigm == 'p300':
         raise Exception('SORRY NOBDOYS GOTTEN AROUND TO THIS YET')
 

--- a/moabb/datasets/utils.py
+++ b/moabb/datasets/utils.py
@@ -22,7 +22,7 @@ def dataset_search(paradigm, multi_session=False, events=None,
     Parameters
     ----------
     paradigm: str
-        'imagery','p300',(more to come)
+        'imagery','p300','ssvep'
 
     multi_session: bool
         if True only returns datasets with more than one session per subject.

--- a/moabb/paradigms/__init__.py
+++ b/moabb/paradigms/__init__.py
@@ -7,3 +7,4 @@ paradigms.
 """
 # flake8: noqa
 from moabb.paradigms.motor_imagery import *
+from moabb.paradigms.ssvep import BaseSSVEP

--- a/moabb/paradigms/__init__.py
+++ b/moabb/paradigms/__init__.py
@@ -7,4 +7,4 @@ paradigms.
 """
 # flake8: noqa
 from moabb.paradigms.motor_imagery import *
-from moabb.paradigms.ssvep import BaseSSVEP
+from moabb.paradigms.ssvep import *

--- a/moabb/paradigms/motor_imagery.py
+++ b/moabb/paradigms/motor_imagery.py
@@ -1,9 +1,6 @@
 """Motor Imagery Paradigms"""
 
 import abc
-import mne
-import numpy as np
-import pandas as pd
 import logging
 
 from moabb.paradigms.base import BaseParadigm
@@ -78,61 +75,6 @@ class BaseMotorImagery(BaseParadigm):
     @abc.abstractmethod
     def used_events(self, dataset):
         pass
-
-    def process_raw(self, raw, dataset):
-        # find the events
-        events = mne.find_events(raw, shortest_event=0, verbose=False)
-        channels = () if self.channels is None else self.channels
-
-        # picks channels
-        picks = mne.pick_types(raw.info, eeg=True, stim=False,
-                               include=channels)
-
-        # get event id
-        event_id = self.used_events(dataset)
-
-        # pick events, based on event_id
-        try:
-            events = mne.pick_events(events, include=list(event_id.values()))
-        except RuntimeError:
-            # skip raw if no event found
-            return
-
-        # get interval
-        tmin = self.tmin + dataset.interval[0]
-        if self.tmax is None:
-            tmax = dataset.interval[1]
-        else:
-            tmax = self.tmax + dataset.interval[0]
-
-        X = []
-        for bandpass in self.filters:
-            fmin, fmax = bandpass
-            # filter data
-            raw_f = raw.copy().filter(fmin, fmax, method='iir',
-                                      picks=picks, verbose=False)
-            # epoch data
-            epochs = mne.Epochs(raw_f, events, event_id=event_id,
-                                tmin=tmin, tmax=tmax, proj=False,
-                                baseline=None, preload=True,
-                                verbose=False, picks=picks,
-                                on_missing='ignore')
-            if self.resample is not None:
-                epochs = epochs.resample(self.resample)
-            # MNE is in V, rescale to have uV
-            X.append(1e6 * epochs.get_data())
-
-        inv_events = {k: v for v, k in event_id.items()}
-        labels = np.array([inv_events[e] for e in epochs.events[:, -1]])
-
-        # if only one band, return a 3D array, otherwise return a 4D
-        if len(self.filters) == 1:
-            X = X[0]
-        else:
-            X = np.array(X).transpose((1, 2, 3, 0))
-
-        metadata = pd.DataFrame(index=range(len(labels)))
-        return X, labels, metadata
 
     @property
     def datasets(self):

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -123,8 +123,8 @@ class BaseSSVEP(BaseParadigm):
             self.filters = [[float(f)-0.5, float(f)+0.5]
                             for f in freq_id.keys()
                             if f.replace('.','',1).isnumeric()]
-            if self.n_classes is None:
-                self.filters.append([1, 45])
+            # if self.n_classes is None:
+            self.filters.append([1, 45])
 
         X = []
         for bandpass in self.filters:

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -123,7 +123,8 @@ class BaseSSVEP(BaseParadigm):
             self.filters = [[float(f)-0.5, float(f)+0.5]
                             for f in freq_id.keys()
                             if f.replace('.','',1).isnumeric()]
-            self.filters.append([1, 45])
+            if self.n_classes is None:
+                self.filters.append([1, 45])
 
         X = []
         for bandpass in self.filters:

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -23,8 +23,8 @@ class BaseSSVEP(BaseParadigm):
     freqs: list of str | None (default None)
         List of stimulation frequencies (float). If None, use all stimulus
         found in the dataset.
-    n_classes: int,
-        Number of classes each dataset must have.
+    n_classes: int or None (default None)
+        Number of classes each dataset must have. All dataset classes if None
     tmin: float (default 0.0)
         Start time (in second) of the epoch, relative to the dataset specific
         task interval e.g. tmin = 1 would mean the epoch will start 1 second
@@ -41,8 +41,8 @@ class BaseSSVEP(BaseParadigm):
         If not None, resample the eeg data with the sampling rate provided.
     """
 
-    def __init__(self, filters=None, freqs=None, tmin=0.0, tmax=None,
-                 channels=None, n_classes=None, resample=None):
+    def __init__(self, filters=None, freqs=None, n_classes=None, tmin=0.0,
+                 tmax=None, channels=None, resample=None):
         super().__init__()
         self.filters = filters
         self.freqs = freqs
@@ -124,7 +124,6 @@ class BaseSSVEP(BaseParadigm):
             self.filters = [[float(f) - 0.5, float(f) + 0.5]
                             for f in freq_id.keys()
                             if f.replace('.', '', 1).isnumeric()]
-            # if self.n_classes is None:
             self.filters.append([1, 45])
 
         X = []

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -1,0 +1,183 @@
+"""Steady-State Visually Evoked Paradigms"""
+
+import mne
+import numpy as np
+import pandas as pd
+import logging
+
+from moabb.paradigms.base import BaseParadigm
+from moabb.datasets import utils
+from moabb.datasets.fake import FakeDataset
+
+log = logging.getLogger()
+
+
+class BaseSSVEP(BaseParadigm):
+    """Base SSVEP Paradigm
+
+    Parameters
+    ----------
+    filters: list of list | None (default None)
+        Bank of bandpass filter to apply. If None, bandpass set around freqs
+        with [f_n-0.5, f_n+0.5] and a global one [1, 45]
+    freqs: list of str | None (default None)
+        List of stimulation frequencies (float). If None, use all stimulus
+        found in the dataset.
+    n_classes: int,
+        Number of classes each dataset must have.
+    tmin: float (default 0.0)
+        Start time (in second) of the epoch, relative to the dataset specific
+        task interval e.g. tmin = 1 would mean the epoch will start 1 second
+        after the begining of the task as defined by the dataset.
+    tmax: float | None, (default None)
+        End time (in second) of the epoch, relative to the begining of the
+        dataset specific task interval. tmax = 5 would mean the epoch will end
+        5 second after the begining of the task as defined in the dataset. If
+        None, use the dataset value.
+    channels: list of str | None (default None)
+        List of channel to select. If None, use all EEG channels available in
+        the dataset.
+    resample: float | None (default None)
+        If not None, resample the eeg data with the sampling rate provided.
+    """
+    def __init__(self, filters=None, freqs=None, tmin=0.0, tmax=None,
+                 channels=None, n_classes=None, resample=None):
+        super().__init__()
+        self.filters = filters
+        self.freqs = freqs
+        self.n_classes = n_classes
+        self.channels = channels
+        self.resample = resample
+
+        if (tmax is not None):
+            if tmin >= tmax:
+                raise(ValueError("tmax must be greater than tmin"))
+
+        self.tmin = tmin
+        self.tmax = tmax
+
+    def is_valid(self, dataset):
+        ret = True
+        if not (dataset.paradigm == 'ssvep'):
+            ret = False
+        if self.freqs is None and self.n_classes is None:
+            return ret
+        
+        if self.freqs is None and self.n_classes is not None:
+            if not len(dataset.event_id) >= self.n_classes:
+                ret = False
+        else:
+            overlap = len(set(self.freqs) & set(dataset.event_id.keys()))
+            if not overlap >= self.n_classes:
+                ret = False
+
+        # we should verify list of channels, somehow
+        return ret
+
+    def used_freqs(self, dataset):
+        out = {}
+        if self.freqs is None:
+            for k, v in dataset.event_id.items():
+                out[k] = v
+                if self.n_classes and len(out) == self.n_classes:
+                    break
+        else:
+            for freqs in self.freqs:
+                if freq in dataset.event_id.keys():
+                    out[freq] = dataset.event_id[freq]
+                if self.n_classes and len(out) == self.n_classes:
+                    break
+        if self.n_classes and len(out) < self.n_classes:
+            raise(ValueError(f"Dataset {dataset.code} did not have enough "
+                             f"freqs in {self.freqs} to run analysis"))
+        return out
+
+    def process_raw(self, raw, dataset):
+        # find the events
+        events = mne.find_events(raw, shortest_event=0, verbose=False)
+        channels = () if self.channels is None else self.channels
+
+        # picks channels
+        picks = mne.pick_types(raw.info, eeg=True, stim=False,
+                               include=channels)
+
+        # get freqs id
+        freq_id = self.used_freqs(dataset)
+
+        # pick events, based on event_id
+        try:
+            events = mne.pick_events(events, include=list(freq_id.values()))
+        except RuntimeError:
+            # skip raw if no event found
+            return
+
+        # get interval
+        tmin = self.tmin + dataset.interval[0]
+        if self.tmax is None:
+            tmax = dataset.interval[1]
+        else:
+            tmax = self.tmax + dataset.interval[0]
+
+        # get filters
+        if self.filters is None:
+            self.filters = [[float(f)-0.5, float(f)+0.5]
+                            for f in freq_id.keys()
+                            if f.replace('.','',1).isnumeric()]
+            self.filters.append([1, 45])
+
+        X = []
+        for bandpass in self.filters:
+            fmin, fmax = bandpass
+            # filter data
+            raw_f = raw.copy().filter(fmin, fmax, method='iir',
+                                      picks=picks, verbose=False)
+            # epoch data
+            epochs = mne.Epochs(raw_f, events, event_id=freq_id,
+                                tmin=tmin, tmax=tmax, proj=False,
+                                baseline=None, preload=True,
+                                verbose=False, picks=picks,
+                                on_missing='ignore')
+            if self.resample is not None:
+                epochs = epochs.resample(self.resample)
+            # MNE is in V, rescale to have uV
+            X.append(1e6 * epochs.get_data())
+
+        inv_freqs = {k: v for v, k in freq_id.items()}
+        labels = np.array([inv_freqs[e] for e in epochs.events[:, -1]])
+
+        # if only one band, return a 3D array, otherwise return a 4D
+        if len(self.filters) == 1:
+            X = X[0]
+        else:
+            X = np.array(X).transpose((1, 2, 3, 0))
+
+        metadata = pd.DataFrame(index=range(len(labels)))
+        return X, labels, metadata
+
+    @property
+    def datasets(self):
+        if self.tmax is None:
+            interval = None
+        else:
+            interval = self.tmax - self.tmin
+        return utils.dataset_search(paradigm='ssvep',
+                                    freqs=self.freqs,
+                                    total_classes=self.n_classes,
+                                    interval=interval,
+                                    has_all_events=False)
+
+    @property
+    def scoring(self):
+        if self.n_classes == 2:
+            return 'roc_auc'
+        else:
+            return 'accuracy'
+    
+
+class FakeSSVEPParadigm(BaseSSVEP):
+    """Fake SSVEP classification.
+    """
+
+    @property
+    def datasets(self):
+        return [FakeDataset(['13', '15'], paradigm='ssvep')]

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -218,4 +218,4 @@ class FakeSSVEPParadigm(BaseSSVEP):
 
     @property
     def datasets(self):
-        return [FakeDataset(events=['13', '15'], paradigm='ssvep')]
+        return [FakeDataset(event_list=['13', '15'], paradigm='ssvep')]

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -17,80 +17,90 @@ class BaseSSVEP(BaseParadigm):
 
     Parameters
     ----------
-    filters: list of list | None (default None)
-        Bank of bandpass filter to apply. If None, bandpass set around freqs
-        with [f_n-0.5, f_n+0.5] and a global one [1, 45]
-    freqs: list of str | None (default None)
-        List of stimulation frequencies (float). If None, use all stimulus
+    filters: list of list | None (default [7, 45])
+        Bank of bandpass filter to apply. 
+
+    events: list of str | None (default None)
+        List of stimulation frequencies. If None, use all stimulus
         found in the dataset.
-    n_classes: int or None (default None)
+
+    n_classes: int or None (default 2)
         Number of classes each dataset must have. All dataset classes if None
+
     tmin: float (default 0.0)
         Start time (in second) of the epoch, relative to the dataset specific
         task interval e.g. tmin = 1 would mean the epoch will start 1 second
         after the begining of the task as defined by the dataset.
+
     tmax: float | None, (default None)
         End time (in second) of the epoch, relative to the begining of the
         dataset specific task interval. tmax = 5 would mean the epoch will end
         5 second after the begining of the task as defined in the dataset. If
         None, use the dataset value.
+
     channels: list of str | None (default None)
         List of channel to select. If None, use all EEG channels available in
         the dataset.
+
     resample: float | None (default None)
         If not None, resample the eeg data with the sampling rate provided.
     """
-
-    def __init__(self, filters=None, freqs=None, n_classes=None, tmin=0.0,
+    def __init__(self, filters=[7, 45], events=None, n_classes=2, tmin=0.0,
                  tmax=None, channels=None, resample=None):
         super().__init__()
         self.filters = filters
-        self.freqs = freqs
+        self.events = events
         self.n_classes = n_classes
         self.channels = channels
         self.resample = resample
 
-        if (tmax is not None):
-            if tmin >= tmax:
-                raise(ValueError("tmax must be greater than tmin"))
-
+        if tmax is not None and  tmin >= tmax:
+            raise(ValueError("tmax must be greater than tmin"))
         self.tmin = tmin
         self.tmax = tmax
+        
+        if self.events is None:
+            log.warning("Choosing the first " + str(n_classes) + " classes"
+                        + "from all possible events")
+        else:
+            assert n_classes <= len(
+                self.events), 'More classes than events specified'
+        
 
     def is_valid(self, dataset):
         ret = True
         if not (dataset.paradigm == 'ssvep'):
             ret = False
-        if self.freqs is None and self.n_classes is None:
+            
+        if self.events is None and self.n_classes is None:
             return ret
 
-        if self.freqs is None and self.n_classes is not None:
-            if not len(dataset.event_id) >= self.n_classes:
-                ret = False
-        else:
-            overlap = len(set(self.freqs) & set(dataset.event_id.keys()))
-            if not overlap >= self.n_classes:
-                ret = False
-
-        # we should verify list of channels, somehow
+        # if self.events is None and self.n_classes is not None:
+        #     if not len(dataset.event_id) >= self.n_classes:
+        #         ret = False
+        # else:
+        #     overlap = len(set(self.events) & set(dataset.event_id.keys()))
+        #     if not overlap >= self.n_classes:
+        #         ret = False
+                
         return ret
 
-    def used_freqs(self, dataset):
+    def used_events(self, dataset):
         out = {}
-        if self.freqs is None:
+        if self.events is None:
             for k, v in dataset.event_id.items():
                 out[k] = v
                 if self.n_classes and len(out) == self.n_classes:
                     break
         else:
-            for freq in self.freqs:
-                if freq in dataset.event_id.keys():
-                    out[freq] = dataset.event_id[freq]
+            for event in self.events:
+                if event in dataset.event_id.keys():
+                    out[event] = dataset.event_id[event]
                 if self.n_classes and len(out) == self.n_classes:
                     break
         if self.n_classes and len(out) < self.n_classes:
             raise(ValueError(f"Dataset {dataset.code} did not have enough "
-                             f"freqs in {self.freqs} to run analysis"))
+                             f"freqs in {self.events} to run analysis"))
         return out
 
     def process_raw(self, raw, dataset):
@@ -102,12 +112,12 @@ class BaseSSVEP(BaseParadigm):
         picks = mne.pick_types(raw.info, eeg=True, stim=False,
                                include=channels)
 
-        # get freqs id
-        freq_id = self.used_freqs(dataset)
+        # get events id
+        event_id = self.used_events(dataset)
 
         # pick events, based on event_id
         try:
-            events = mne.pick_events(events, include=list(freq_id.values()))
+            events = mne.pick_events(events, include=list(event_id.values()))
         except RuntimeError:
             # skip raw if no event found
             return
@@ -122,9 +132,8 @@ class BaseSSVEP(BaseParadigm):
         # get filters
         if self.filters is None:
             self.filters = [[float(f) - 0.5, float(f) + 0.5]
-                            for f in freq_id.keys()
+                            for f in event_id.keys()
                             if f.replace('.', '', 1).isnumeric()]
-            self.filters.append([1, 45])
 
         X = []
         for bandpass in self.filters:
@@ -133,7 +142,7 @@ class BaseSSVEP(BaseParadigm):
             raw_f = raw.copy().filter(fmin, fmax, method='iir',
                                       picks=picks, verbose=False)
             # epoch data
-            epochs = mne.Epochs(raw_f, events, event_id=freq_id,
+            epochs = mne.Epochs(raw_f, events, event_id=event_id,
                                 tmin=tmin, tmax=tmax, proj=False,
                                 baseline=None, preload=True,
                                 verbose=False, picks=picks,
@@ -143,8 +152,8 @@ class BaseSSVEP(BaseParadigm):
             # MNE is in V, rescale to have uV
             X.append(1e6 * epochs.get_data())
 
-        inv_freqs = {k: v for v, k in freq_id.items()}
-        labels = np.array([inv_freqs[e] for e in epochs.events[:, -1]])
+        inv_events = {k: v for v, k in event_id.items()}
+        labels = np.array([inv_events[e] for e in epochs.events[:, -1]])
 
         # if only one band, return a 3D array, otherwise return a 4D
         if len(self.filters) == 1:
@@ -162,7 +171,7 @@ class BaseSSVEP(BaseParadigm):
         else:
             interval = self.tmax - self.tmin
         return utils.dataset_search(paradigm='ssvep',
-                                    freqs=self.freqs,
+                                    events=self.events,
                                     total_classes=self.n_classes,
                                     interval=interval,
                                     has_all_events=False)
@@ -175,10 +184,97 @@ class BaseSSVEP(BaseParadigm):
             return 'accuracy'
 
 
+class SSVEP(BaseSSVEP):
+    """Single bandpass filter SSVEP
+
+    SSVEP paradigm with only one bandpass filter (default 7 to 45 Hz)
+    Metric is 'roc-auc' if 2 classes and 'accuracy' if more
+
+    Parameters
+    ----------
+    fmin: float (default 7)
+        cutoff frequency (Hz) for the high pass filter
+
+    fmax: float (default 45)
+        cutoff frequency (Hz) for the low pass filter
+
+    events: list of str | None (default None)
+        List of stimulation frequencies. If None, use all stimulus
+        found in the dataset.
+
+    n_classes: int or None (default 2)
+        Number of classes each dataset must have. All dataset classes if None
+
+    tmin: float (default 0.0)
+        Start time (in second) of the epoch, relative to the dataset specific
+        task interval e.g. tmin = 1 would mean the epoch will start 1 second
+        after the begining of the task as defined by the dataset.
+
+    tmax: float | None, (default None)
+        End time (in second) of the epoch, relative to the begining of the
+        dataset specific task interval. tmax = 5 would mean the epoch will end
+        5 second after the begining of the task as defined in the dataset. If
+        None, use the dataset value.
+
+    channels: list of str | None (default None)
+        List of channel to select. If None, use all EEG channels available in
+        the dataset.
+
+    resample: float | None (default None)
+        If not None, resample the eeg data with the sampling rate provided.
+    """
+    def __init__(self, fmin=7, fmax=45, **kwargs):
+        if 'filters' in kwargs.keys():
+            raise(ValueError("MotorImagery does not take argument filters"))
+        super().__init__(filters=[(fmin, fmax)], **kwargs)
+        
+
+class FilterBankSSVEP(BaseSSVEP):
+    """ Filtered bank n-class SSVEP paradigm
+
+    SSVEP paradigm with multiple narrow bandpass filters, centered around the
+    frequencies of considered events. 
+    Metric is 'roc-auc' if 2 classes and 'accuracy' if more.
+
+    Parameters
+    -----------
+
+    filters: list of list | None (default None)
+        If None, bandpass set around freqs of events with [f_n-0.5, f_n+0.5]
+
+    events: List of str,
+        List of stimulation frequencies. If None, use all stimulus
+        found in the dataset.
+
+    n_classes: int or None (default 2)
+        Number of classes each dataset must have. All dataset classes if None
+
+    tmin: float (default 0.0)
+        Start time (in second) of the epoch, relative to the dataset specific
+        task interval e.g. tmin = 1 would mean the epoch will start 1 second
+        after the begining of the task as defined by the dataset.
+
+    tmax: float | None, (default None)
+        End time (in second) of the epoch, relative to the begining of the
+        dataset specific task interval. tmax = 5 would mean the epoch will end
+        5 second after the begining of the task as defined in the dataset. If
+        None, use the dataset value.
+
+    channels: list of str | None (default None)
+        List of channel to select. If None, use all EEG channels available in
+        the dataset.
+
+    resample: float | None (default None)
+        If not None, resample the eeg data with the sampling rate provided.
+    """
+    def __init__(self, filters=None, **kwargs):
+        super().__init__(filters=filters, **kwargs)
+
+
 class FakeSSVEPParadigm(BaseSSVEP):
     """Fake SSVEP classification.
     """
 
     @property
     def datasets(self):
-        return [FakeDataset(['13', '15'], paradigm='ssvep')]
+        return [FakeDataset(events=['13', '15'], paradigm='ssvep')]

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -68,8 +68,12 @@ class BaseSSVEP(BaseParadigm):
         ret = True
         if not (dataset.paradigm == 'ssvep'):
             ret = False
-        if self.events is None and self.n_classes is None:
-            return ret
+
+        # check if dataset has required events
+        if self.events:
+            if not set(self.events) <= set(dataset.event_id.keys()):
+                ret = False
+
         return ret
 
     def used_events(self, dataset):

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -40,6 +40,7 @@ class BaseSSVEP(BaseParadigm):
     resample: float | None (default None)
         If not None, resample the eeg data with the sampling rate provided.
     """
+
     def __init__(self, filters=None, freqs=None, tmin=0.0, tmax=None,
                  channels=None, n_classes=None, resample=None):
         super().__init__()
@@ -62,7 +63,7 @@ class BaseSSVEP(BaseParadigm):
             ret = False
         if self.freqs is None and self.n_classes is None:
             return ret
-        
+
         if self.freqs is None and self.n_classes is not None:
             if not len(dataset.event_id) >= self.n_classes:
                 ret = False
@@ -82,7 +83,7 @@ class BaseSSVEP(BaseParadigm):
                 if self.n_classes and len(out) == self.n_classes:
                     break
         else:
-            for freqs in self.freqs:
+            for freq in self.freqs:
                 if freq in dataset.event_id.keys():
                     out[freq] = dataset.event_id[freq]
                 if self.n_classes and len(out) == self.n_classes:
@@ -120,9 +121,9 @@ class BaseSSVEP(BaseParadigm):
 
         # get filters
         if self.filters is None:
-            self.filters = [[float(f)-0.5, float(f)+0.5]
+            self.filters = [[float(f) - 0.5, float(f) + 0.5]
                             for f in freq_id.keys()
-                            if f.replace('.','',1).isnumeric()]
+                            if f.replace('.', '', 1).isnumeric()]
             # if self.n_classes is None:
             self.filters.append([1, 45])
 
@@ -173,7 +174,7 @@ class BaseSSVEP(BaseParadigm):
             return 'roc_auc'
         else:
             return 'accuracy'
-    
+
 
 class FakeSSVEPParadigm(BaseSSVEP):
     """Fake SSVEP classification.

--- a/moabb/pipelines/__init__.py
+++ b/moabb/pipelines/__init__.py
@@ -3,3 +3,7 @@ Pipeline defines all steps required by an algorithm to obtain predictions.
 Pipelines are typically a chain of sklearn compatible transformers and end
 with an sklearn compatible estimator.
 """
+# flake8: noqa
+from .classification import SSVEP_CCA
+from .features import LogVariance, FM, ExtendedSSVEPSignal
+from .utils import create_pipeline_from_config, FilterBank

--- a/moabb/pipelines/classification.py
+++ b/moabb/pipelines/classification.py
@@ -23,6 +23,7 @@ class SSVEP_CCA(BaseEstimator, ClassifierMixin):
     def __init__(self, interval, freqs, n_harmonics=3):
         self.Yf = dict()
         self.cca = CCA(n_components=1)
+        self.interval = interval
         self.slen = interval[1] - interval[0]
         self.freqs = freqs
         self.n_harmonics = n_harmonics

--- a/moabb/pipelines/classification.py
+++ b/moabb/pipelines/classification.py
@@ -1,0 +1,72 @@
+from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.cross_decomposition import CCA
+import numpy as np
+
+
+class SSVEP_CCA(BaseEstimator, ClassifierMixin):
+    """Classifier based on Canonical Correlation Analysis for SSVEP
+
+    A CCA is computed from the set of training signals and some pure
+    sinusoids to act as reference.
+    Classification is made by taking the frequency with the max correlation,
+    as proposed in [1]_.
+
+    References
+    ----------
+
+    .. [1] Bin, G., Gao, X., Yan, Z., Hong, B., & Gao, S. (2009). An online
+           multi-channel SSVEP-based brain-computer interface using a
+           canonical correlation analysis method. Journal of neural
+           engineering, 6(4), 046002.
+           https://doi.org/10.1088/1741-2560/6/4/046002
+    """
+    def __init__(self, interval, freqs, n_harmonics=3):
+        self.Yf = dict()
+        self.cca = CCA(n_components=1)
+        self.slen = interval[1] - interval[0]
+        self.freqs = freqs
+        self.n_harmonics = n_harmonics
+        self.one_hot = {}
+        for i, k in enumerate(freqs.keys()):
+            self.one_hot[k] = i
+
+    def fit(self, X, y, sample_weight=None):
+        """Compute reference sinusoid signal
+
+        These sinusoid are generated for each frequency in the dataset
+        """
+        n_times = X.shape[2]
+
+        for f in self.freqs:
+            if f.replace('.', '', 1).isnumeric():
+                freq = float(f)
+                yf = []
+                for h in range(1, self.n_harmonics + 1):
+                    yf.append(np.sin(2 * np.pi * freq * h *
+                                     np.linspace(0, self.slen, n_times)))
+                    yf.append(np.cos(2 * np.pi * freq * h *
+                                     np.linspace(0, self.slen, n_times)))
+                self.Yf[f] = np.array(yf)
+        return self
+
+    def predict(self, X):
+        """Predict is made by taking the maximum correlation coefficient"""
+        y = []
+        for i, x in enumerate(X):
+            corr_f = {}
+            for f in self.freqs:
+                if f.replace('.', '', 1).isnumeric():
+                    S_x, S_y = self.cca.fit_transform(x.T, self.Yf[f].T)
+                    corr_f[f] = np.corrcoef(S_x.T, S_y.T)[0, 1]
+            y.append(self.one_hot[max(corr_f, key=lambda k: corr_f[k])])
+        return y
+
+    def predict_proba(self, X):
+        """Probabilty could be computed from the correlation coefficient"""
+        P = np.zeros(shape=(len(X), len(self.freqs)))
+        for i, x in enumerate(X):
+            for j, f in enumerate(self.freqs):
+                if f.replace('.', '', 1).isnumeric():
+                    S_x, S_y = self.cca.fit_transform(x.T, self.Yf[f].T)
+                    P[i, j] = np.corrcoef(S_x.T, S_y.T)[0, 1]
+        return P / np.resize(P.sum(axis=1), P.T.shape).T

--- a/moabb/pipelines/features.py
+++ b/moabb/pipelines/features.py
@@ -35,3 +35,30 @@ class FM(BaseEstimator, TransformerMixin):
         xphase = np.unwrap(np.angle(signal.hilbert(X, axis=-1)))
         return np.median(self.freq * np.diff(xphase, axis=-1) / (2 * np.pi),
                          axis=-1)
+
+
+class ExtendedSSVEPSignal(BaseEstimator, TransformerMixin):
+    """Prepare FilterBank SSVEP EEG signal for estimating extended covariances
+
+    Riemannian approaches on SSVEP rely on extended covariances matrices, where
+    the filtered signals are contenated to estimate a large covariance matrice.
+
+    FilterBank SSVEP EEG are of shape (n_trials, n_channels, n_times, n_freqs)
+    and should be convert in (n_trials, n_channels*n_freqs, n_times) to
+    estimate covariance matrices of (n_channels*n_freqs,  n_channels*n_freqs).
+    """
+    def __init__(self):
+        """Empty init for ExtendedSSVEPSignal"""
+        pass
+
+    def fit(self, X, y):
+        """No need to fit for ExtendedSSVEPSignal"""
+        return self
+
+    def transform(self, X):
+        """Transpose and reshape EEG for extended covmat estimation
+        """
+        out = X.transpose((0, 3, 1, 2))
+        n_trials, n_freqs, n_channels, n_times = out.shape
+        out = out.reshape((n_trials, n_channels * n_freqs, n_times))
+        return out

--- a/moabb/run.py
+++ b/moabb/run.py
@@ -188,7 +188,8 @@ if __name__ == '__main__':
     paradigms = generate_paradigms(pipeline_configs, context_params)
 
     if len(context_params) == 0:
-        for paradigm in paradigms: context_params[paradigm] = {}
+        for paradigm in paradigms:
+            context_params[paradigm] = {}
 
     all_results = []
     for paradigm in paradigms:

--- a/moabb/run.py
+++ b/moabb/run.py
@@ -187,11 +187,12 @@ if __name__ == '__main__':
 
     paradigms = generate_paradigms(pipeline_configs, context_params)
 
+    if len(context_params) == 0:
+        for paradigm in paradigms: context_params[paradigm] = {}
+
     all_results = []
     for paradigm in paradigms:
         # get the context
-        if len(context_params) == 0:
-            context_params[paradigm] = {}
         log.debug('{}: {}'.format(paradigm, context_params[paradigm]))
         p = getattr(moabb_paradigms, paradigm)(**context_params[paradigm])
         context = WithinSessionEvaluation(paradigm=p, random_state=42,

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -149,13 +149,8 @@ class Test_SSVEP(unittest.TestCase):
     def test_BaseSSVEP_nclasses_default(self):
         # Default is with 2 classes
         paradigm = BaseSSVEP()
-        dataset = FakeDataset(
-            event_list=[
-                '13',
-                '15',
-                '17',
-                '19'],
-            paradigm='ssvep')
+        dataset = FakeDataset(event_list=['13', '15', '17', '19'],
+                              paradigm='ssvep')
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
         # labels must contain 2 values, as n_classes is 2 by default
@@ -164,17 +159,17 @@ class Test_SSVEP(unittest.TestCase):
     def test_BaseSSVEP_specified_nclasses(self):
         # Set the number of classes
         paradigm = BaseSSVEP(n_classes=3)
-        dataset = FakeDataset(
-            event_list=[
-                '13',
-                '15',
-                '17',
-                '19'],
-            paradigm='ssvep')
+        dataset = FakeDataset(event_list=['13', '15', '17', '19'],
+                              paradigm='ssvep')
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
         # labels must contain 3 values
         self.assertEqual(len(np.unique(labels)), 3)
+
+    def test_BaseSSVEP_toomany_nclasses(self):
+        paradigm = BaseSSVEP(n_classes=4)
+        dataset = FakeDataset(event_list=['13', '15'], paradigm='ssvep')
+        self.assertRaises(ValueError, paradigm.get_data, dataset)
 
     def test_SSVEP_paradigm(self):
         paradigm = SSVEP(n_classes=None)

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -1,7 +1,8 @@
 import unittest
 
 from moabb.datasets.fake import FakeDataset
-from moabb.paradigms import (LeftRightImagery, BaseMotorImagery,
+from moabb.paradigms import (BaseSSVEP,
+                             LeftRightImagery, BaseMotorImagery,
                              FilterBankMotorImagery,
                              FilterBankLeftRightImagery)
 
@@ -94,3 +95,49 @@ class Test_MotorImagery(unittest.TestCase):
         # X must be a 3D Array
         self.assertEquals(len(X.shape), 4)
         self.assertEquals(X.shape[-1], 6)
+
+
+class Test_SSVEP(unittest.TestCase):
+
+    def test_BaseSSVEP_paradigm(self):
+
+        class SimpleSSVEP(BaseSSVEP):
+            
+            def used_events(self, dataset):
+                return dataset.event_id
+
+        self.assertRaises(ValueError, SimpleSSVEP, tmin=1, tmax=0)
+
+        paradigm = SimpleSSVEP()
+        dataset = FakeDataset(paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+
+        # Verify that they have the same length
+        self.assertEquals(len(X), len(labels), len(metadata))
+        # X must be a 3D Array
+        self.assertEquals(len(X.shape), 3)
+        # labels must contain 3 values
+        self.assertEquals(len(np.unique(labels)), 3)
+
+        # metadata must have subjets, sessions, runs
+        self.assertTrue('subject' in metadata.columns)
+        self.assertTrue('session' in metadata.columns)
+        self.assertTrue('run' in metadata.columns)
+
+        # Only one subject in the metadata
+        self.assertEquals(np.unique(metadata.subject), 1)
+
+        # we should have two sessions in the metadata
+        self.assertEquals(len(np.unique(metadata.session)), 2)
+
+        # Accept filters
+        paradigm = SimpleSSVEP(filters=[[10.5, 11.5], [12.5, 13.5]])
+        dataset = FakeDataset(paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+        # X must be a 3D Array
+        self.assertEquals(len(X.shape), 4)
+        self.assertEquals(X.shape[-1], 2)
+
+
+
+        

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -67,6 +67,12 @@ class Test_MotorImagery(unittest.TestCase):
         raw._data[-1] *= 0
         self.assertIsNone(paradigm.process_raw(raw, dataset))
 
+    def test_BaseImagery_noevent(self):
+        # Assert error if events from paradigm and dataset dont overlap
+        paradigm = SimpleMotorImagery(events=['left_hand', 'right_hand'])
+        dataset = FakeDataset()
+        self.assertRaises(AssertionError, paradigm.get_data, dataset)
+
     def test_LeftRightImagery_paradigm(self):
         # with a good dataset
         paradigm = LeftRightImagery()
@@ -94,6 +100,10 @@ class Test_MotorImagery(unittest.TestCase):
         # X must be a 4D Array
         self.assertEqual(len(X.shape), 4)
         self.assertEqual(X.shape[-1], 6)
+
+    def test_FilterBankMotorImagery_moreclassesthanevent(self):
+        self.assertRaises(AssertionError, FilterBankMotorImagery, n_classes=3,
+                          events=['hands', 'feet'])
 
     def test_FilterBankLeftRightImagery_paradigm(self):
         # can work with filter bank
@@ -171,6 +181,16 @@ class Test_SSVEP(unittest.TestCase):
         dataset = FakeDataset(event_list=['13', '15'], paradigm='ssvep')
         self.assertRaises(ValueError, paradigm.get_data, dataset)
 
+    def test_BaseSSVEP_moreclassesthanevent(self):
+        self.assertRaises(AssertionError, BaseSSVEP, n_classes=3,
+                          events=['13.', '14.'])
+
+    def test_SSVEP_noevent(self):
+        # Assert error if events from paradigm and dataset dont overlap
+        paradigm = SSVEP(events=['11', '12'], n_classes=2)
+        dataset = FakeDataset(event_list=['13', '14'], paradigm='ssvep')
+        self.assertRaises(AssertionError, paradigm.get_data, dataset)
+
     def test_SSVEP_paradigm(self):
         paradigm = SSVEP(n_classes=None)
         dataset = FakeDataset(event_list=['13', '15', '17', '19'],
@@ -210,9 +230,8 @@ class Test_SSVEP(unittest.TestCase):
 
     def test_SSVEP_filter(self):
         # Do not accept multiple filters
-        self.assertRaises(
-            ValueError, SSVEP, filters=[
-                (10.5, 11.5), (12.5, 13.5)])
+        self.assertRaises(ValueError, SSVEP,
+                          filters=[(10.5, 11.5), (12.5, 13.5)])
 
     def test_FilterBankSSVEP_paradigm(self):
         # FilterBankSSVEP with all events

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -1,35 +1,36 @@
 import unittest
 
 from moabb.datasets.fake import FakeDataset
-from moabb.paradigms import (BaseSSVEP,
+from moabb.paradigms import (BaseSSVEP, FilterBankSSVEP, SSVEP,
                              LeftRightImagery, BaseMotorImagery,
                              FilterBankMotorImagery,
                              FilterBankLeftRightImagery)
 
 import numpy as np
+import logging
+
+log = logging.getLogger()
+log.setLevel(logging.ERROR)
+
+
+class SimpleMotorImagery(BaseMotorImagery):  # Needed to assess BaseImagery
+    def used_events(self, dataset):
+        return dataset.event_id
 
 
 class Test_MotorImagery(unittest.TestCase):
 
     def test_BaseImagery_paradigm(self):
-
-        class SimpleMotorImagery(BaseMotorImagery):
-
-            def used_events(self, dataset):
-                return dataset.event_id
-
-        self.assertRaises(ValueError, SimpleMotorImagery, tmin=1, tmax=0)
-
         paradigm = SimpleMotorImagery()
         dataset = FakeDataset()
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
-        # we should have all the same lenght
-        self.assertEquals(len(X), len(labels), len(metadata))
+        # we should have all the same length
+        self.assertEqual(len(X), len(labels), len(metadata))
         # X must be a 3D Array
-        self.assertEquals(len(X.shape), 3)
+        self.assertEqual(len(X.shape), 3)
         # labels must contain 3 values
-        self.assertEquals(len(np.unique(labels)), 3)
+        self.assertEqual(len(np.unique(labels)), 3)
 
         # metadata must have subjets, sessions, runs
         self.assertTrue('subject' in metadata.columns)
@@ -37,19 +38,23 @@ class Test_MotorImagery(unittest.TestCase):
         self.assertTrue('run' in metadata.columns)
 
         # we should have only one subject in the metadata
-        self.assertEquals(np.unique(metadata.subject), 1)
+        self.assertEqual(np.unique(metadata.subject), 1)
 
         # we should have two sessions in the metadata
-        self.assertEquals(len(np.unique(metadata.session)), 2)
+        self.assertEqual(len(np.unique(metadata.session)), 2)
 
+    def test_BaseImagery_tmintmax(self):
+        self.assertRaises(ValueError, SimpleMotorImagery, tmin=1, tmax=0)
+
+    def test_BaseImagery_filters(self):
         # can work with filter bank
         paradigm = SimpleMotorImagery(filters=[[7, 12], [12, 24]])
         dataset = FakeDataset()
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
-        # X must be a 3D Array
-        self.assertEquals(len(X.shape), 4)
-        self.assertEquals(X.shape[-1], 2)
+        # X must be a 4D Array
+        self.assertEqual(len(X.shape), 4)
+        self.assertEqual(X.shape[-1], 2)
 
         # test process_raw return empty list if raw does not contain any
         # selected event. cetain runs in dataset are event specific.
@@ -62,62 +67,58 @@ class Test_MotorImagery(unittest.TestCase):
         raw._data[-1] *= 0
         self.assertIsNone(paradigm.process_raw(raw, dataset))
 
-    def test_leftright_paradigm(self):
-        # we cant pass event to this class
+    def test_LeftRightImagery_paradigm(self):
+        # with a good dataset
         paradigm = LeftRightImagery()
+        dataset = FakeDataset(event_list=['left_hand', 'right_hand'])
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+        self.assertEqual(len(np.unique(labels)), 2)
+        self.assertEqual(list(np.unique(labels)), ['left_hand', 'right_hand'])
+
+    def test_LeftRightImagery_noevent(self):
+        # we cant pass event to this class
         self.assertRaises(ValueError, LeftRightImagery, events=['a'])
 
+    def test_LeftRightImagery_badevents(self):
+        paradigm = LeftRightImagery()
         # does not accept dataset with bad event
         dataset = FakeDataset()
         self.assertRaises(AssertionError, paradigm.get_data, dataset)
 
-        # with a good dataset
-        dataset = FakeDataset(event_list=['left_hand', 'right_hand'])
-        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
-        self.assertEquals(len(np.unique(labels)), 2)
-        self.assertEquals(list(np.unique(labels)), ['left_hand', 'right_hand'])
-
-    def test_filter_bank_mi(self):
+    def test_FilterBankMotorImagery_paradigm(self):
         # can work with filter bank
         paradigm = FilterBankMotorImagery()
         dataset = FakeDataset()
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
-        # X must be a 3D Array
-        self.assertEquals(len(X.shape), 4)
-        self.assertEquals(X.shape[-1], 6)
+        # X must be a 4D Array
+        self.assertEqual(len(X.shape), 4)
+        self.assertEqual(X.shape[-1], 6)
 
+    def test_FilterBankLeftRightImagery_paradigm(self):
         # can work with filter bank
         paradigm = FilterBankLeftRightImagery()
         dataset = FakeDataset(event_list=['left_hand', 'right_hand'])
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
-        # X must be a 3D Array
-        self.assertEquals(len(X.shape), 4)
-        self.assertEquals(X.shape[-1], 6)
+        # X must be a 4D Array
+        self.assertEqual(len(X.shape), 4)
+        self.assertEqual(X.shape[-1], 6)
 
 
 class Test_SSVEP(unittest.TestCase):
 
     def test_BaseSSVEP_paradigm(self):
-
-        class SimpleSSVEP(BaseSSVEP):
-
-            def used_events(self, dataset):
-                return dataset.event_id
-
-        self.assertRaises(ValueError, SimpleSSVEP, tmin=1, tmax=0)
-
-        paradigm = SimpleSSVEP()
+        paradigm = BaseSSVEP(n_classes=None)
         dataset = FakeDataset(paradigm='ssvep')
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
         # Verify that they have the same length
-        self.assertEquals(len(X), len(labels), len(metadata))
-        # X must be a 3D Array
-        self.assertEquals(len(X.shape), 3)
+        self.assertEqual(len(X), len(labels), len(metadata))
+        # X must be a 3D array
+        self.assertEqual(len(X.shape), 3)
         # labels must contain 3 values
-        self.assertEquals(len(np.unique(labels)), 3)
+        self.assertEqual(len(np.unique(labels)), 3)
 
         # metadata must have subjets, sessions, runs
         self.assertTrue('subject' in metadata.columns)
@@ -125,15 +126,117 @@ class Test_SSVEP(unittest.TestCase):
         self.assertTrue('run' in metadata.columns)
 
         # Only one subject in the metadata
-        self.assertEquals(np.unique(metadata.subject), 1)
+        self.assertEqual(np.unique(metadata.subject), 1)
 
-        # we should have two sessions in the metadata
-        self.assertEquals(len(np.unique(metadata.session)), 2)
+        # we should have two sessions in the metadata, n_classes = 2 as default
+        self.assertEqual(len(np.unique(metadata.session)), 2)
 
+    def test_baseSSVEP_tmintmax(self):
+        # Verify that tmin < tmax
+        self.assertRaises(ValueError, BaseSSVEP, tmin=1, tmax=0)
+
+    def test_BaseSSVEP_filters(self):
         # Accept filters
-        paradigm = SimpleSSVEP(filters=[[10.5, 11.5], [12.5, 13.5]])
+        paradigm = BaseSSVEP(filters=[(10.5, 11.5), (12.5, 13.5)])
         dataset = FakeDataset(paradigm='ssvep')
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
-        # X must be a 3D Array
-        self.assertEquals(len(X.shape), 4)
-        self.assertEquals(X.shape[-1], 2)
+
+        # X must be a 4D array
+        self.assertEqual(len(X.shape), 4)
+        # Last dim should be 2 as the number of filters
+        self.assertEqual(X.shape[-1], 2)
+
+    def test_BaseSSVEP_nclasses_default(self):
+        # Default is with 2 classes
+        paradigm = BaseSSVEP()
+        dataset = FakeDataset(
+            event_list=[
+                '13',
+                '15',
+                '17',
+                '19'],
+            paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+
+        # labels must contain 2 values, as n_classes is 2 by default
+        self.assertEqual(len(np.unique(labels)), 2)
+
+    def test_BaseSSVEP_specified_nclasses(self):
+        # Set the number of classes
+        paradigm = BaseSSVEP(n_classes=3)
+        dataset = FakeDataset(
+            event_list=[
+                '13',
+                '15',
+                '17',
+                '19'],
+            paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+
+        # labels must contain 3 values
+        self.assertEqual(len(np.unique(labels)), 3)
+
+    def test_SSVEP_paradigm(self):
+        paradigm = SSVEP(n_classes=None)
+        dataset = FakeDataset(event_list=['13', '15', '17', '19'],
+                              paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+
+        # Verify that they have the same length
+        self.assertEqual(len(X), len(labels), len(metadata))
+        # X must be a 3D array
+        self.assertEqual(len(X.shape), 3)
+        # labels must contain 4 values, defined in the dataset
+        self.assertEqual(len(np.unique(labels)), 4)
+
+        # metadata must have subjets, sessions, runs
+        self.assertTrue('subject' in metadata.columns)
+        self.assertTrue('session' in metadata.columns)
+        self.assertTrue('run' in metadata.columns)
+
+        # Only one subject in the metadata
+        self.assertEqual(np.unique(metadata.subject), 1)
+
+        # We should have two sessions in the metadata
+        self.assertEqual(len(np.unique(metadata.session)), 2)
+
+    def test_SSVEP_singlepass(self):
+        # Accept only single pass filter
+        paradigm = SSVEP(fmin=2, fmax=25)
+        dataset = FakeDataset(paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+
+        # Verify that they have the same length
+        self.assertEqual(len(X), len(labels), len(metadata))
+        # X must be a 3D array
+        self.assertEqual(len(X.shape), 3)
+        # labels must contain 2 values, as n_classes = 2 by default
+        self.assertEqual(len(np.unique(labels)), 2)
+
+    def test_SSVEP_filter(self):
+        # Do not accept multiple filters
+        self.assertRaises(
+            ValueError, SSVEP, filters=[
+                (10.5, 11.5), (12.5, 13.5)])
+
+    def test_FilterBankSSVEP_paradigm(self):
+        # FilterBankSSVEP with all events
+        paradigm = FilterBankSSVEP(n_classes=None)
+        dataset = FakeDataset(event_list=['13', '15', '17', '19'],
+                              paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+
+        # X must be a 4D array
+        self.assertEqual(len(X.shape), 4)
+        # X must be a 4D array with d=4 as last dimension for the 4 events
+        self.assertEqual(X.shape[-1], 4)
+
+    def test_FilterBankSSVEP_filters(self):
+        # can work with filter bank
+        paradigm = FilterBankSSVEP(filters=[(10.5, 11.5), (12.5, 13.5)])
+        dataset = FakeDataset(event_list=['13', '15', '17'], paradigm='ssvep')
+        X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
+
+        # X must be a 4D array with d=2 as last dimension for the 2 filters
+        self.assertEqual(len(X.shape), 4)
+        self.assertEqual(X.shape[-1], 2)

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -102,7 +102,7 @@ class Test_SSVEP(unittest.TestCase):
     def test_BaseSSVEP_paradigm(self):
 
         class SimpleSSVEP(BaseSSVEP):
-            
+
             def used_events(self, dataset):
                 return dataset.event_id
 
@@ -137,7 +137,3 @@ class Test_SSVEP(unittest.TestCase):
         # X must be a 3D Array
         self.assertEquals(len(X.shape), 4)
         self.assertEquals(X.shape[-1], 2)
-
-
-
-        

--- a/moabb/tests/test_pipelines/LogVar.yml
+++ b/moabb/tests/test_pipelines/LogVar.yml
@@ -2,6 +2,7 @@ name: Log Variance LDA
 
 paradigms:
   - FakeImageryParadigm
+  - FakeSSVEPParadigm
 
 pipeline:
   - name: LogVariance

--- a/moabb/tests/test_pipelines/LogVar.yml
+++ b/moabb/tests/test_pipelines/LogVar.yml
@@ -2,7 +2,6 @@ name: Log Variance LDA
 
 paradigms:
   - FakeImageryParadigm
-  - FakeSSVEPParadigm
 
 pipeline:
   - name: LogVariance

--- a/moabb/tests/test_pipelines/SSVEP_CCA.yml
+++ b/moabb/tests/test_pipelines/SSVEP_CCA.yml
@@ -1,0 +1,12 @@
+name: SSVEP CCA
+
+paradigms:
+  - FakeSSVEPParadigm
+
+pipeline:
+  - name: SSVEP_CCA
+    from: moabb.pipelines.classification
+    parameters:
+      n_harmonics: 3
+      interval: [1, 3]
+      freqs: {'13': 0, '17': 1}


### PR DESCRIPTION
This PR add the support for SSVEP paradigm, which defines the stimulation frequencies, the number of classes to consider. The returned data is a concatenation of the EEG bandpass filtered around the stim freq (`[f_n-0.5, f_n+0.5]`) and the EEG with a wide bandpass (`[1, 45]`). So for a dataset with 10 electrodes, T time samples and 2 stim freq, the returned data of shape (10*(2+1), T). The first ten rows are the 10 electrodes filtered around the first stim freq, the next 10 rows are filtered around the second freq and the last 10 rows are the EEG filtered with a wide bandpass. There is a unit test for SSVEP paradigm in `moabb/tests/paradigms.py`

A first SSVEP dataset, `SSVEPExo()` is included, which is tested in `examples/plot_cross_subject_ssvep.py`. The dataset have 4 classes (3 stim frequency and a resting class), 2 classes corresponding to the first stim freq are used in the example. I wrote a Canonical Correlation Analaysis (CCA)-based classifier, as it is commonly used in SSVEP. The CCA classifier use the broadband filtered signal. The dataset is also benchmark against Riemannian tangent classifier using extended covariance matrices. These matrices are computed from the concatenation of signal filtered around the stim freq. 

For compatibility issue, I copied the modifications made in the  #51 on `moabb/datasets/fake.py` 