### PR TITLE
Dataset compatibility using MNE >= 0.20

### DIFF
--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -111,7 +111,7 @@ class Weibo2014(BaseDataset):
         # TODO: add 1s 0 buffer between trials and make continuous
         data = loadmat(fname, squeeze_me=True, struct_as_record=False,
                        verify_compressed_data_integrity=False)
-        montage = mne.channels.read_montage('standard_1005')
+        montage = mne.channels.make_standard_montage('standard_1005')
         ch_names = ['Fp1', 'Fpz', 'Fp2', 'AF3', 'AF4', 'F7', 'F5', 'F3', 'F1',
                     'Fz', 'F2', 'F4', 'F6', 'F8', 'FT7', 'FC5', 'FC3', 'FC1',
                     'FCz', 'FC2', 'FC4', 'FC6', 'FT8', 'T7', 'C5', 'C3', 'C1',

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.io import loadmat
 from mne import create_info
 from mne.io import RawArray
-from mne.channels import read_montage
+from mne.channels import make_standard_montage
 import os.path as op
 import os
 import zipfile as z
@@ -127,7 +127,7 @@ class Shin2017(BaseDataset):
         ch_names = list(data[session].clab) + ['Stim']
         ch_types = ['eeg'] * 30 + ['eog'] * 2 + ['stim']
 
-        montage = read_montage('standard_1005')
+        montage = make_standard_montage('standard_1005')
         info = create_info(ch_names=ch_names, ch_types=ch_types,
                            sfreq=200., montage=montage)
         raw = RawArray(data=eeg, info=info, verbose=False)

--- a/moabb/datasets/bnci.py
+++ b/moabb/datasets/bnci.py
@@ -7,7 +7,7 @@ from moabb.datasets import download as dl
 
 from mne import create_info
 from mne.io import RawArray
-from mne.channels import read_montage
+from mne.channels import make_standard_montage
 from mne.utils import verbose
 import numpy as np
 
@@ -297,7 +297,7 @@ def _load_data_003_2015(subject,
     ]
 
     ch_types = ['eeg'] * 8 + ['stim'] * 2
-    montage = read_montage('standard_1005')
+    montage = make_standard_montage('standard_1005')
 
     info = create_info(
         ch_names=ch_names, ch_types=ch_types, sfreq=sfreq, montage=montage)
@@ -507,7 +507,7 @@ def _convert_run(run, ch_names=None, ch_types=None, verbose=None):
     # parse eeg data
     event_id = {}
     n_chan = run.X.shape[1]
-    montage = read_montage('standard_1005')
+    montage = make_standard_montage('standard_1005')
     eeg_data = 1e-6 * run.X
     sfreq = run.fs
 
@@ -536,7 +536,7 @@ def _convert_run(run, ch_names=None, ch_types=None, verbose=None):
 @verbose
 def _convert_run_p300_sl(run, verbose=None):
     """Convert one p300 run from santa lucia file format."""
-    montage = read_montage('standard_1005')
+    montage = make_standard_montage('standard_1005')
     eeg_data = 1e-6 * run.X
     sfreq = 256
     ch_names = list(run.channels) + ['Target stim', 'Flash stim']
@@ -573,7 +573,7 @@ def _convert_bbci(filename, ch_types, verbose=None):
 def _convert_run_bbci(run, ch_types, verbose=None):
     """Convert one run to raw."""
     # parse eeg data
-    montage = read_montage('standard_1005')
+    montage = make_standard_montage('standard_1005')
     eeg_data = 1e-6 * run.X
     sfreq = run.fs
 
@@ -604,7 +604,7 @@ def _convert_run_epfl(run, verbose=None):
     # parse eeg data
     event_id = {}
 
-    montage = read_montage('standard_1005')
+    montage = make_standard_montage('standard_1005')
     eeg_data = 1e-6 * run.eeg
     sfreq = run.header.SampleRate
 

--- a/moabb/datasets/fake.py
+++ b/moabb/datasets/fake.py
@@ -1,6 +1,6 @@
 from mne import create_info
 from mne.io import RawArray
-from mne.channels import read_montage
+from mne.channels import make_standard_montage
 import numpy as np
 
 from moabb.datasets.base import BaseDataset
@@ -32,7 +32,7 @@ class FakeDataset(BaseDataset):
 
         ch_names = ['C3', 'Cz', 'C4']
 
-        montage = read_montage('standard_1005')
+        montage = make_standard_montage('standard_1005')
         sfreq = 128
         duration = len(self.event_id) * 60
         eeg_data = 2e-5 * np.random.randn(duration * sfreq, len(ch_names))

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from mne import create_info
 from mne.io import RawArray
-from mne.channels import read_montage
+from mne.channels import make_standard_montage
 from . import download as dl
 import logging
 
@@ -88,7 +88,7 @@ class Cho2017(BaseDataset):
         emg_ch_names = ['EMG1', 'EMG2', 'EMG3', 'EMG4']
         ch_names = eeg_ch_names + emg_ch_names + ['Stim']
         ch_types = ['eeg'] * 64 + ['emg'] * 4 + ['stim']
-        montage = read_montage('standard_1005')
+        montage = make_standard_montage('standard_1005')
         imagery_left = data.imagery_left - \
             data.imagery_left.mean(axis=1, keepdims=True)
         imagery_right = data.imagery_right - \

--- a/moabb/datasets/physionet_mi.py
+++ b/moabb/datasets/physionet_mi.py
@@ -94,7 +94,7 @@ class PhysionetMI(BaseDataset):
                                      base_url=BASE_URL)[0]
         raw = read_raw_edf(raw_fname, preload=preload, verbose='ERROR')
         raw.rename_channels(lambda x: x.strip('.'))
-        raw.set_montage(mne.channels.read_montage('standard_1005'))
+        raw.set_montage(mne.channels.make_standard_montage('standard_1005'))
         return raw
 
     def _get_single_subject_data(self, subject):

--- a/moabb/datasets/upper_limb.py
+++ b/moabb/datasets/upper_limb.py
@@ -1,7 +1,7 @@
 from moabb.datasets.base import BaseDataset
 
 from mne.io import read_raw_edf
-from mne.channels import read_montage
+from mne.channels import make_standard_montage
 import numpy as np
 
 from . import download as dl
@@ -91,7 +91,7 @@ class Ofner2017(BaseDataset):
             paths = self.data_path(subject, session=session)
 
             eog = ['eog-l', 'eog-m', 'eog-r']
-            montage = read_montage('standard_1005')
+            montage = make_standard_montage('standard_1005')
             data = {}
             for ii, path in enumerate(paths):
                 raw = read_raw_edf(path, montage=montage, eog=eog,


### PR DESCRIPTION
use DigMontage instead of Montage, which is deprecated and will be removed in MNE >= 0.20


Unittests run, but produce long logger.infos, as the fake.py dataset uses only 3 out of the 343 channels in the standard_1005 montage.