### PR TITLE
Fix h5py>=3.0 Compatibility Issue

### DIFF
--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -192,4 +192,4 @@ class Results:
                 else:
                     # if dataset, check for subject
                     dset = pipe_grp[dataset.code]
-                    return (str(subject) in dset['id'][:, 0])
+                    return (str(subject).encode('utf-8') in dset['id'][:, 0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ mne >= 0.19
 pyriemann
 matplotlib >= 2.2
 seaborn >= 0.9.0
-h5py==2.10  # locked due to https://github.com/NeuroTechX/moabb/issues/122
+h5py
 pandas
 pyyaml
 coloredlogs


### PR DESCRIPTION
Solves https://github.com/NeuroTechX/moabb/issues/122.

From [h5py 3.0 changelog/breaking changes](https://docs.h5py.org/en/latest/whatsnew/3.0.html#breaking-changes-deprecations):

> Variable-length UTF-8 strings in datasets are now read as bytes objects instead of str by default, for consistency with other kinds of strings.