### PR TITLE
Handled errors during validation via error_score parameter

### DIFF
--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -61,9 +61,15 @@ class WithinSessionEvaluation(BaseEvaluation):
 
         le = LabelEncoder()
         y = le.fit_transform(y)
-        acc = cross_val_score(clf, X, y, cv=cv, scoring=scoring,
-                              n_jobs=self.n_jobs, error_score=self.error_score)
-        return acc.mean()
+        try:
+            acc = cross_val_score(clf, X, y, cv=cv, scoring=scoring,
+                                  n_jobs=self.n_jobs, error_score=self.error_score).mean()
+        except ValueError as e:
+            if self.error_score == 'raise':
+                raise e
+            elif self.error_score is np.nan:
+                acc = np.nan
+        return acc
 
     def is_valid(self, dataset):
         return True


### PR DESCRIPTION
When using `error_score=np.nan` in sklearn, this results in np.nan value whenver there's an **error during transformations or model fitting**.
For my personal use case I also would like values of `np.nan` when there's an error in the validation itself. I have a dataset for which (due to early stopping) sometimes the AUC cannot be calculated for 5-folds. In current moabb, this error is raised and stops the benchmark.

So far I only implemented it for `WithinSessionEvaluation` as I don't use the other ones.