### PR TITLE
Expose sklearn error_score parameter

### DIFF
--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -33,9 +33,10 @@ class BaseEvaluation(ABC):
     '''
 
     def __init__(self, paradigm, datasets=None, random_state=None, n_jobs=1,
-                 overwrite=False, suffix=''):
+                 overwrite=False, error_score='raise', suffix=''):
         self.random_state = random_state
         self.n_jobs = n_jobs
+        self.error_score = error_score
 
         # check paradigm
         if not isinstance(paradigm, BaseParadigm):

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -62,7 +62,7 @@ class WithinSessionEvaluation(BaseEvaluation):
         le = LabelEncoder()
         y = le.fit_transform(y)
         acc = cross_val_score(clf, X, y, cv=cv, scoring=scoring,
-                              n_jobs=self.n_jobs)
+                              n_jobs=self.n_jobs, error_score=self.error_score)
         return acc.mean()
 
     def is_valid(self, dataset):
@@ -106,7 +106,8 @@ class CrossSessionEvaluation(BaseEvaluation):
                     score = _fit_and_score(clone(clf), X, y, scorer, train,
                                            test, verbose=False,
                                            parameters=None,
-                                           fit_params=None)[0]
+                                           fit_params=None,
+                                           error_score=self.error_score)[0]
                     duration = time() - t_start
                     res = {'time': duration,
                            'dataset': dataset,


### PR DESCRIPTION
Current behaviour:

Default: If there's an error during fitting (e.g. linalg errors), the benchmark is interrupted.
A different behaviour requires a custom evaluation implementation.

New behaviour:

Default: If there's an error during fitting, the benchmark is interrupted.
If we want to set the score for the current run to e.g. `np.nan` once we get an error, we simply instantiate e.g. `WithinSessionEvaluation(..., error_score=np.nan)`.

This simply propagates the error_score argument to the underlying sklearn validation methods.  `CrossSubjectEvaluation` does not use sklearn validation and is therefore unaffected.