### PR TITLE
Additional columns that should be evaluated

### DIFF
--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -104,7 +104,6 @@ class Results:
                 n_add_cols = len(self.additional_columns)
                 if dname not in ppline_grp.keys():
                     # create dataset subgroup if nonexistant
-                    print(f"add cols: {n_add_cols}")
                     dset = ppline_grp.create_group(dname)
                     dset.attrs['n_subj'] = len(d1['dataset'].subject_list)
                     dset.attrs['n_sessions'] = d1['dataset'].n_sessions

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -101,9 +101,10 @@ class Results:
                 dlist = to_list(data_dict)
                 d1 = dlist[0]  # FIXME: handle multiple session ?
                 dname = d1['dataset'].code
+                n_add_cols = len(self.additional_columns)
                 if dname not in ppline_grp.keys():
                     # create dataset subgroup if nonexistant
-                    n_add_cols = len(self.additional_columns)
+                    print(f"add cols: {n_add_cols}")
                     dset = ppline_grp.create_group(dname)
                     dset.attrs['n_subj'] = len(d1['dataset'].subject_list)
                     dset.attrs['n_sessions'] = d1['dataset'].n_sessions
@@ -124,7 +125,12 @@ class Results:
                     dset['data'].resize(length, 0)
                     dset['id'][-1, :] = np.asarray([str(d['subject']),
                                                     str(d['session'])])
-                    add_cols = [d[ac] for ac in self.additional_columns]
+                    try:
+                        add_cols = [d[ac] for ac in self.additional_columns]
+                    except:
+                        raise ValueError(f'Additional columns {self.additional_columns} '
+                                         f'were specified in the evaluation, but results'
+                                         f' contain only these keys: {d.keys()}.')
                     dset['data'][-1, :] = np.asarray([d['score'],
                                                       d['time'],
                                                       d['n_samples'],

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -115,7 +115,8 @@ class Results:
                                         maxshape=(None, 3 + n_add_cols))
                     dset.attrs['channels'] = d1['n_channels']
                     dset.attrs.create('columns',
-                                      ['score', 'time', 'samples', *self.additional_columns],
+                                      ['score', 'time', 'samples',
+                                          *self.additional_columns],
                                       dtype=dt)
                 dset = ppline_grp[dname]
                 for d in dlist:
@@ -127,10 +128,11 @@ class Results:
                                                     str(d['session'])])
                     try:
                         add_cols = [d[ac] for ac in self.additional_columns]
-                    except:
-                        raise ValueError(f'Additional columns {self.additional_columns} '
-                                         f'were specified in the evaluation, but results'
-                                         f' contain only these keys: {d.keys()}.')
+                    except KeyError:
+                        raise ValueError(
+                            f'Additional columns: {self.additional_columns} '
+                            f'were specified in the evaluation, but results'
+                            f' contain only these keys: {d.keys()}.')
                     dset['data'][-1, :] = np.asarray([d['score'],
                                                       d['time'],
                                                       d['n_samples'],

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -34,7 +34,7 @@ class BaseEvaluation(ABC):
 
     def __init__(self, paradigm, datasets=None, random_state=None, n_jobs=1,
                  overwrite=False, error_score='raise', suffix='',
-                 hdf5_path=None):
+                 hdf5_path=None, additional_columns=None):
         self.random_state = random_state
         self.n_jobs = n_jobs
         self.error_score = error_score
@@ -85,7 +85,8 @@ class BaseEvaluation(ABC):
                                type(self.paradigm),
                                overwrite=overwrite,
                                suffix=suffix,
-                               hdf5_path=self.hdf5_path)
+                               hdf5_path=self.hdf5_path,
+                               additional_columns=additional_columns)
 
     def process(self, pipelines):
         '''Runs all pipelines on all datasets.

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -43,9 +43,9 @@ class Test_WithinSess(unittest.TestCase):
 class Test_AdditionalColumns(unittest.TestCase):
 
     def setUp(self):
-        self.eval = ev.WithinSessionEvaluation(paradigm=FakeImageryParadigm(),
-                                               datasets=[dataset],
-                                               additional_columns=['one', 'two'])
+        self.eval = ev.WithinSessionEvaluation(
+                paradigm=FakeImageryParadigm(), datasets=[dataset],
+                additional_columns=['one', 'two'])
 
     def tearDown(self):
         path = self.eval.results.filepath

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -40,6 +40,23 @@ class Test_WithinSess(unittest.TestCase):
         self.assertEqual(len(results), 4)
 
 
+class Test_AdditionalColumns(unittest.TestCase):
+
+    def setUp(self):
+        self.eval = ev.WithinSessionEvaluation(paradigm=FakeImageryParadigm(),
+                                               datasets=[dataset],
+                                               additional_columns=['one', 'two'])
+
+    def tearDown(self):
+        path = self.eval.results.filepath
+        if os.path.isfile(path):
+            os.remove(path)
+
+    def test_fails_if_nothing_returned(self):
+        self.assertRaises(ValueError, self.eval.process, pipelines)
+        # TODO Add custom evaluation that actually returns additional info
+
+
 class Test_CrossSubj(Test_WithinSess):
 
     def setUp(self):


### PR DESCRIPTION
For instance when comparing different covariance matrix estimation techniques I maybe want to know the determinant/condition/something of each method in order to maybe explain a difference in the outcome, i.e. score.

So far this PR only allows the user to define additional columns that should be evaluated. To actually fill these with values, a custom Evaluation implementation is needed.