### PR TITLE
Channel selection in paradigm

### DIFF
--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -111,11 +111,12 @@ class BaseParadigm(metaclass=ABCMeta):
             events = mne.find_events(raw, shortest_event=0, verbose=False)
         else:
             events, _ = mne.events_from_annotations(raw, verbose=False)
-        channels = () if self.channels is None else self.channels
 
         # picks channels
-        picks = mne.pick_types(raw.info, eeg=True, stim=False,
-                               include=channels)
+        if self.channels is None:
+            picks = mne.pick_types(raw.info, eeg=True, stim=False)
+        else:
+            picks = mne.pick_types(raw.info, stim=False, include=self.channels)
 
         # pick events, based on event_id
         try:

--- a/tutorials/select_electrodes_resample.py
+++ b/tutorials/select_electrodes_resample.py
@@ -1,0 +1,88 @@
+"""
+================================
+Select electrodes and resampling
+================================
+
+Within paradigm, it is possible to restrict analysis only to a subset of
+electrodes and to resample to a specific sampling rate. There is also a
+utility function to select common electrodes shared between datasets.
+This tutorial demonstrates how to use this functionality.
+"""
+# Authors: Sylvain Chevallier <sylvain.chevallier@uvsq.fr>
+#
+# License: BSD (3-clause)
+from moabb.datasets import BNCI2014001, Zhou2016
+from moabb.paradigms import LeftRightImagery
+from moabb.evaluations import WithinSessionEvaluation
+from moabb.datasets.utils import find_intersecting_channels
+
+from sklearn.pipeline import make_pipeline
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
+from sklearn.linear_model import LogisticRegression as LR
+
+from mne.decoding import CSP
+from pyriemann.estimation import Covariances
+from pyriemann.tangentspace import TangentSpace
+
+import matplotlib.pyplot as plt
+import moabb.analysis.plotting as moabb_plt
+
+##############################################################################
+# Datasets
+# --------
+#
+# Select datasets for motor imagery
+
+datasets = [Zhou2016(), BNCI2014001()]
+
+##############################################################################
+# Paradigm
+# --------
+#
+# Restrict further analysis to specified channels, here C3, C4, and Cz.
+# Also, use a specific resampling. In this example, all datasets are
+# set to 200 Hz.
+
+paradigm = LeftRightImagery(channels=['C3', 'C4', 'Cz'], resample=200.)
+
+##############################################################################
+# Evaluation
+# ----------
+#
+# The evaluation is conducted on with CSP+LDA, only on the 3 electrodes, with
+# a sampling rate of 200 Hz.
+
+evaluation = WithinSessionEvaluation(paradigm=paradigm,
+                                     datasets=datasets)
+csp_lda = make_pipeline(CSP(n_components=2), LDA())
+ts_lr = make_pipeline(Covariances(estimator='oas'),
+                      TangentSpace(metric='riemann'),
+                      LR(C=1.0))
+results = evaluation.process({'csp+lda': csp_lda, 'ts+lr': ts_lr})
+print(results.head())
+
+##############################################################################
+# Electrode selection
+# -------------------
+#
+# It is possible to select the electrodes that are shared by all datasets
+# using the `find_intersecting_channels` function. Datasets that have 0
+# overlap with others are discarded. It returns the set of common channels,
+# as well as the list of datasets with valid channels.
+
+electrodes, datasets = find_intersecting_channels(datasets)
+evaluation = WithinSessionEvaluation(paradigm=paradigm,
+                                     datasets=datasets,
+                                     overwrite=True)
+results = evaluation.process({'csp+lda': csp_lda, 'ts+lr': ts_lr})
+print(results.head())
+
+##############################################################################
+# Plot results
+# ------------
+#
+# Compare the obtained results with the two pipelines, CSP+LDA and logistic
+# regression computed in the tangent space of the covariance matrices.
+
+fig = moabb_plt.paired_plot(results, 'csp+lda', 'ts+lr')
+plt.show()


### PR DESCRIPTION
Closes #107 

This PR adress the fact that despite indicating a set of channels in a paradigm, the set is not taken into account.

I added an example in the tutorial section, documenting the function `find_intersecting_channels` that have not been documented yet.