### PR TITLE
Delete outdated initialization

### DIFF
--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -89,8 +89,6 @@ class BaseDataset(metaclass=abc.ABCMeta):
         data: Dict
             dict containing the raw data
         """
-        data = []
-
         if subjects is None:
             subjects = self.subject_list
 


### PR DESCRIPTION
I noticed there was an initialization of `data` in `get_data` first as list, but finally `dict` is reinitialized to `data`, so I removed first one