### PR TITLE
Remove unused dependencies - review examples and tutorials

### DIFF
--- a/examples/plot_cross_session_ssvep.py
+++ b/examples/plot_cross_session_ssvep.py
@@ -4,7 +4,7 @@ Cross Session SSVEP
 ===================
 
 This Example show how to perform a cross-session SSVEP analysis on the
-MAMEM dataset 1, using a CCA pipeline.
+MAMEM dataset 3, using a CCA pipeline.
 
 The cross session evaluation context will evaluate performance using a leave
 one session out cross-validation. For each session in the dataset, a model
@@ -22,7 +22,7 @@ import seaborn as sns
 from sklearn.pipeline import make_pipeline
 
 import moabb
-from moabb.datasets import MAMEM1
+from moabb.datasets import MAMEM3
 from moabb.evaluations import CrossSessionEvaluation
 from moabb.paradigms import SSVEP
 from moabb.pipelines import SSVEP_CCA
@@ -36,12 +36,12 @@ moabb.set_log_level("info")
 # Loading dataset
 # ---------------
 #
-# Load 2 subjects of MAMEM1 dataset, with 3 session each
+# Load 2 subjects of MAMEM3 dataset, with 3 session each
 
 subj = [1, 3]
 for s in subj:
-    MAMEM1()._get_single_subject_data(s)
-dataset = MAMEM1()
+    MAMEM3()._get_single_subject_data(s)
+dataset = MAMEM3()
 dataset.subject_list = subj
 
 ###############################################################################

--- a/examples/plot_cross_session_ssvep.py
+++ b/examples/plot_cross_session_ssvep.py
@@ -39,8 +39,6 @@ moabb.set_log_level("info")
 # Load 2 subjects of MAMEM3 dataset, with 3 session each
 
 subj = [1, 3]
-for s in subj:
-    MAMEM3()._get_single_subject_data(s)
 dataset = MAMEM3()
 dataset.subject_list = subj
 
