### PR TITLE
Generalize Paradigms

### DIFF
--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -49,7 +49,7 @@ class BaseDataset(metaclass=abc.ABCMeta):
     """
 
     def __init__(self, subjects, sessions_per_subject, events,
-                 code, interval, paradigm, doi=None):
+                 code, interval, paradigm, doi=None, unit_factor=1e6):
         if not isinstance(subjects, list):
             raise(ValueError("subjects must be a list"))
 
@@ -60,6 +60,7 @@ class BaseDataset(metaclass=abc.ABCMeta):
         self.interval = interval
         self.paradigm = paradigm
         self.doi = doi
+        self.unit_factor = unit_factor
 
     def get_data(self, subjects=None):
         """

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -95,8 +95,14 @@ class BaseParadigm(metaclass=ABCMeta):
             A dataframe containing the metadata
 
         """
-        # find the events
-        events = mne.find_events(raw, shortest_event=0, verbose=False)
+        # find the events, first check stim_channels then annotations
+        stim_channels = mne.utils._get_stim_channel(
+            None, raw.info, raise_error=False)
+        if len(stim_channels) > 0:
+            events = mne.find_events(raw, shortest_event=0, verbose=False)
+        else:
+            events, _ = mne.events_from_annotations(raw, verbose=False)
+
         channels = () if self.channels is None else self.channels
 
         # picks channels
@@ -134,8 +140,8 @@ class BaseParadigm(metaclass=ABCMeta):
                                 on_missing='ignore')
             if self.resample is not None:
                 epochs = epochs.resample(self.resample)
-            # MNE is in V, rescale to have uV
-            X.append(1e6 * epochs.get_data())
+            # rescale to work with uV
+            X.append(dataset.unit_factor * epochs.get_data())
 
         inv_events = {k: v for v, k in event_id.items()}
         labels = np.array([inv_events[e] for e in epochs.events[:, -1]])

--- a/moabb/paradigms/p300.py
+++ b/moabb/paradigms/p300.py
@@ -80,8 +80,14 @@ class BaseP300(BaseParadigm):
         pass
 
     def process_raw(self, raw, dataset):
-        # find the events
-        events = mne.find_events(raw, shortest_event=0, verbose=False)
+        # find the events, first check stim_channels then annotations
+        stim_channels = mne.utils._get_stim_channel(
+            None, raw.info, raise_error=False)
+        if len(stim_channels) > 0:
+            events = mne.find_events(raw, shortest_event=0, verbose=False)
+        else:
+            events, _ = mne.events_from_annotations(raw, verbose=False)
+
         channels = () if self.channels is None else self.channels
 
         # picks channels
@@ -119,8 +125,8 @@ class BaseP300(BaseParadigm):
                                 on_missing='ignore')
             if self.resample is not None:
                 epochs = epochs.resample(self.resample)
-            # MNE is in V, rescale to have uV
-            X.append(1e6 * epochs.get_data())
+            # rescale to work with uV
+            X.append(dataset.unit_factor * epochs.get_data())
 
         inv_events = {k: v for v, k in event_id.items()}
         labels = np.array([inv_events[e] for e in epochs.events[:, -1]])


### PR DESCRIPTION
1. Adds a unit_factor attribute (default: 1e6) to all datasets and uses this attribute in base_paradigms and p300_paradigms to determine the factor to multiply the data with.

2. Check if stim channels are present. If yes, use default mne.find_events. Otherwise check annotations for events (e.g. for brainvision data)