### PR TITLE
Restore basic logging

### DIFF
--- a/moabb/analysis/__init__.py
+++ b/moabb/analysis/__init__.py
@@ -11,7 +11,7 @@ from moabb.analysis.meta_analysis import (  # noqa: E501
 from moabb.analysis.results import Results  # noqa: F401
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def analyze(results, out_path, name="analysis", plot=False):

--- a/moabb/analysis/meta_analysis.py
+++ b/moabb/analysis/meta_analysis.py
@@ -6,7 +6,7 @@ import pandas as pd
 import scipy.stats as stats
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def collapse_session_scores(df):

--- a/moabb/analysis/plotting.py
+++ b/moabb/analysis/plotting.py
@@ -17,7 +17,7 @@ from moabb.analysis.meta_analysis import (
 PIPELINE_PALETTE = sea.color_palette("husl", 6)
 sea.set(font="serif", style="whitegrid", palette=PIPELINE_PALETTE, color_codes=False)
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def _simplify_names(x):

--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -17,7 +17,7 @@ from scipy.io import loadmat
 from .base import BaseDataset
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 FILES = []
 FILES.append("https://dataverse.harvard.edu/api/access/datafile/2499178")

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -5,7 +5,7 @@ import abc
 import logging
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class BaseDataset(metaclass=abc.ABCMeta):

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -14,7 +14,7 @@ from . import download as dl
 from .base import BaseDataset
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 GIGA_URL = "ftp://parrot.genomics.cn/gigadb/pub/10.5524/100001_101000/100295/mat_data/"
 
 

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -23,7 +23,7 @@ except ImportError:
 # and continues to have the problem, (Issue #254 on wfdb-python)
 # better to do pip install git+https://github.com/MIT-LCP/wfdb-python.git
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 # Alternate Download Location
 # MAMEM1_URL = 'https://ndownloader.figshare.com/articles/2068677/versions/5'

--- a/moabb/datasets/ssvep_nakanishi.py
+++ b/moabb/datasets/ssvep_nakanishi.py
@@ -14,7 +14,7 @@ from . import download as dl
 from .base import BaseDataset
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 NAKAHISHI_URL = "https://github.com/mnakanishi/12JFPM_SSVEP/raw/master/data/"
 

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -16,7 +16,7 @@ from . import download as dl
 from .base import BaseDataset
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 # WANG_URL = 'http://bci.med.tsinghua.edu.cn/upload/yijun/' # 403 error
 # WANG_URL = 'ftp://anonymous@sccn.ucsd.edu/pub/ssvep_benchmark_dataset/'

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -8,7 +8,7 @@ from moabb.datasets.base import BaseDataset
 from moabb.paradigms.base import BaseParadigm
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class BaseEvaluation(ABC):

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -12,7 +12,7 @@ from sklearn.preprocessing import LabelEncoder
 from moabb.evaluations.base import BaseEvaluation
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class WithinSessionEvaluation(BaseEvaluation):

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class BaseParadigm(metaclass=ABCMeta):

--- a/moabb/paradigms/motor_imagery.py
+++ b/moabb/paradigms/motor_imagery.py
@@ -8,7 +8,7 @@ from moabb.datasets.fake import FakeDataset
 from moabb.paradigms.base import BaseParadigm
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class BaseMotorImagery(BaseParadigm):

--- a/moabb/paradigms/p300.py
+++ b/moabb/paradigms/p300.py
@@ -12,7 +12,7 @@ from moabb.datasets.fake import FakeDataset
 from moabb.paradigms.base import BaseParadigm
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class BaseP300(BaseParadigm):

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -7,7 +7,7 @@ from moabb.datasets.fake import FakeDataset
 from moabb.paradigms.base import BaseParadigm
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class BaseSSVEP(BaseParadigm):

--- a/moabb/run.py
+++ b/moabb/run.py
@@ -20,7 +20,7 @@ from moabb.evaluations import WithinSessionEvaluation
 from moabb.pipelines.utils import create_pipeline_from_config
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def parser_init():

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -17,7 +17,7 @@ from moabb.paradigms import (
 )
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(logging.ERROR)
 
 

--- a/moabb/utils.py
+++ b/moabb/utils.py
@@ -1,9 +1,21 @@
+import logging
+
 import mne
 
 
-def set_log_level(verbose="info"):
+def set_log_level(level="INFO"):
     """Set lot level.
 
-    Set the general log level. level can be 'info', 'debug' or 'warning'
+    Set the general log level.
+    Use one of the levels supported by python logging, i.e.:
+        DEBUG, INFO, WARNING, ERROR, CRITICAL
     """
+    VALID_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    level = level.upper()
+    if level not in VALID_LEVELS:
+        raise ValueError(f"Invalid level {level}. Choose one of {VALID_LEVELS}.")
     mne.set_log_level(False)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(threadName)s %(name)s %(message)s",
+    )


### PR DESCRIPTION
Fixes #176 

This PR restores basic logging functionality using the python internal `logging` module instead of the removed coloredLogs.

Additionally, the basic logger will now indicate the basic name of the module from which it was logged instead of showing `root`. 