### PR TITLE
Ability to set path for hdf5 files

### DIFF
--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -39,7 +39,7 @@ class Results:
     '''
 
     def __init__(self, evaluation_class, paradigm_class, suffix='',
-                 overwrite=False):
+                 overwrite=False, hdf5_path=None):
         """
         class that will abstract result storage
         """
@@ -49,8 +49,11 @@ class Results:
         assert issubclass(evaluation_class, BaseEvaluation)
         assert issubclass(paradigm_class, BaseParadigm)
 
-        self.mod_dir = os.path.dirname(
-            os.path.abspath(inspect.getsourcefile(moabb)))
+        if hdf5_path is None:
+            self.mod_dir = os.path.dirname(
+                os.path.abspath(inspect.getsourcefile(moabb)))
+        else:
+            self.mod_dir = os.path.abspath(hdf5_path)
         self.filepath = os.path.join(self.mod_dir, 'results',
                                      paradigm_class.__name__,
                                      evaluation_class.__name__,

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -33,7 +33,7 @@ class BaseEvaluation(ABC):
     '''
 
     def __init__(self, paradigm, datasets=None, random_state=None, n_jobs=1,
-                 overwrite=False, error_score='raise', suffix='', 
+                 overwrite=False, error_score='raise', suffix='',
                  hdf5_path=None):
         self.random_state = random_state
         self.n_jobs = n_jobs

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -33,10 +33,11 @@ class BaseEvaluation(ABC):
     '''
 
     def __init__(self, paradigm, datasets=None, random_state=None, n_jobs=1,
-                 overwrite=False, error_score='raise', suffix=''):
+                 overwrite=False, error_score='raise', suffix='', hdf5_path=None):
         self.random_state = random_state
         self.n_jobs = n_jobs
         self.error_score = error_score
+        self.hdf5_path = hdf5_path
 
         # check paradigm
         if not isinstance(paradigm, BaseParadigm):
@@ -82,7 +83,8 @@ class BaseEvaluation(ABC):
         self.results = Results(type(self),
                                type(self.paradigm),
                                overwrite=overwrite,
-                               suffix=suffix)
+                               suffix=suffix,
+                               hdf5_path=self.hdf5_path)
 
     def process(self, pipelines):
         '''Runs all pipelines on all datasets.

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -33,7 +33,8 @@ class BaseEvaluation(ABC):
     '''
 
     def __init__(self, paradigm, datasets=None, random_state=None, n_jobs=1,
-                 overwrite=False, error_score='raise', suffix='', hdf5_path=None):
+                 overwrite=False, error_score='raise', suffix='', 
+                 hdf5_path=None):
         self.random_state = random_state
         self.n_jobs = n_jobs
         self.error_score = error_score


### PR DESCRIPTION
Adds ability to set the path for hdf5_files. If unset, keeps the current default of putting the hdf5 files into virtual environment. Implements #91 .

Example:

```
evaluation = WithinSessionEvaluation(..., hdf5_path='/tmp/moabb')
```

Should be usable from all Evaluation implementations that do not overwirte `BaseEvaluation`'s `__init__`.