@@ -71,14 +69,15 @@ pipeline["CCA"] = make_pipeline(SSVEP_CCA(interval=interval, freqs=freqs, n_harm
 # -------------------
 #
 # To get access to the EEG signals downloaded from the dataset, you could
-# use `dataset._get_single_subject_data(subject_id) to obtain the EEG under
-# an MNE format, stored in a dictionary of sessions and runs.
+# use `dataset.get_data(subjects=[subject_id])` to obtain the EEG under
+# MNE format, stored in a dictionary of sessions and runs.
 # Otherwise, `paradigm.get_data(dataset=dataset, subjects=[subject_id])`
 # allows to obtain the EEG data in scikit format, the labels and the meta
-# information.
+# information. In `paradigm.get_data`, the EEG are preprocessed according
+# to the paradigm requirement.
 
-sessions = dataset._get_single_subject_data(3)
-X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[3])
+# sessions = dataset.get_data(subjects=[3])
+# X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[3])
 
 ##############################################################################
 # Evaluation

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -45,8 +45,6 @@ moabb.set_log_level("info")
 # frequency.
 
 n_subject = 2
-for i in range(n_subject):
-    SSVEPExo()._get_single_subject_data(i + 1)
 dataset = SSVEPExo()
 dataset.subject_list = dataset.subject_list[:n_subject]
 interval = dataset.interval

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -171,8 +171,8 @@ class Results:
                     array = np.array(dset["data"])
                     ids = np.array(dset["id"])
                     df = pd.DataFrame(array, columns=dset.attrs["columns"])
-                    df["subject"] = ids[:, 0]
-                    df["session"] = ids[:, 1]
+                    df["subject"] = [s.decode() for s in ids[:, 0]]
+                    df["session"] = [s.decode() for s in ids[:, 1]]
                     df["channels"] = dset.attrs["channels"]
                     df["n_sessions"] = dset.attrs["n_sessions"]
                     df["dataset"] = dname

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -1,12 +1,14 @@
 import hashlib
-import inspect
 import os
+import os.path as osp
 import re
 from datetime import datetime
 
 import h5py
 import numpy as np
 import pandas as pd
+from mne import get_config, set_config
+from mne.datasets.utils import _get_path
 from sklearn.base import BaseEstimator
 
 
@@ -50,7 +52,6 @@ class Results:
         """
         class that will abstract result storage
         """
-        import moabb
         from moabb.evaluations.base import BaseEvaluation
         from moabb.paradigms.base import BaseParadigm
 
@@ -64,10 +65,14 @@ class Results:
             self.additional_columns = additional_columns
 
         if hdf5_path is None:
-            self.mod_dir = os.path.dirname(os.path.abspath(inspect.getsourcefile(moabb)))
+            if get_config("MOABB_RESULTS") is None:
+                set_config("MOABB_RESULTS", osp.join(osp.expanduser("~"), "mne_data"))
+            self.mod_dir = _get_path(None, "MOABB_RESULTS", "results")
+            # was previously stored in the moabb source file folder:
+            # self.mod_dir = osp.dirname(osp.abspath(inspect.getsourcefile(moabb)))
         else:
-            self.mod_dir = os.path.abspath(hdf5_path)
-        self.filepath = os.path.join(
+            self.mod_dir = osp.abspath(hdf5_path)
+        self.filepath = osp.join(
             self.mod_dir,
             "results",
             paradigm_class.__name__,
@@ -75,13 +80,13 @@ class Results:
             "results{}.hdf5".format("_" + suffix),
         )
 
-        os.makedirs(os.path.dirname(self.filepath), exist_ok=True)
+        os.makedirs(osp.dirname(self.filepath), exist_ok=True)
         self.filepath = self.filepath
 
-        if overwrite and os.path.isfile(self.filepath):
+        if overwrite and osp.isfile(self.filepath):
             os.remove(self.filepath)
 
-        if not os.path.isfile(self.filepath):
+        if not osp.isfile(self.filepath):
             with h5py.File(self.filepath, "w") as f:
                 f.attrs["create_time"] = np.string_(
                     "{:%Y-%m-%d, %H:%M}".format(datetime.now())

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -118,7 +118,6 @@ class Lee2019_MI(BaseDataset):
     def data_path(
         self, subject, path=None, force_update=False, update_path=None, verbose=None
     ):
-
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
 
@@ -127,8 +126,7 @@ class Lee2019_MI(BaseDataset):
             url = "{0}session{1}/s{2}/sess{1:02d}_subj{2:02d}_EEG_MI.mat".format(
                 Lee2019_URL, session, subject
             )
-
-            data_path = dl.data_path(
+            data_path = dl.data_dl(
                 url, "Lee2019_MI", path, force_update, update_path, verbose
             )
             subject_paths.append(data_path)

--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -134,8 +134,9 @@ class Weibo2014(BaseDataset):
         ch_names = [
             "Fp1", "Fpz", "Fp2", "AF3", "AF4", "F7", "F5", "F3", "F1", "Fz", "F2", "F4", "F6",
             "F8", "FT7", "FC5", "FC3", "FC1", "FCz", "FC2", "FC4", "FC6", "FT8", "T7", "C5",
-            "C3", "C1", "Pz", "P2", "P4", "P6", "P8", "PO7", "PO5", "PO3", "POz", "PO4", "PO6",
-            "PO8", "CB1", "O1", "Oz", "O2", "CB2", "VEO", "HEO",
+            "C3", "C1", "Cz", "C2", "C4", "C6", "T8", "TP7", "CP5", "CP3", "CP1", "CPz", "CP2",
+            "CP4", "CP6", "TP8", "P7", "P5", "P3", "P1", "Pz", "P2", "P4", "P6", "P8", "PO7",
+            "PO5", "PO3", "POz", "PO4", "PO6", "PO8", "CB1", "O1", "Oz", "O2", "CB2", "VEO", "HEO",
         ]
         # fmt: on
 

--- a/moabb/datasets/Zhou2016.py
+++ b/moabb/datasets/Zhou2016.py
@@ -11,7 +11,7 @@ import numpy as np
 from mne.channels import make_standard_montage
 from mne.datasets.utils import _do_path_update, _get_path
 from mne.io import read_raw_cnt
-from mne.utils import _fetch_file
+from pooch import retrieve
 
 from .base import BaseDataset
 
@@ -22,9 +22,7 @@ DATA_PATH = "https://ndownloader.figshare.com/files/3662952"
 def local_data_path(base_path, subject):
     if not os.path.isdir(os.path.join(base_path, "subject_{}".format(subject))):
         if not os.path.isdir(os.path.join(base_path, "data")):
-            _fetch_file(
-                DATA_PATH, os.path.join(base_path, "data.zip"), print_destination=False
-            )
+            retrieve(DATA_PATH, None, fname="data.zip", path=base_path)
             with z.ZipFile(os.path.join(base_path, "data.zip"), "r") as f:
                 f.extractall(base_path)
             os.remove(os.path.join(base_path, "data.zip"))

--- a/moabb/datasets/alex_mi.py
+++ b/moabb/datasets/alex_mi.py
@@ -59,4 +59,4 @@ class AlexMI(BaseDataset):
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
         url = "{:s}subject{:d}.raw.fif".format(ALEX_URL, subject)
-        return dl.data_path(url, "ALEXEEG", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "ALEXEEG", path, force_update, update_path, verbose)

--- a/moabb/datasets/bnci.py
+++ b/moabb/datasets/bnci.py
@@ -18,7 +18,7 @@ BBCI_URL = "http://doc.ml.tu-berlin.de/bbci/"
 
 
 def data_path(url, path=None, force_update=False, update_path=None, verbose=None):
-    return [dl.data_path(url, "BNCI", path, force_update, update_path, verbose)]
+    return [dl.data_dl(url, "BNCI", path, force_update, update_path, verbose)]
 
 
 @verbose

--- a/moabb/datasets/braininvaders.py
+++ b/moabb/datasets/braininvaders.py
@@ -155,7 +155,7 @@ class bi2013a(BaseDataset):
 
         # check if has the .zip
         url = "{:s}subject{:d}.zip".format(BI2013a_URL, subject)
-        path_zip = dl.data_path(url, "BRAININVADERS")
+        path_zip = dl.data_dl(url, "BRAININVADERS")
         path_folder = path_zip.strip("subject{:d}.zip".format(subject))
 
         # check if has to unzip

--- a/moabb/datasets/download.py
+++ b/moabb/datasets/download.py
@@ -15,10 +15,10 @@ from requests.exceptions import HTTPError
 
 @verbose
 def data_path(url, sign, path=None, force_update=False, update_path=True, verbose=None):
-    """Get path to local copy of given dataset URL.
+    """Get path to local copy of given dataset URL. **Deprecated**
 
     This is a low-level function useful for getting a local copy of a
-    remote dataset
+    remote dataset. It is deprecated in favor of data_dl.
 
     Parameters
     ----------

--- a/moabb/datasets/download.py
+++ b/moabb/datasets/download.py
@@ -1,13 +1,15 @@
 # Author: Alexandre Barachant <alexandre.barachant@gmail.com>
 # License: BSD Style.
 
+import json
 import os
 import os.path as osp
-from os import path as op
 
+import requests
 from mne import get_config, set_config
 from mne.datasets.utils import _do_path_update, _get_path
 from mne.utils import _fetch_file, _url_to_local_path, verbose
+from requests.exceptions import HTTPError
 
 
 @verbose
@@ -51,15 +53,131 @@ def data_path(url, sign, path=None, force_update=False, update_path=True, verbos
     if get_config(key) is None:
         set_config(key, osp.join(osp.expanduser("~"), "mne_data"))
     path = _get_path(path, key, sign)
-    destination = _url_to_local_path(url, op.join(path, key_dest))
+    destination = _url_to_local_path(url, osp.join(path, key_dest))
     # Fetch the file
-    if not op.isfile(destination) or force_update:
-        if op.isfile(destination):
+    if not osp.isfile(destination) or force_update:
+        if osp.isfile(destination):
             os.remove(destination)
-        if not op.isdir(op.dirname(destination)):
-            os.makedirs(op.dirname(destination))
+        if not osp.isdir(osp.dirname(destination)):
+            os.makedirs(osp.dirname(destination))
         _fetch_file(url, destination, print_destination=False)
 
     # Offer to update the path
     _do_path_update(path, update_path, key, sign)
     return destination
+
+
+# This function is from https://github.com/cognoma/figshare (BSD-3-Clause)
+def issue_request(method, url, headers, data=None, binary=False):
+    """Wrapper for HTTP request
+
+    Parameters
+    ----------
+    method : str
+        HTTP method. One of GET, PUT, POST or DELETE
+    url : str
+        URL for the request
+    headers: dict
+        HTTP header information
+    data: dict
+        Figshare article data
+    binary: bool
+        Whether data is binary or not
+
+    Returns
+    -------
+    response_data: dict
+        JSON response for the request returned as python dict
+    """
+    if data is not None and not binary:
+        data = json.dumps(data)
+
+    response = requests.request(method, url, headers=headers, data=data)
+
+    try:
+        response.raise_for_status()
+        try:
+            response_data = json.loads(response.text)
+        except ValueError:
+            response_data = response.content
+    except HTTPError as error:
+        print("Caught an HTTPError: {}".format(error))
+        print("Body:\n", response.text)
+        raise
+
+    return response_data
+
+
+def fs_get_file_list(article_id, version=None):
+    """List all the files associated with a given article.
+
+    Parameters
+    ----------
+    article_id : str or int
+        Figshare article ID
+    version : str or id, default is None
+        Figshare article version. If None, selects the most recent version.
+
+    Returns
+    -------
+    response : dict
+        HTTP request response as a python dict
+    """
+    fsurl = "https://api.figshare.com/v2"
+    if version is None:
+        url = fsurl + "/articles/{}/files".format(article_id)
+        headers = {"Content-Type": "application/json"}
+        response = issue_request("GET", url, headers=headers)
+        return response
+    else:
+        url = fsurl + "/articles/{}/versions/{}".format(article_id, version)
+        request = issue_request("GET", url, headers=headers)
+        return request["files"]
+
+
+def fs_get_file_hash(filelist):
+    """Returns a dict associating figshare file id to MD5 hash
+
+    Parameters
+    ----------
+    filelist : list of dict
+        HTTP request response from fs_get_file_list
+
+    Returns
+    -------
+    response : dict
+        keys are file_id and values are md5 hash
+    """
+    return {str(f["id"]): "md5:" + f["supplied_md5"] for f in filelist}
+
+
+def fs_get_file_id(filelist):
+    """Returns a dict associating filename to figshare file id
+
+    Parameters
+    ----------
+    filelist : list of dict
+        HTTP request response from fs_get_file_list
+
+    Returns
+    -------
+    response : dict
+        keys are filname and values are file_id
+    """
+    return {f["name"]: str(f["id"]) for f in filelist}
+
+
+def fs_get_file_name(filelist):
+    """Returns a dict associating figshare file id to filename
+
+    Parameters
+    ----------
+    filelist : list of dict
+        HTTP request response from fs_get_file_list
+
+    Returns
+    -------
+    response : dict
+        keys are file_id and values are file name
+    """
+    return {str(f["id"]): f["name"] for f in filelist}

--- a/moabb/datasets/download.py
+++ b/moabb/datasets/download.py
@@ -74,7 +74,6 @@ def data_dl(url, sign, path=None, force_update=False, update_path=True, verbose=
 
     This function should replace data_path as the MNE will not support the download
     of dataset anymore. This version is using Pooch.
-    Beware that now, all the file are stored directly in
 
     Parameters
     ----------
@@ -132,7 +131,7 @@ def data_dl(url, sign, path=None, force_update=False, update_path=True, verbose=
 
 
 # This function is from https://github.com/cognoma/figshare (BSD-3-Clause)
-def issue_request(method, url, headers, data=None, binary=False):
+def fs_issue_request(method, url, headers, data=None, binary=False):
     """Wrapper for HTTP request
 
     Parameters
@@ -191,11 +190,11 @@ def fs_get_file_list(article_id, version=None):
     if version is None:
         url = fsurl + "/articles/{}/files".format(article_id)
         headers = {"Content-Type": "application/json"}
-        response = issue_request("GET", url, headers=headers)
+        response = fs_issue_request("GET", url, headers=headers)
         return response
     else:
         url = fsurl + "/articles/{}/versions/{}".format(article_id, version)
-        request = issue_request("GET", url, headers=headers)
+        request = fs_issue_request("GET", url, headers=headers)
         return request["files"]
 
 

--- a/moabb/datasets/epfl.py
+++ b/moabb/datasets/epfl.py
@@ -168,7 +168,7 @@ class EPFLP300(BaseDataset):
 
         # check if has the .zip
         url = "{:s}subject{:d}.zip".format(EPFLP300_URL, subject)
-        path_zip = dl.data_path(url, "EPFLP300")
+        path_zip = dl.data_dl(url, "EPFLP300")
         path_folder = path_zip.strip("subject{:d}.zip".format(subject))
 
         # check if has to unzip

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -127,4 +127,4 @@ class Cho2017(BaseDataset):
             raise (ValueError("Invalid subject number"))
 
         url = "{:s}s{:02d}.mat".format(GIGA_URL, subject)
-        return dl.data_path(url, "GIGADB", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "GIGADB", path, force_update, update_path, verbose)

--- a/moabb/datasets/mpi_mi.py
+++ b/moabb/datasets/mpi_mi.py
@@ -87,10 +87,8 @@ class MunichMI(BaseDataset):
 
         # download .set
         _set = "{:s}subject{:d}.set".format(DOWNLOAD_URL, subject)
-        set_local = dl.data_path(
-            _set, "MUNICHMI", path, force_update, update_path, verbose
-        )
+        set_local = dl.data_dl(_set, "MUNICHMI", path, force_update, update_path, verbose)
         # download .fdt
         _fdt = "{:s}subject{:d}.fdt".format(DOWNLOAD_URL, subject)
-        dl.data_path(_fdt, "MUNICHMI", path, force_update, update_path, verbose)
+        dl.data_dl(_fdt, "MUNICHMI", path, force_update, update_path, verbose)
         return set_local

--- a/moabb/datasets/neiry.py
+++ b/moabb/datasets/neiry.py
@@ -176,7 +176,7 @@ class DemonsP300(BaseDataset):
         if subject not in self.subject_list:
             raise ValueError("Invalid subject number")
 
-        zip_path = Path(dl.data_path(self.url, self._ds_folder_name))
+        zip_path = Path(dl.data_dl(self.url, self._ds_folder_name))
         self.path = zip_path.parent / self._ds_folder_name / zip_path.stem
 
         if not self.path.exists():

--- a/moabb/datasets/schirrmeister2017.py
+++ b/moabb/datasets/schirrmeister2017.py
@@ -78,7 +78,7 @@ class Schirrmeister2017(BaseDataset):
             return "/".join([GIN_URL, prefix, "{:d}.mat".format(subject)])
 
         return [
-            dl.data_path(
+            dl.data_dl(
                 _url(t), "SCHIRRMEISTER2017", path, force_update, update_path, verbose
             )
             for t in ["train", "test"]

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -83,6 +83,6 @@ class SSVEPExo(BaseDataset):
             url = "{:s}subject{:02d}_run{:d}_raw.fif".format(
                 SSVEPEXO_URL, subject, run + 1
             )
-            p = dl.data_path(url, "SSVEPEXO", path, force_update, update_path, verbose)
+            p = dl.data_dl(url, "SSVEPEXO", path, force_update, update_path, verbose)
             paths.append(p)
         return paths

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -19,17 +19,16 @@ from .download import fs_get_file_hash, fs_get_file_id, fs_get_file_list, fs_get
 
 log = logging.getLogger(__name__)
 
-# Alternate Download Location
-# MAMEM1_URL = 'https://ndownloader.figshare.com/articles/2068677/versions/5'
-# foldername = '2068677'
-# MAMEM2_URL = 'https://ndownloader.figshare.com/articles/3153409/versions/2'
-# MAMEM3_URL = 'https://ndownloader.figshare.com/articles/3413851/versions/1'
+MAMEM_URL = "https://ndownloader.figshare.com/files/"
+# Specific release
+# MAMEM1_URL = 'https://ndownloader.figshare.com/articles/2068677/versions/6'
+# MAMEM2_URL = 'https://ndownloader.figshare.com/articles/3153409/versions/4'
+# MAMEM3_URL = 'https://ndownloader.figshare.com/articles/3413851/versions/3'
 
+# Alternate Download Location
 # MAMEM1_URL = "https://archive.physionet.org/physiobank/database/mssvepdb/dataset1/"
 # MAMEM2_URL = "https://archive.physionet.org/physiobank/database/mssvepdb/dataset2/"
 # MAMEM3_URL = "https://archive.physionet.org/physiobank/database/mssvepdb/dataset3/"
-
-MAMEM_URL = "https://ndownloader.figshare.com/files/"
 
 
 def mamem_event(eeg, dins, labels=None):

--- a/moabb/datasets/ssvep_nakanishi.py
+++ b/moabb/datasets/ssvep_nakanishi.py
@@ -97,4 +97,4 @@ class Nakanishi2015(BaseDataset):
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
         url = "{:s}s{:d}.mat".format(NAKAHISHI_URL, subject)
-        return dl.data_path(url, "NAKANISHI", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "NAKANISHI", path, force_update, update_path, verbose)

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -19,8 +19,8 @@ from .base import BaseDataset
 log = logging.getLogger(__name__)
 
 # WANG_URL = 'http://bci.med.tsinghua.edu.cn/upload/yijun/' # 403 error
-# WANG_URL = 'ftp://anonymous@sccn.ucsd.edu/pub/ssvep_benchmark_dataset/'
-WANG_URL = "http://www.thubci.com/uploads/down/"
+WANG_URL = "ftp://anonymous@sccn.ucsd.edu/pub/ssvep_benchmark_dataset/"
+# WANG_URL = "http://www.thubci.com/uploads/down/"
 
 
 class Wang2016(BaseDataset):
@@ -150,4 +150,4 @@ class Wang2016(BaseDataset):
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
         url = "{:s}s{:d}.rar".format(WANG_URL, subject)
-        return dl.data_path(url, "WANG", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "WANG", path, force_update, update_path, verbose)

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -3,13 +3,11 @@ SSVEP Wang dataset.
 """
 
 import logging
-from os.path import dirname
 
 import numpy as np
 from mne import create_info
 from mne.channels import make_standard_montage
 from mne.io import RawArray
-from pyunpack import Archive
 from scipy.io import loadmat
 
 from . import download as dl
@@ -19,7 +17,7 @@ from .base import BaseDataset
 log = logging.getLogger(__name__)
 
 # WANG_URL = 'http://bci.med.tsinghua.edu.cn/upload/yijun/' # 403 error
-WANG_URL = "ftp://anonymous@sccn.ucsd.edu/pub/ssvep_benchmark_dataset/"
+WANG_URL = "ftp://sccn.ucsd.edu/pub/ssvep_benchmark_dataset/"
 # WANG_URL = "http://www.thubci.com/uploads/down/"
 
 
@@ -117,7 +115,6 @@ class Wang2016(BaseDataset):
         n_classes = len(self.event_id)
 
         fname = self.data_path(subject)
-        Archive(fname).extractall(dirname(fname))
         mat = loadmat(fname[:-4])
 
         data = np.transpose(mat["data"], axes=(2, 3, 0, 1))
@@ -149,5 +146,5 @@ class Wang2016(BaseDataset):
     ):
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
-        url = "{:s}s{:d}.rar".format(WANG_URL, subject)
+        url = "{:s}S{:d}.mat".format(WANG_URL, subject)
         return dl.data_dl(url, "WANG", path, force_update, update_path, verbose)

--- a/moabb/datasets/upper_limb.py
+++ b/moabb/datasets/upper_limb.py
@@ -149,9 +149,7 @@ class Ofner2017(BaseDataset):
                 url = (
                     f"{UPPER_LIMB_URL}motor{session}_subject{subject}" + f"_run{run}.gdf"
                 )
-                p = dl.data_path(
-                    url, "UPPERLIMB", path, force_update, update_path, verbose
-                )
+                p = dl.data_dl(url, "UPPERLIMB", path, force_update, update_path, verbose)
                 paths.append(p)
 
         return paths

--- a/moabb/tests/download.py
+++ b/moabb/tests/download.py
@@ -15,6 +15,14 @@ Tests to ensure that datasets download correctly
 # from moabb.datasets.Zhou2016 import Zhou2016
 # from moabb.datasets.ssvep_exo import SSVEPExo
 # from moabb.datasets.braininvaders import bi2013a
+# from moabb.datasets.epfl import EPFLP300
+# from moabb.datasets.Lee2019 import Lee2019_MI
+# from moabb.datasets.neiry import DemonsP300
+# from moabb.datasets.physionet_mi import PhysionetMI
+# from moabb.datasets.ssvep_mamem import MAMEM1, MAMEM2, MAMEM3
+# from moabb.datasets.ssvep_nakanishi import Nakanishi2015
+# from moabb.datasets.ssvep_wang import Wang2016
+
 import unittest
 
 import mne
@@ -59,28 +67,14 @@ class Test_Downloads(unittest.TestCase):
     # def test_cho2017(self):
     #     self.run_dataset(Cho2017)
 
-    # def test_bnci_1401(self):
+    # def test_bnci(self):
     #     self.run_dataset(BNCI2014001)
-
-    # def test_bnci_1402(self):
     #     self.run_dataset(BNCI2014002)
-
-    # def test_bnci_1404(self):
     #     self.run_dataset(BNCI2014004)
-
-    # def test_bnci_1408(self):
     #     self.run_dataset(BNCI2014008)
-
-    # def test_bnci_1409(self):
     #     self.run_dataset(BNCI2014009)
-
-    # def test_bnci_1501(self):
     #     self.run_dataset(BNCI2015001)
-
-    # def test_bnci_1503(self):
     #     self.run_dataset(BNCI2015003)
-
-    # def test_bnci_1504(self):
     #     self.run_dataset(BNCI2015004)
 
     # def test_alexmi(self):
@@ -113,6 +107,29 @@ class Test_Downloads(unittest.TestCase):
 
     # def test_bi2013a(self):
     #     self.run_dataset(bi2013a)
+
+    # def test_epflp300(self):
+    #     self.run_dataset(EPFLP300)
+
+    # def test_lee2019_MI(self):
+    #     self.run_dataset(Lee2019_MI)
+
+    # def test_demonsp300(self):
+    #     self.run_dataset(DemonsP300)
+
+    # def test_physionetmi(self):
+    #     self.run_dataset(PhysionetMI)
+
+    # def test_mamem(self):
+    #     self.run_dataset(MAMEM1)
+    #     self.run_dataset(MAMEM2)
+    #     self.run_dataset(MAMEM3)
+
+    # def test_nakanishi2015(self):
+    #     self.run_dataset(Nakanishi2015)
+
+    # def test_wang2016(self):
+    #     self.run_dataset(Wang2016)
 
 
 if __name__ == "__main__":

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -1,4 +1,5 @@
 import os
+import os.path as osp
 import unittest
 from collections import OrderedDict
 
@@ -16,6 +17,7 @@ from moabb.paradigms.motor_imagery import FakeImageryParadigm
 pipelines = OrderedDict()
 pipelines["C"] = make_pipeline(Covariances("oas"), CSP(8), LDA())
 dataset = FakeDataset(["left_hand", "right_hand"], n_subjects=2)
+os.makedirs(osp.join(osp.expanduser("~"), "mne_data"))
 
 
 class Test_WithinSess(unittest.TestCase):

--- a/poetry.lock
+++ b/poetry.lock
@@ -93,22 +93,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "easyprocess"
-version = "0.3"
-description = "Easy to use Python subprocess interface."
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "entrypoint2"
-version = "0.2.4"
-description = "easy to use command-line interface for python modules"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "filelock"
 version = "3.0.12"
 description = "A platform independent file lock."
@@ -336,14 +320,6 @@ pytz = ">=2017.2"
 test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
-name = "patool"
-version = "1.12"
-description = "portable archive file manager"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "pillow"
 version = "8.2.0"
 description = "Python Imaging Library (Fork)"
@@ -431,18 +407,6 @@ description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
 python-versions = "*"
-
-[[package]]
-name = "pyunpack"
-version = "0.2.2"
-description = "unpack archive files"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-easyprocess = "*"
-entrypoint2 = "*"
 
 [[package]]
 name = "pyyaml"
@@ -739,7 +703,7 @@ external = ["tdlda"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "9d37615a89aa78bd84e575f99ad5f62b65ee79bab88c98a20743e2817f35ecd9"
+content-hash = "0d1367177b8ddf1957ecbadbb302e669d9076dea7d2a9fa84c7e3e559fe44047"
 
 [metadata.files]
 alabaster = [
@@ -785,14 +749,6 @@ distlib = [
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
-]
-easyprocess = [
-    {file = "EasyProcess-0.3-py2.py3-none-any.whl", hash = "sha256:fca26794d3ced044d0471bd4ed767d5c287391d8a1c5e9d106fc59478b732543"},
-    {file = "EasyProcess-0.3.tar.gz", hash = "sha256:fb948daac01f64c1e49750752711253614846c6fc7e5692a718a7408f2ffb984"},
-]
-entrypoint2 = [
-    {file = "entrypoint2-0.2.4-py3-none-any.whl", hash = "sha256:47a64379a9c5d9f0f3a3857a79f99c21809ce8d554704cb565a7c977b7d67ff7"},
-    {file = "entrypoint2-0.2.4.tar.gz", hash = "sha256:4770c3afcf3865c606a6e5f7cfcc5c59212f555fcee9b2540270399149c1dde3"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
@@ -1024,10 +980,6 @@ pandas = [
     {file = "pandas-1.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782"},
     {file = "pandas-1.1.5.tar.gz", hash = "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"},
 ]
-patool = [
-    {file = "patool-1.12-py2.py3-none-any.whl", hash = "sha256:3f642549c9a78f5b8bef1af92df385b521d360520d1f34e4dba3fd1dee2a21bc"},
-    {file = "patool-1.12.tar.gz", hash = "sha256:e3180cf8bfe13bedbcf6f5628452fca0c2c84a3b5ae8c2d3f55720ea04cb1097"},
-]
 pillow = [
     {file = "Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9"},
     {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b"},
@@ -1090,10 +1042,6 @@ python-dateutil = [
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
-]
-pyunpack = [
-    {file = "pyunpack-0.2.2-py2.py3-none-any.whl", hash = "sha256:c5754ff2178951aacd554df7d8a128cb6fb2513a8fa46a7f184920faf7411e6a"},
-    {file = "pyunpack-0.2.2.tar.gz", hash = "sha256:8db8d350e3329ad06fa0aa00aa28295f5babf8c1249ce26292c026e875ba2436"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -10,21 +10,13 @@ python-versions = "*"
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "argparse"
-version = "1.4.0"
-description = "Python command-line parsing library"
 category = "main"
 optional = false
 python-versions = "*"
 
 [[package]]
 name = "babel"
-version = "2.9.0"
+version = "2.9.1"
 description = "Internationalization utilities"
 category = "dev"
 optional = false
@@ -110,14 +102,11 @@ python-versions = "*"
 
 [[package]]
 name = "entrypoint2"
-version = "0.2.3"
+version = "0.2.4"
 description = "easy to use command-line interface for python modules"
 category = "main"
 optional = false
 python-versions = "*"
-
-[package.dependencies]
-argparse = "*"
 
 [[package]]
 name = "filelock"
@@ -146,7 +135,7 @@ numpy = [
 
 [[package]]
 name = "identify"
-version = "2.2.0"
+version = "2.2.4"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -157,11 +146,11 @@ license = ["editdistance-s"]
 
 [[package]]
 name = "idna"
-version = "3.1"
+version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "imagesize"
@@ -173,7 +162,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.7.3"
+version = "4.0.1"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -185,7 +174,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -278,19 +267,19 @@ python-versions = "*"
 
 [[package]]
 name = "mne"
-version = "0.22.0"
+version = "0.23.0"
 description = "MNE python project for MEG and EEG data analysis."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-numpy = ">=1.11.3"
-scipy = ">=0.17.1"
+numpy = ">=1.15.4"
+scipy = ">=1.1.0"
 
 [[package]]
 name = "nodeenv"
-version = "1.5.0"
+version = "1.6.0"
 description = "Node.js virtual environment builder"
 category = "dev"
 optional = false
@@ -323,7 +312,7 @@ testing = ["matplotlib", "pytest", "pytest-cov"]
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -356,15 +345,28 @@ python-versions = "*"
 
 [[package]]
 name = "pillow"
-version = "8.1.2"
+version = "8.2.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "pooch"
+version = "1.3.0"
+description = "Pooch manages your Python library's sample data files: it automatically downloads and stores them in a local directory, with support for versioning and corruption checks."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+appdirs = "*"
+packaging = "*"
+requests = "*"
+
+[[package]]
 name = "pre-commit"
-version = "2.11.1"
+version = "2.12.1"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -382,7 +384,7 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "pygments"
-version = "2.8.1"
+version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
@@ -452,14 +454,20 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "requests"
-version = "2.15.1"
+version = "2.25.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-security = ["cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)"]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
@@ -506,7 +514,7 @@ scipy = ">=1.0"
 
 [[package]]
 name = "six"
-version = "1.15.0"
+version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
@@ -522,7 +530,7 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "3.5.3"
+version = "3.5.4"
 description = "Python documentation generator"
 category = "dev"
 optional = false
@@ -532,7 +540,7 @@ python-versions = ">=3.5"
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
 colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.12"
+docutils = ">=0.12,<0.17"
 imagesize = "*"
 Jinja2 = ">=2.3"
 packaging = "*"
@@ -674,7 +682,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
+version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "dev"
 optional = false
@@ -695,7 +703,7 @@ brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.4.3"
+version = "20.4.6"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -712,36 +720,6 @@ six = ">=1.9.0,<2"
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
-
-[[package]]
-name = "wfdb"
-version = "3.3.0"
-description = "The WFDB Python Toolbox"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-certifi = ">=2016.8.2"
-chardet = ">=3.0.0"
-cycler = ">=0.10.0"
-idna = ">=2.2"
-joblib = ">=0.11"
-kiwisolver = ">=1.1.0"
-matplotlib = ">=2.0.0"
-numpy = ">=1.10.1"
-pandas = ">=0.17.0"
-pyparsing = ">=2.0.4"
-python-dateutil = ">=2.4.2"
-pytz = ">=2017.2"
-requests = ">=2.8.1"
-scikit-learn = ">=0.18"
-scipy = ">=0.17.0"
-threadpoolctl = ">=1.0.0"
-urllib3 = ">=1.22"
-
-[package.extras]
-test = ["nose (>=1.3.7)"]
 
 [[package]]
 name = "zipp"
@@ -761,7 +739,7 @@ external = ["tdlda"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "eb3006beacc8c7094206d98e3a1f6b57d799a62aa081fac9205521d41cffc4a4"
+content-hash = "d65b77a5783c103075a1e5e44f1c6f4ff10415b5bd74b219f03ec9546b7d6ad7"
 
 [metadata.files]
 alabaster = [
@@ -772,13 +750,9 @@ appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
-argparse = [
-    {file = "argparse-1.4.0-py2.py3-none-any.whl", hash = "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314"},
-    {file = "argparse-1.4.0.tar.gz", hash = "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4"},
-]
 babel = [
-    {file = "Babel-2.9.0-py2.py3-none-any.whl", hash = "sha256:9d35c22fcc79893c3ecc85ac4a56cde1ecf3f19c540bba0922308a6c06ca6fa5"},
-    {file = "Babel-2.9.0.tar.gz", hash = "sha256:da031ab54472314f210b0adcff1588ee5d1d1d0ba4dbd07b94dba82bde791e05"},
+    {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
+    {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
 ]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
@@ -817,8 +791,8 @@ easyprocess = [
     {file = "EasyProcess-0.3.tar.gz", hash = "sha256:fb948daac01f64c1e49750752711253614846c6fc7e5692a718a7408f2ffb984"},
 ]
 entrypoint2 = [
-    {file = "entrypoint2-0.2.3-py2.py3-none-any.whl", hash = "sha256:26424450650848b6139d8313e2f8828660e150b93685416e40bdcaa81b864748"},
-    {file = "entrypoint2-0.2.3.tar.gz", hash = "sha256:4ac1a8f08477d93282c422faa90875ce5edaa941e1f3fd410b95cb31d9f473a7"},
+    {file = "entrypoint2-0.2.4-py3-none-any.whl", hash = "sha256:47a64379a9c5d9f0f3a3857a79f99c21809ce8d554704cb565a7c977b7d67ff7"},
+    {file = "entrypoint2-0.2.4.tar.gz", hash = "sha256:4770c3afcf3865c606a6e5f7cfcc5c59212f555fcee9b2540270399149c1dde3"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
@@ -840,20 +814,20 @@ h5py = [
     {file = "h5py-3.1.0.tar.gz", hash = "sha256:1e2516f190652beedcb8c7acfa1c6fa92d99b42331cbef5e5c7ec2d65b0fc3c2"},
 ]
 identify = [
-    {file = "identify-2.2.0-py2.py3-none-any.whl", hash = "sha256:39c0b110c9d0cd2391b6c38cd0ff679ee4b4e98f8db8b06c5d9d9e502711a1e1"},
-    {file = "identify-2.2.0.tar.gz", hash = "sha256:efbf090a619255bc31c4fbba709e2805f7d30913fd4854ad84ace52bd276e2f6"},
+    {file = "identify-2.2.4-py2.py3-none-any.whl", hash = "sha256:ad9f3fa0c2316618dc4d840f627d474ab6de106392a4f00221820200f490f5a8"},
+    {file = "identify-2.2.4.tar.gz", hash = "sha256:9bcc312d4e2fa96c7abebcdfb1119563b511b5e3985ac52f60d9116277865b2e"},
 ]
 idna = [
-    {file = "idna-3.1-py3-none-any.whl", hash = "sha256:5205d03e7bcbb919cc9c19885f9920d622ca52448306f2377daede5cf3faac16"},
-    {file = "idna-3.1.tar.gz", hash = "sha256:c5b02147e01ea9920e6b0a3f1f7bb833612d507592c837a6c49552768f4054e1"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 imagesize = [
     {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.7.3-py3-none-any.whl", hash = "sha256:b74159469b464a99cb8cc3e21973e4d96e05d3024d337313fedb618a6e86e6f4"},
-    {file = "importlib_metadata-3.7.3.tar.gz", hash = "sha256:742add720a20d0467df2f444ae41704000f50e1234f46174b51f9c6031a1bd71"},
+    {file = "importlib_metadata-4.0.1-py3-none-any.whl", hash = "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"},
+    {file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.1.2-py3-none-any.whl", hash = "sha256:ebab3efe74d83b04d6bf5cd9a17f0c5c93e60fb60f30c90f56265fce4682a469"},
@@ -991,12 +965,12 @@ mistune = [
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
 ]
 mne = [
-    {file = "mne-0.22.0-py3-none-any.whl", hash = "sha256:9da4050e7455ab577fbf1aaf4b745722e5f9ddaf3144ce35346a6b782d3b9f85"},
-    {file = "mne-0.22.0.tar.gz", hash = "sha256:63cf8a7985a350ff2b4dc64d1071044eceaca30f1a8ff51a2dc0552d122326a5"},
+    {file = "mne-0.23.0-py3-none-any.whl", hash = "sha256:49a9763d394bdb8c66c919d54f132c207b6dad2a9c030000e5443826642ea193"},
+    {file = "mne-0.23.0.tar.gz", hash = "sha256:159cac597f0243519c85ef851ce302c7edd04189648ce659ce537e129d64c5c1"},
 ]
 nodeenv = [
-    {file = "nodeenv-1.5.0-py2.py3-none-any.whl", hash = "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9"},
-    {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
+    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
+    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 numpy = [
     {file = "numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff"},
@@ -1073,47 +1047,51 @@ patool = [
     {file = "patool-1.12.tar.gz", hash = "sha256:e3180cf8bfe13bedbcf6f5628452fca0c2c84a3b5ae8c2d3f55720ea04cb1097"},
 ]
 pillow = [
-    {file = "Pillow-8.1.2-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0"},
-    {file = "Pillow-8.1.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:f91b50ad88048d795c0ad004abbe1390aa1882073b1dca10bfd55d0b8cf18ec5"},
-    {file = "Pillow-8.1.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8"},
-    {file = "Pillow-8.1.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34"},
-    {file = "Pillow-8.1.2-cp36-cp36m-win32.whl", hash = "sha256:72027ebf682abc9bafd93b43edc44279f641e8996fb2945104471419113cfc71"},
-    {file = "Pillow-8.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341"},
-    {file = "Pillow-8.1.2-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:90882c6f084ef68b71bba190209a734bf90abb82ab5e8f64444c71d5974008c6"},
-    {file = "Pillow-8.1.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:89e4c757a91b8c55d97c91fa09c69b3677c227b942fa749e9a66eef602f59c28"},
-    {file = "Pillow-8.1.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8c4e32218c764bc27fe49b7328195579581aa419920edcc321c4cb877c65258d"},
-    {file = "Pillow-8.1.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:a01da2c266d9868c4f91a9c6faf47a251f23b9a862dce81d2ff583135206f5be"},
-    {file = "Pillow-8.1.2-cp37-cp37m-win32.whl", hash = "sha256:30d33a1a6400132e6f521640dd3f64578ac9bfb79a619416d7e8802b4ce1dd55"},
-    {file = "Pillow-8.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:71b01ee69e7df527439d7752a2ce8fb89e19a32df484a308eca3e81f673d3a03"},
-    {file = "Pillow-8.1.2-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:5a2d957eb4aba9d48170b8fe6538ec1fbc2119ffe6373782c03d8acad3323f2e"},
-    {file = "Pillow-8.1.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:87f42c976f91ca2fc21a3293e25bd3cd895918597db1b95b93cbd949f7d019ce"},
-    {file = "Pillow-8.1.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:15306d71a1e96d7e271fd2a0737038b5a92ca2978d2e38b6ced7966583e3d5af"},
-    {file = "Pillow-8.1.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:71f31ee4df3d5e0b366dd362007740106d3210fb6a56ec4b581a5324ba254f06"},
-    {file = "Pillow-8.1.2-cp38-cp38-win32.whl", hash = "sha256:98afcac3205d31ab6a10c5006b0cf040d0026a68ec051edd3517b776c1d78b09"},
-    {file = "Pillow-8.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:328240f7dddf77783e72d5ed79899a6b48bc6681f8d1f6001f55933cb4905060"},
-    {file = "Pillow-8.1.2-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:bead24c0ae3f1f6afcb915a057943ccf65fc755d11a1410a909c1fefb6c06ad1"},
-    {file = "Pillow-8.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:81b3716cc9744ffdf76b39afb6247eae754186838cedad0b0ac63b2571253fe6"},
-    {file = "Pillow-8.1.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:63cd413ac52ee3f67057223d363f4f82ce966e64906aea046daf46695e3c8238"},
-    {file = "Pillow-8.1.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:8565355a29655b28fdc2c666fd9a3890fe5edc6639d128814fafecfae2d70910"},
-    {file = "Pillow-8.1.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1940fc4d361f9cc7e558d6f56ff38d7351b53052fd7911f4b60cd7bc091ea3b1"},
-    {file = "Pillow-8.1.2-cp39-cp39-win32.whl", hash = "sha256:46c2bcf8e1e75d154e78417b3e3c64e96def738c2a25435e74909e127a8cba5e"},
-    {file = "Pillow-8.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:aeab4cd016e11e7aa5cfc49dcff8e51561fa64818a0be86efa82c7038e9369d0"},
-    {file = "Pillow-8.1.2-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:74cd9aa648ed6dd25e572453eb09b08817a1e3d9f8d1bd4d8403d99e42ea790b"},
-    {file = "Pillow-8.1.2-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:e5739ae63636a52b706a0facec77b2b58e485637e1638202556156e424a02dc2"},
-    {file = "Pillow-8.1.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:903293320efe2466c1ab3509a33d6b866dc850cfd0c5d9cc92632014cec185fb"},
-    {file = "Pillow-8.1.2-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:5daba2b40782c1c5157a788ec4454067c6616f5a0c1b70e26ac326a880c2d328"},
-    {file = "Pillow-8.1.2-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:1f93f2fe211f1ef75e6f589327f4d4f8545d5c8e826231b042b483d8383e8a7c"},
-    {file = "Pillow-8.1.2-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:6efac40344d8f668b6c4533ae02a48d52fd852ef0654cc6f19f6ac146399c733"},
-    {file = "Pillow-8.1.2-pp37-pypy37_pp73-win32.whl", hash = "sha256:f36c3ff63d6fc509ce599a2f5b0d0732189eed653420e7294c039d342c6e204a"},
-    {file = "Pillow-8.1.2.tar.gz", hash = "sha256:b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44"},
+    {file = "Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win32.whl", hash = "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f"},
+    {file = "Pillow-8.2.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win32.whl", hash = "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2"},
+    {file = "Pillow-8.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb"},
+    {file = "Pillow-8.2.0-cp38-cp38-win32.whl", hash = "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232"},
+    {file = "Pillow-8.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef"},
+    {file = "Pillow-8.2.0-cp39-cp39-win32.whl", hash = "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713"},
+    {file = "Pillow-8.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e"},
+    {file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"},
+]
+pooch = [
+    {file = "pooch-1.3.0-py3-none-any.whl", hash = "sha256:2cec8cbd0515462da1f84446113e77a785029b8514841e0ad344dd57f7924902"},
+    {file = "pooch-1.3.0.tar.gz", hash = "sha256:30d448e825904e2d763bbbe418831a788813c32f636b21c8d60ee5f474532898"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.11.1-py2.py3-none-any.whl", hash = "sha256:94c82f1bf5899d56edb1d926732f4e75a7df29a0c8c092559c77420c9d62428b"},
-    {file = "pre_commit-2.11.1.tar.gz", hash = "sha256:de55c5c72ce80d79106e48beb1b54104d16495ce7f95b0c7b13d4784193a00af"},
+    {file = "pre_commit-2.12.1-py2.py3-none-any.whl", hash = "sha256:70c5ec1f30406250b706eda35e868b87e3e4ba099af8787e3e8b4b01e84f4712"},
+    {file = "pre_commit-2.12.1.tar.gz", hash = "sha256:900d3c7e1bf4cf0374bb2893c24c23304952181405b4d88c9c40b72bda1bb8a9"},
 ]
 pygments = [
-    {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
-    {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
+    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
+    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1167,8 +1145,8 @@ pyyaml = [
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 requests = [
-    {file = "requests-2.15.1-py2.py3-none-any.whl", hash = "sha256:ff753b2196cd18b1bbeddc9dcd5c864056599f7a7d9a4fb5677e723efa2b7fb9"},
-    {file = "requests-2.15.1.tar.gz", hash = "sha256:e5659b9315a0610505e050bb7190bf6fa2ccee1ac295f2b760ef9d8a03ebbb2e"},
+    {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
+    {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
 ]
 scikit-learn = [
     {file = "scikit-learn-0.23.2.tar.gz", hash = "sha256:20766f515e6cd6f954554387dfae705d93c7b544ec0e6c6a5d8e006f6f7ef480"},
@@ -1220,16 +1198,16 @@ seaborn = [
     {file = "seaborn-0.11.1.tar.gz", hash = "sha256:44e78eaed937c5a87fc7a892c329a7cc091060b67ebd1d0d306b446a74ba01ad"},
 ]
 six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
     {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 sphinx = [
-    {file = "Sphinx-3.5.3-py3-none-any.whl", hash = "sha256:3f01732296465648da43dec8fb40dc451ba79eb3e2cc5c6d79005fd98197107d"},
-    {file = "Sphinx-3.5.3.tar.gz", hash = "sha256:ce9c228456131bab09a3d7d10ae58474de562a6f79abb3dc811ae401cf8c1abc"},
+    {file = "Sphinx-3.5.4-py3-none-any.whl", hash = "sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8"},
+    {file = "Sphinx-3.5.4.tar.gz", hash = "sha256:19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1"},
 ]
 sphinx-bootstrap-theme = [
     {file = "sphinx-bootstrap-theme-0.7.1.tar.gz", hash = "sha256:571e43ccb76d4c6c06576aa24a826b6ebc7adac45a5b54985200128806279d08"},
@@ -1271,21 +1249,17 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
+    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
+    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
     {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.4.3-py2.py3-none-any.whl", hash = "sha256:83f95875d382c7abafe06bd2a4cdd1b363e1bb77e02f155ebe8ac082a916b37c"},
-    {file = "virtualenv-20.4.3.tar.gz", hash = "sha256:49ec4eb4c224c6f7dd81bb6d0a28a09ecae5894f4e593c89b0db0885f565a107"},
-]
-wfdb = [
-    {file = "wfdb-3.3.0-py3-none-any.whl", hash = "sha256:d75297fc0ce5184fb73d7564eba35c8c9ea8ecbc7a15a27bf6cabfe7072f9e05"},
-    {file = "wfdb-3.3.0.tar.gz", hash = "sha256:a0a2ce36ab429e5a19ec0ac09e1441ead4bbab2ddc04af3b9b920c950ea75b6b"},
+    {file = "virtualenv-20.4.6-py2.py3-none-any.whl", hash = "sha256:307a555cf21e1550885c82120eccaf5acedf42978fd362d32ba8410f9593f543"},
+    {file = "virtualenv-20.4.6.tar.gz", hash = "sha256:72cf267afc04bf9c86ec932329b7e94db6a0331ae9847576daaa7ca3c86b29a4"},
 ]
 zipp = [
     {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -178,7 +178,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [[package]]
 name = "importlib-resources"
-version = "5.1.2"
+version = "5.1.3"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
@@ -189,21 +189,21 @@ zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "jinja2"
-version = "2.11.3"
+version = "3.0.0"
 description = "A very fast and expressive template engine."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-MarkupSafe = ">=0.23"
+MarkupSafe = ">=2.0.0rc2"
 
 [package.extras]
-i18n = ["Babel (>=0.8)"]
+i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "joblib"
@@ -235,11 +235,11 @@ mistune = "*"
 
 [[package]]
 name = "markupsafe"
-version = "1.1.1"
+version = "2.0.0"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "dev"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "matplotlib"
@@ -739,7 +739,7 @@ external = ["tdlda"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "d65b77a5783c103075a1e5e44f1c6f4ff10415b5bd74b219f03ec9546b7d6ad7"
+content-hash = "9d37615a89aa78bd84e575f99ad5f62b65ee79bab88c98a20743e2817f35ecd9"
 
 [metadata.files]
 alabaster = [
@@ -830,12 +830,12 @@ importlib-metadata = [
     {file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.1.2-py3-none-any.whl", hash = "sha256:ebab3efe74d83b04d6bf5cd9a17f0c5c93e60fb60f30c90f56265fce4682a469"},
-    {file = "importlib_resources-5.1.2.tar.gz", hash = "sha256:642586fc4740bd1cad7690f836b3321309402b20b332529f25617ff18e8e1370"},
+    {file = "importlib_resources-5.1.3-py3-none-any.whl", hash = "sha256:3b9c774e0e7e8d9c069eb2fe6aee7e9ae71759a381dec02eb45249fba7f38713"},
+    {file = "importlib_resources-5.1.3.tar.gz", hash = "sha256:0786b216556e53b34156263ab654406e543a8b0d9b1381019e25a36a09263c36"},
 ]
 jinja2 = [
-    {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
-    {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
+    {file = "Jinja2-3.0.0-py3-none-any.whl", hash = "sha256:2f2de5285cf37f33d33ecd4a9080b75c87cd0c1994d5a9c6df17131ea1f049c6"},
+    {file = "Jinja2-3.0.0.tar.gz", hash = "sha256:ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5"},
 ]
 joblib = [
     {file = "joblib-1.0.1-py3-none-any.whl", hash = "sha256:feeb1ec69c4d45129954f1b7034954241eedfd6ba39b5e9e4b6883be3332d5e5"},
@@ -880,58 +880,40 @@ m2r2 = [
     {file = "m2r2-0.2.7.tar.gz", hash = "sha256:fbf72ade9f648d41658f97c5267687431612451f36b65761a138fbc276294df5"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
-    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2efaeb1baff547063bad2b2893a8f5e9c459c4624e1a96644bbba08910ae34e0"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:441ce2a8c17683d97e06447fcbccbdb057cbf587c78eb75ae43ea7858042fe2c"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:45535241baa0fc0ba2a43961a1ac7562ca3257f46c4c3e9c0de38b722be41bd1"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:90053234a6479738fd40d155268af631c7fca33365f964f2208867da1349294b"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3b54a9c68995ef4164567e2cd1a5e16db5dac30b2a50c39c82db8d4afaf14f63"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f58b5ba13a5689ca8317b98439fccfbcc673acaaf8241c1869ceea40f5d585bf"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-win32.whl", hash = "sha256:a00dce2d96587651ef4fa192c17e039e8cfab63087c67e7d263a5533c7dad715"},
+    {file = "MarkupSafe-2.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:007dc055dbce5b1104876acee177dbfd18757e19d562cd440182e1f492e96b95"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a08cd07d3c3c17cd33d9e66ea9dee8f8fc1c48e2d11bd88fd2dc515a602c709b"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3c352ff634e289061711608f5e474ec38dbaa21e3e168820d53d5f4015e5b91b"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:32200f562daaab472921a11cbb63780f1654552ae49518196fc361ed8e12e901"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:fef86115fdad7ae774720d7103aa776144cf9b66673b4afa9bcaa7af990ed07b"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e79212d09fc0e224d20b43ad44bb0a0a3416d1e04cf6b45fed265114a5d43d20"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:79b2ae94fa991be023832e6bcc00f41dbc8e5fe9d997a02db965831402551730"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-win32.whl", hash = "sha256:3261fae28155e5c8634dd7710635fe540a05b58f160cef7713c7700cb9980e66"},
+    {file = "MarkupSafe-2.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e4570d16f88c7f3032ed909dc9e905a17da14a1c4cfd92608e3fda4cb1208bbd"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8f806bfd0f218477d7c46a11d3e52dc7f5fdfaa981b18202b7dc84bbc287463b"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e77e4b983e2441aff0c0d07ee711110c106b625f440292dfe02a2f60c8218bd6"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:031bf79a27d1c42f69c276d6221172417b47cb4b31cdc73d362a9bf5a1889b9f"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:83cf0228b2f694dcdba1374d5312f2277269d798e65f40344964f642935feac1"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4cc563836f13c57f1473bc02d1e01fc37bab70ad4ee6be297d58c1d66bc819bf"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d00a669e4a5bec3ee6dbeeeedd82a405ced19f8aeefb109a012ea88a45afff96"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-win32.whl", hash = "sha256:161d575fa49395860b75da5135162481768b11208490d5a2143ae6785123e77d"},
+    {file = "MarkupSafe-2.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:58bc9fce3e1557d463ef5cee05391a05745fd95ed660f23c1742c711712c0abb"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3fb47f97f1d338b943126e90b79cad50d4fcfa0b80637b5a9f468941dbbd9ce5"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dab0c685f21f4a6c95bfc2afd1e7eae0033b403dd3d8c1b6d13a652ada75b348"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:664832fb88b8162268928df233f4b12a144a0c78b01d38b81bdcf0fc96668ecb"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:df561f65049ed3556e5b52541669310e88713fdae2934845ec3606f283337958"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:24bbc3507fb6dfff663af7900a631f2aca90d5a445f272db5fc84999fa5718bc"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:87de598edfa2230ff274c4de7fcf24c73ffd96208c8e1912d5d0fee459767d75"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a19d39b02a24d3082856a5b06490b714a9d4179321225bbf22809ff1e1887cc8"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-win32.whl", hash = "sha256:4aca81a687975b35e3e80bcf9aa93fe10cd57fac37bf18b2314c186095f57e05"},
+    {file = "MarkupSafe-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:70820a1c96311e02449591cbdf5cd1c6a34d5194d5b55094ab725364375c9eb2"},
+    {file = "MarkupSafe-2.0.0.tar.gz", hash = "sha256:4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527"},
 ]
 matplotlib = [
     {file = "matplotlib-3.3.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:672960dd114e342b7c610bf32fb99d14227f29919894388b41553217457ba7ef"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ pyriemann = ">=0.2.6"
 matplotlib = "^3.0.0"
 seaborn = ">=0.9.0"
 PyYAML = "^5.0.0"
+pooch = "^1.3.0"
 
-wfdb = "^3.3.0"  # TODO: remove. Used only once, for downloading. Try to replace
 pyunpack = "^0.2.2"  # TODO: remove. used only once, could be replaced with standard library call
 patool = "^1.12"  #  TODO: remove. required as pyunpack's backend
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ matplotlib = "^3.0.0"
 seaborn = ">=0.9.0"
 PyYAML = "^5.0.0"
 pooch = "^1.3.0"
+requests = "^2.15.1"
 
 pyunpack = "^0.2.2"  # TODO: remove. used only once, could be replaced with standard library call
 patool = "^1.12"  #  TODO: remove. required as pyunpack's backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ PyYAML = "^5.0.0"
 pooch = "^1.3.0"
 requests = "^2.15.1"
 
-pyunpack = "^0.2.2"  # TODO: remove. used only once, could be replaced with standard library call
-patool = "^1.12"  #  TODO: remove. required as pyunpack's backend
 tdlda = {git = "https://github.com/jsosulski/tdlda.git", rev = "0.1.0", optional = true}
 
 [tool.poetry.dev-dependencies]

--- a/tutorials/tutorial_1_simple_example_motor_imagery.py
+++ b/tutorials/tutorial_1_simple_example_motor_imagery.py
@@ -12,7 +12,6 @@ classify these signals.
 #
 # https://github.com/plcrodrigues/Workshop-MOABB-BCI-Graz-2019
 
-import os
 import warnings
 
 import matplotlib.pyplot as plt
@@ -46,6 +45,7 @@ warnings.filterwarnings("ignore")
 # (like .mat, .gdf, etc.) and instantiate a Raw object from the MNE package
 
 dataset = BNCI2014001()
+dataset.subject_list = [1, 2, 3]
 
 ##############################################################################
 # Accessing EEG Recording
@@ -121,19 +121,21 @@ pipeline = make_pipeline(CSP(n_components=8), LDA())
 # partition and the remaining one as testing partition.
 
 evaluation = WithinSessionEvaluation(
-    paradigm=paradigm, datasets=[dataset], overwrite=True
+    paradigm=paradigm,
+    datasets=[dataset],
+    hdf5_path=None,
 )
 
 # We obtain the results in the form of a pandas dataframe
 results = evaluation.process({"csp+lda": pipeline})
 
-# To export the results in CSV within a directory:
-if not os.path.exists("./results"):
-    os.mkdir("./results")
-results.to_csv("./results/results_part2-1.csv")
+# The results are stored in locally, to avoid recomputing the results each time.
+# It is saved in `hdf5_path` if defined or in ~/mne_data/results  otherwise.
+# To export the results in CSV:
+results.to_csv("./results_part2-1.csv")
 
 # To load previously obtained results saved in CSV
-results = pd.read_csv("./results/results_part2-1.csv")
+results = pd.read_csv("./results_part2-1.csv")
 
 ##############################################################################
 # Plotting Results

--- a/tutorials/tutorial_2_using_mulitple_datasets.py
+++ b/tutorials/tutorial_2_using_mulitple_datasets.py
@@ -10,19 +10,17 @@ we begin by importing all relevant libraries.
 #
 # https://github.com/plcrodrigues/Workshop-MOABB-BCI-Graz-2019
 
-import os
 import warnings
 
 import matplotlib.pyplot as plt
 import mne
-import pandas as pd
 import seaborn as sns
 from mne.decoding import CSP
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 from sklearn.pipeline import make_pipeline
 
 import moabb
-from moabb.datasets import BNCI2014001, Weibo2014, Zhou2016
+from moabb.datasets import BNCI2014001, Zhou2016
 from moabb.evaluations import WithinSessionEvaluation
 from moabb.paradigms import LeftRightImagery
 
@@ -36,30 +34,26 @@ warnings.filterwarnings("ignore")
 # Initializing Datasets
 # ---------------------
 #
-# We instantiate the three different datasets that follow the MI paradigm
+# We instantiate the two different datasets that follow the MI paradigm
 # (with left-hand/right-hand classes) but were recorded with different number
 # of electrodes, different number of trials, etc.
 
-datasets = [Zhou2016(), Weibo2014(), BNCI2014001()]
+datasets = [Zhou2016(), BNCI2014001()]
+subj = [1, 2, 3]
+for d in datasets:
+    d.subject_list = subj
+
 
 # The following lines go exactly as in the previous example, where we end up
 # obtaining a pandas dataframe containing the results of the evaluation. We
-# set `overwrite` to False to cache the results, avoiding to restart all the
-# evaluation from scratch if a problem occurs.
+# could set `overwrite` to False to cache the results, avoiding to restart all
+# the evaluation from scratch if a problem occurs.
 paradigm = LeftRightImagery()
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm, datasets=datasets, overwrite=False
 )
 pipeline = make_pipeline(CSP(n_components=8), LDA())
 results = evaluation.process({"csp+lda": pipeline})
-
-# To export the results in CSV within a directory:
-if not os.path.exists("./results"):
-    os.mkdir("./results")
-results.to_csv("./results/results_part2-2.csv")
-
-# To load previously obtained results saved in CSV
-results = pd.read_csv("./results/results_part2-2.csv")
 
 ##############################################################################
 # Plotting Results

--- a/tutorials/tutorial_3_benchmarking_multiple_pipelines.py
+++ b/tutorials/tutorial_3_benchmarking_multiple_pipelines.py
@@ -9,12 +9,10 @@ classification score of not one but three classification pipelines.
 #
 # https://github.com/plcrodrigues/Workshop-MOABB-BCI-Graz-2019
 
-import os
 import warnings
 
 import matplotlib.pyplot as plt
 import mne
-import pandas as pd
 import seaborn as sns
 from mne.decoding import CSP
 from pyriemann.classification import MDM
@@ -25,7 +23,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.svm import SVC
 
 import moabb
-from moabb.datasets import BNCI2014001, Weibo2014, Zhou2016
+from moabb.datasets import BNCI2014001, Zhou2016
 from moabb.evaluations import WithinSessionEvaluation
 from moabb.paradigms import LeftRightImagery
 
@@ -52,16 +50,21 @@ pipelines["tgsp+svm"] = make_pipeline(
 )
 pipelines["MDM"] = make_pipeline(Covariances("oas"), MDM(metric="riemann"))
 
-# The following lines go exactly as in the previous example, where we end up
+# The following lines go exactly as in the previous tutorial, where we end up
 # obtaining a pandas dataframe containing the results of the evaluation.
-datasets = [BNCI2014001(), Weibo2014(), Zhou2016()]
+datasets = [BNCI2014001(), Zhou2016()]
+subj = [1, 2, 3]
+for d in datasets:
+    d.subject_list = subj
 paradigm = LeftRightImagery()
-evaluation = WithinSessionEvaluation(paradigm=paradigm, datasets=datasets, overwrite=True)
+evaluation = WithinSessionEvaluation(
+    paradigm=paradigm, datasets=datasets, overwrite=False
+)
 results = evaluation.process(pipelines)
-if not os.path.exists("./results"):
-    os.mkdir("./results")
-results.to_csv("./results/results_part2-3.csv")
-results = pd.read_csv("./results/results_part2-3.csv")
+
+# As `overwrite` is set to False, the results from the previous tutorial are reused and
+# only the new pipelines are evaluated. The results from "csp+lda" are not recomputed.
+# The results are saved in ~/mne_data/results if the parameter `hdf5_path` is not set.
 
 ##############################################################################
 # Plotting Results


### PR DESCRIPTION
closes #180 

This issue is connected with the problem in documentation generation #173 as wfdb silently fails to download the file and when the example code extracts MNE epochs from downloaded files, they are empty.

I contacted Dr. Spiridon Nikolopoulos, that posted the MAMEM dataset on figshare. Unfortunately, these are only big rar/zip files that contain .mat files for each session/subject. I worked on the figshare to upload the separate files, it is okay for MAMEM 2 and 3.

I added all the code to download and open mat files instead of wfdb format. The data and labels obtained with mat files are similar to those obtained with wfdb. 

This PR also introduces some new code to download dataset without using MNE internal fetch function. [As they told us](https://github.com/mne-tools/mne-python/issues/9226), it would be deprecated. They recommend to use [pooch](https://pypi.org/project/pooch/). I added helper function in `download.py` to get FigShare file using pooch.

There is still a problem with MAMEM 1 dataset, because of an internal error of FigShare. Maybe it is possible to merge this code without waiting for full support of the MAMEM 1.