### PR TITLE
Allow event lists in P300 paradigm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: ${{ matrix.os }}, py-${{ matrix.python_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macOS-latest]
+        python_version: [3.6]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python_version }}
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip wheel flake8
+        pip install -r requirements.txt
+        pip install .
+    - name: Run tests
+      shell: bash
+      run: |
+        python -m unittest moabb.tests
+        python -m moabb.run --pipelines=./moabb/tests/test_pipelines/ --verbose
+    - name: Run linting
+      shell: bash
+      run: |
+        flake8 moabb

--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,29 @@
-Copyright © 2017, authors of moabb
+BSD 3-Clause License
+
+Copyright (c) 2017, authors of moabb
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the names of moabb authors nor the names of any
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **This is work in progress. API will change significantly (as well as the results of the benchmark).**
 
-[![Build Status](https://travis-ci.org/NeuroTechX/moabb.svg?branch=master)](https://travis-ci.org/NeuroTechX/moabb)
+[![Build Status](https://github.com/NeuroTechX/moabb/workflows/Test/badge.svg)](https://github.com/NeuroTechX/moabb/actions?query=branch%3Amaster)
 
 ## Welcome!
 

--- a/moabb/paradigms/p300.py
+++ b/moabb/paradigms/p300.py
@@ -99,14 +99,11 @@ class BaseP300(BaseParadigm):
 
         # pick events, based on event_id
         try:
-            if type(event_id['Target']) == list:
-                if type(event_id['NonTarget']) == list:
-                    event_id_new = dict(Target=1, NonTarget=0)
-                    events = mne.merge_events(events, event_id['Target'], 1)
-                    events = mne.merge_events(events, event_id['NonTarget'], 0)
-                    event_id = event_id_new
-                else:
-                    raise ValueError('Please provide both Target/NonTarget event ids in lists or neither.')
+            if type(event_id['Target']) is list and type(event_id['NonTarget']) == list:
+                event_id_new = dict(Target=1, NonTarget=0)
+                events = mne.merge_events(events, event_id['Target'], 1)
+                events = mne.merge_events(events, event_id['NonTarget'], 0)
+                event_id = event_id_new
             events = mne.pick_events(events, include=list(event_id.values()))
         except RuntimeError:
             # skip raw if no event found

--- a/moabb/paradigms/p300.py
+++ b/moabb/paradigms/p300.py
@@ -99,6 +99,14 @@ class BaseP300(BaseParadigm):
 
         # pick events, based on event_id
         try:
+            if type(event_id['Target']) == list:
+                if type(event_id['NonTarget']) == list:
+                    event_id_new = dict(Target=1, NonTarget=0)
+                    events = mne.merge_events(events, event_id['Target'], 1)
+                    events = mne.merge_events(events, event_id['NonTarget'], 0)
+                    event_id = event_id_new
+                else:
+                    raise ValueError('Please provide both Target/NonTarget event ids in lists or neither.')
             events = mne.pick_events(events, include=list(event_id.values()))
         except RuntimeError:
             # skip raw if no event found

--- a/moabb/paradigms/p300.py
+++ b/moabb/paradigms/p300.py
@@ -108,7 +108,8 @@ class BaseP300(BaseParadigm):
 
         # pick events, based on event_id
         try:
-            if type(event_id['Target']) is list and type(event_id['NonTarget']) == list:
+            if (type(event_id['Target']) is list and
+                    type(event_id['NonTarget']) == list):
                 event_id_new = dict(Target=1, NonTarget=0)
                 events = mne.merge_events(events, event_id['Target'], 1)
                 events = mne.merge_events(events, event_id['NonTarget'], 0)

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -130,15 +130,15 @@ class Test_P300(unittest.TestCase):
 
     def test_BaseP300_paradigm(self):
         paradigm = SimpleP300()
-        dataset = FakeDataset(paradigm='p300')
+        dataset = FakeDataset(paradigm='p300', event_list=['Target', 'NonTarget'])
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
         # we should have all the same length
         self.assertEqual(len(X), len(labels), len(metadata))
         # X must be a 3D Array
         self.assertEqual(len(X.shape), 3)
-        # labels must contain 3 values
-        self.assertEqual(len(np.unique(labels)), 3)
+        # labels must contain 2 values (Target/NonTarget)
+        self.assertEqual(len(np.unique(labels)), 2)
 
         # metadata must have subjets, sessions, runs
         self.assertTrue('subject' in metadata.columns)
@@ -160,7 +160,7 @@ class Test_P300(unittest.TestCase):
     def test_BaseP300_filters(self):
         # can work with filter bank
         paradigm = SimpleP300(filters=[[1, 12], [12, 24]])
-        dataset = FakeDataset(paradigm='p300')
+        dataset = FakeDataset(paradigm='p300', event_list=['Target', 'NonTarget'])
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
         # X must be a 4D Array
@@ -171,7 +171,7 @@ class Test_P300(unittest.TestCase):
         # test process_raw return empty list if raw does not contain any
         # selected event. cetain runs in dataset are event specific.
         paradigm = SimpleP300(filters=[[1, 12], [12, 24]])
-        dataset = FakeDataset(paradigm='p300')
+        dataset = FakeDataset(paradigm='p300', event_list=['Target', 'NonTarget'])
         raw = dataset.get_data([1])[1]['session_0']['run_0']
         # add something on the event channel
         raw._data[-1] *= 10

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -130,7 +130,8 @@ class Test_P300(unittest.TestCase):
 
     def test_BaseP300_paradigm(self):
         paradigm = SimpleP300()
-        dataset = FakeDataset(paradigm='p300', event_list=['Target', 'NonTarget'])
+        dataset = FakeDataset(paradigm='p300',
+                              event_list=['Target', 'NonTarget'])
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
         # we should have all the same length
@@ -160,7 +161,8 @@ class Test_P300(unittest.TestCase):
     def test_BaseP300_filters(self):
         # can work with filter bank
         paradigm = SimpleP300(filters=[[1, 12], [12, 24]])
-        dataset = FakeDataset(paradigm='p300', event_list=['Target', 'NonTarget'])
+        dataset = FakeDataset(paradigm='p300',
+                              event_list=['Target', 'NonTarget'])
         X, labels, metadata = paradigm.get_data(dataset, subjects=[1])
 
         # X must be a 4D Array
@@ -171,7 +173,8 @@ class Test_P300(unittest.TestCase):
         # test process_raw return empty list if raw does not contain any
         # selected event. cetain runs in dataset are event specific.
         paradigm = SimpleP300(filters=[[1, 12], [12, 24]])
-        dataset = FakeDataset(paradigm='p300', event_list=['Target', 'NonTarget'])
+        dataset = FakeDataset(paradigm='p300',
+                              event_list=['Target', 'NonTarget'])
         raw = dataset.get_data([1])[1]['session_0']['run_0']
         # add something on the event channel
         raw._data[-1] *= 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-scikit-learn
+scikit-learn<0.24.0  # 0.24.0 breaks pyriemann, requires https://github.com/alexandrebarachant/pyRiemann/pull/93
 mne >= 0.19
 pyriemann
 matplotlib >= 2.2
 seaborn >= 0.9.0
-h5py
+h5py==2.10  # locked due to https://github.com/NeuroTechX/moabb/issues/122
 pandas
 pyyaml
 coloredlogs


### PR DESCRIPTION
When defining a dataset, it is now possible to use lists to specify target / non-target events. This code merges all events and proceeds using only the binary target / non-target events 1 / 0.

In my benchmarks this works without issues. However, if you see any obvious problems feel free to comment. This could (in theory) also be used for other paradigm types.