### PR TITLE
Use MNE epoch in evaluation

### DIFF
--- a/examples/mne_and_scikit_estimators.py
+++ b/examples/mne_and_scikit_estimators.py
@@ -1,0 +1,192 @@
+"""
+=========================
+MNE Epochs-based piplines
+=========================
+
+This example shows how to use machine learning pipeline based on MNE Epochs
+instead of numpy arrays. This is useful to make the most of the MNE code base
+and to embed EEG specific code inside sklearn pipelines.
+
+We will compare compare different pipelines for P300:
+- Logistic Regression, based on MNE Epochs
+- XDAWN and Logistic Regression (LR), based on MNE Epochs
+- XDAWN extended covariance and LR on tangent space, based on numpy
+
+"""
+# Authors: Sylvain Chevallier
+#
+# License: BSD (3-clause)
+
+import warnings
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from mne.decoding import Vectorizer
+from mne.preprocessing import Xdawn
+from pyriemann.estimation import XdawnCovariances
+from pyriemann.tangentspace import TangentSpace
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+import moabb
+from moabb.analysis.meta_analysis import (  # noqa: E501
+    compute_dataset_statistics,
+    find_significant_differences,
+)
+from moabb.analysis.plotting import paired_plot, summary_plot
+from moabb.datasets import BNCI2014009
+from moabb.evaluations import CrossSessionEvaluation
+from moabb.paradigms import P300
+
+
+warnings.simplefilter(action="ignore", category=FutureWarning)
+warnings.simplefilter(action="ignore", category=RuntimeWarning)
+moabb.set_log_level("info")
+
+###############################################################################
+# Loading dataset
+# ---------------
+#
+# Load 2 subjects of BNCI 2014-009 dataset, with 3 session each
+
+dataset = BNCI2014009()
+dataset.subject_list = dataset.subject_list[:3]
+datasets = [dataset]
+paradigm = P300()
+
+##############################################################################
+# Get data (optional)
+# -------------------
+#
+# To get access to the EEG signals downloaded from the dataset, you could
+# use `dataset.get_data([subject_id) to obtain the EEG as MNE Epochs, stored
+# in a dictionary of sessions and runs.
+# The `paradigm.get_data(dataset=dataset, subjects=[subject_id])` allows to
+# obtain the preprocessed EEG data, the labels and the meta information. By
+# default, the EEG is return as a numpy array. With `return_epochs=True`, MNE
+# Epochs are returned.
+
+subject_list = [1]
+sessions = dataset.get_data(subject_list)
+X, labels, meta = paradigm.get_data(dataset=dataset, subjects=subject_list)
+epochs, labels, meta = paradigm.get_data(
+    dataset=dataset, subjects=subject_list, return_epochs=True
+)
+
+##############################################################################
+# A simple MNE pipeline
+# ---------------------
+#
+# Using `return_epochs=True` in the evaluation, it is possible to design a
+# pipeline based on MNE Epochs input. Let's create a simple one, that
+# reshape the input data from epochs, rescale the data and uses a logistic
+# regression to classify the data. We will need to write a basic Transformer
+# estimator, that comply with
+# [sklearn convention](https://scikit-learn.org/stable/developers/develop.html).
+# This transformer will extract the data from an input Epoch, and reshapes into
+# 2D array.
+
+
+class MyVectorizer(BaseEstimator, TransformerMixin):
+    def __init__(self):
+        pass
+
+    def fit(self, X, y=None):
+        arr = X.get_data()
+        self.features_shape_ = arr.shape[1:]
+        return self
+
+    def transform(self, X, y=None):
+        arr = X.get_data()
+        return arr.reshape(len(arr), -1)
+
+
+# We will define a pipeline that is based on this new class, using a scaler
+# and a logistic regression. This pipeline is evaluated across session using
+# ROC-AUC metric.
+
+mne_ppl = {}
+mne_ppl["MNE LR"] = make_pipeline(
+    MyVectorizer(), StandardScaler(), LogisticRegression(penalty="l1", solver="liblinear")
+)
+
+mne_eval = CrossSessionEvaluation(
+    paradigm=paradigm,
+    datasets=datasets,
+    suffix="examples",
+    overwrite=True,
+    return_epochs=True,
+)
+mne_res = mne_eval.process(mne_ppl)
+
+##############################################################################
+# Advanced MNE pipeline
+# ---------------------
+#
+# In some case, the MNE pipeline should have access to the original labels from
+# the dataset. This is the case for the XDAWN code of MNE. One could pass
+# `mne_labels` to evaluation in order to keep this label.
+# As an example, we will define a pipeline that compute an XDAWN filter, rescale,
+# then apply a logistic regression.
+
+mne_adv = {}
+mne_adv["XDAWN LR"] = make_pipeline(
+    Xdawn(n_components=5, reg="ledoit_wolf", correct_overlap=False),
+    Vectorizer(),
+    StandardScaler(),
+    LogisticRegression(penalty="l1", solver="liblinear"),
+)
+adv_eval = CrossSessionEvaluation(
+    paradigm=paradigm,
+    datasets=datasets,
+    suffix="examples",
+    overwrite=True,
+    return_epochs=True,
+    mne_labels=True,
+)
+adv_res = mne_eval.process(mne_adv)
+
+###############################################################################
+# Numpy-based pipeline
+# --------------------
+#
+# For the comparison, we will define a numpy-based pipeline that relies on
+# pyriemann to estimate XDAWN-extended covariance matrices that are projected
+# on the tangent space and classified with a logistic regression.
+
+sk_ppl = {}
+sk_ppl["RG LR"] = make_pipeline(
+    XdawnCovariances(nfilter=5, estimator="lwf", xdawn_estimator="scm"),
+    TangentSpace(),
+    LogisticRegression(penalty="l1", solver="liblinear"),
+)
+sk_eval = CrossSessionEvaluation(
+    paradigm=paradigm,
+    datasets=datasets,
+    suffix="examples",
+    overwrite=True,
+)
+sk_res = sk_eval.process(sk_ppl)
+
+###############################################################################
+# Combining results
+# -----------------
+#
+# Even if the results have been obtained by different evaluation processes, it
+# possible to combine the resulting dataframes to analyze and plot the results.
+
+all_res = pd.concat([mne_res, adv_res, sk_res])
+
+# We could compare the Euclidean and Riemannian performance using a `paired_plot`
+
+paired_plot(all_res, "XDAWN LR", "RG LR")
+
+# All the results could be compared and statistical analysis could highlight the
+# differences between pipelines.
+
+stats = compute_dataset_statistics(all_res)
+P, T = find_significant_differences(stats)
+summary_plot(P, T)
+plt.show()

--- a/moabb/datasets/bnci.py
+++ b/moabb/datasets/bnci.py
@@ -235,17 +235,16 @@ def _load_data_009_2014(
     filename = data_path(url, path, force_update, update_path)[0]
 
     data = loadmat(filename, struct_as_record=False, squeeze_me=True)["data"]
-    raws = []
+    sess = []
     event_id = {}
     for run in data:
         raw, ev = _convert_run_p300_sl(run, verbose=verbose)
-        raws.append(raw)
+        sess.append(raw)
         event_id.update(ev)
 
     sessions = {}
-    sessions["session_0"] = {}
-    for i, rawi in enumerate(raws):
-        sessions["session_0"]["run_" + str(i)] = rawi
+    for i, sessi in enumerate(sess):
+        sessions["session_" + str(i)] = {"run_0": sessi}
 
     return sessions
 
@@ -967,7 +966,7 @@ class BNCI2014009(MNEBNCI):
     def __init__(self):
         super().__init__(
             subjects=list(range(1, 11)),
-            sessions_per_subject=1,
+            sessions_per_subject=3,
             events={"Target": 2, "NonTarget": 1},
             code="009-2014",
             interval=[0, 0.8],

--- a/moabb/evaluations/__init__.py
+++ b/moabb/evaluations/__init__.py
@@ -5,4 +5,8 @@ either within-recording-session accuracy, across-session within-subject
 accuracy, across-subject accuracy, or other transfer learning settings.
 """
 # flake8: noqa
-from moabb.evaluations.evaluations import *
+from .evaluations import (
+    CrossSessionEvaluation,
+    CrossSubjectEvaluation,
+    WithinSessionEvaluation,
+)

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -40,6 +40,8 @@ class BaseEvaluation(ABC):
         Adding information to results.
     return_epochs: bool, default=False
         use MNE epoch to train pipelines.
+    mne_labels: bool, default=False
+        if returning MNE epoch, use original dataset label if True
     """
 
     def __init__(
@@ -54,17 +56,23 @@ class BaseEvaluation(ABC):
         hdf5_path=None,
         additional_columns=None,
         return_epochs=False,
+        mne_labels=False,
     ):
         self.random_state = random_state
         self.n_jobs = n_jobs
         self.error_score = error_score
         self.hdf5_path = hdf5_path
         self.return_epochs = return_epochs
+        self.mne_labels = mne_labels
 
         # check paradigm
         if not isinstance(paradigm, BaseParadigm):
             raise (ValueError("paradigm must be an Paradigm instance"))
         self.paradigm = paradigm
+
+        # check labels
+        if self.mne_labels and not self.return_epochs:
+            raise (ValueError("mne_labels could only be set with return_epochs"))
 
         # if no dataset provided, then we get the list from the paradigm
         if datasets is None:

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -19,18 +19,27 @@ class BaseEvaluation(ABC):
     Parameters
     ----------
     paradigm : Paradigm instance
-        the paradigm to use.
-    datasets : List of Dataset Instance.
+        The paradigm to use.
+    datasets : List of Dataset instance
         The list of dataset to run the evaluation. If none, the list of
         compatible dataset will be retrieved from the paradigm instance.
-    random_state:
-        if not None, can guarantee same seed
-    n_jobs: 1;
-        number of jobs for fitting of pipeline
-    overwrite: bool (defaul False)
-        if true, overwrite the results.
+    random_state: int, RandomState instance, default=None
+        If not None, can guarantee same seed for shuffling examples.
+    n_jobs: int, default=1
+        Number of jobs for fitting of pipeline.
+    overwrite: bool, default=False
+        If true, overwrite the results.
+    error_score: "raise" or numeric, default="raise"
+        Value to assign to the score if an error occurs in estimator fitting. If set to
+        ‘raise’, the error is raised.
     suffix: str
-        suffix for the results file.
+        Suffix for the results file.
+    hdf5_path: str
+        Specific path for storing the results.
+    additional_columns: None
+        Adding information to results.
+    return_epochs: bool, default=False
+        use MNE epoch to train pipelines.
     """
 
     def __init__(
@@ -44,11 +53,13 @@ class BaseEvaluation(ABC):
         suffix="",
         hdf5_path=None,
         additional_columns=None,
+        return_epochs=False,
     ):
         self.random_state = random_state
         self.n_jobs = n_jobs
         self.error_score = error_score
         self.hdf5_path = hdf5_path
+        self.return_epochs = return_epochs
 
         # check paradigm
         if not isinstance(paradigm, BaseParadigm):

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -180,10 +180,13 @@ class BaseParadigm(metaclass=ABCMeta):
         inv_events = {k: v for v, k in event_id.items()}
         labels = np.array([inv_events[e] for e in epochs.events[:, -1]])
 
-        # if only one band, return a 3D array, otherwise return a 4D
-        if len(self.filters) == 1:
+        if return_epochs:
+            X = mne.concatenate_epochs(X)
+        elif len(self.filters) == 1:
+            # if only one band, return a 3D array
             X = X[0]
         else:
+            # otherwise return a 4D
             X = np.array(X).transpose((1, 2, 3, 0))
 
         metadata = pd.DataFrame(index=range(len(labels)))

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -229,7 +229,7 @@ class BaseParadigm(metaclass=ABCMeta):
         data = dataset.get_data(subjects)
         self.prepare_process(dataset)
 
-        X = []
+        X = [] if return_epochs else np.array([])
         labels = []
         metadata = []
         for subject, sessions in data.items():
@@ -249,15 +249,13 @@ class BaseParadigm(metaclass=ABCMeta):
                     metadata.append(met)
 
                     # grow X and labels in a memory efficient way. can be slow
-                    if not return_epochs:
-                        if len(X) > 0:
-                            X = np.append(X, x, axis=0)
-                            labels = np.append(labels, lbs, axis=0)
-                        else:
-                            X = x
-                            labels = lbs
-                    else:
+                    if return_epochs:
                         X.append(x)
+                    else:
+                        X = np.append(X, x, axis=0) if len(X) else x
+                    labels = np.append(labels, lbs, axis=0)
 
         metadata = pd.concat(metadata, ignore_index=True)
+        if return_epochs:
+            X = mne.concatenate_epochs(X)
         return X, labels, metadata

--- a/moabb/paradigms/p300.py
+++ b/moabb/paradigms/p300.py
@@ -98,7 +98,7 @@ class BaseP300(BaseParadigm):
     def used_events(self, dataset):
         pass
 
-    def process_raw(self, raw, dataset, return_epochs=False):
+    def process_raw(self, raw, dataset, return_epochs=False):  # noqa: C901
         # find the events, first check stim_channels then annotations
         stim_channels = mne.utils._get_stim_channel(None, raw.info, raise_error=False)
         if len(stim_channels) > 0:
@@ -178,10 +178,13 @@ class BaseP300(BaseParadigm):
         inv_events = {k: v for v, k in event_id.items()}
         labels = np.array([inv_events[e] for e in epochs.events[:, -1]])
 
-        # if only one band, return a 3D array, otherwise return a 4D
-        if len(self.filters) == 1:
+        if return_epochs:
+            X = mne.concatenate_epochs(X)
+        elif len(self.filters) == 1:
+            # if only one band, return a 3D array
             X = X[0]
         else:
+            # otherwise return a 4D
             X = np.array(X).transpose((1, 2, 3, 0))
 
         metadata = pd.DataFrame(index=range(len(labels)))

--- a/moabb/tests/datasets.py
+++ b/moabb/tests/datasets.py
@@ -31,7 +31,7 @@ class Test_Datasets(unittest.TestCase):
         n_sessions = 2
         n_runs = 2
 
-        for paradigm in ["imagery", "p300"]:
+        for paradigm in ["imagery", "p300", "ssvep"]:
 
             ds = FakeDataset(
                 n_sessions=n_sessions,

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -31,6 +31,11 @@ class Test_WithinSess(unittest.TestCase):
             paradigm=FakeImageryParadigm(), datasets=[dataset]
         )
 
+    def test_mne_labels(self):
+        kwargs = dict(paradigm=FakeImageryParadigm(), datasets=[dataset])
+        epochs = dict(return_epochs=False, mne_labels=True)
+        self.assertRaises(ValueError, ev.WithinSessionEvaluation, **epochs, **kwargs)
+
     def tearDown(self):
         path = self.eval.results.filepath
         if os.path.isfile(path):

--- a/moabb/utils.py
+++ b/moabb/utils.py
@@ -1,6 +1,6 @@
 import logging
 
-import mne
+from mne import set_log_level as sll
 
 
 def set_log_level(level="INFO"):
@@ -14,7 +14,7 @@ def set_log_level(level="INFO"):
     level = level.upper()
     if level not in VALID_LEVELS:
         raise ValueError(f"Invalid level {level}. Choose one of {VALID_LEVELS}.")
-    mne.set_log_level(False)
+    sll(False)
     logging.basicConfig(
         level=level,
         format="%(asctime)s %(levelname)s %(threadName)s %(name)s %(message)s",


### PR DESCRIPTION
Closes #159 #160 

The initial plan was to support scikit estimators that could take as input either numpy arrays or directly MNE epochs. This PR aims at fully implementing this feature, that allows to benefit from the rich ecosystem of MNE. An example is proposed to demonstrate those feature, comparing MNE's `Xdawn` and Pyriemann's `XdawnCovariances`. For this example, I rely on dataset BNCI 2014-009, and I fixed #160 to be able to display cross-session evaluation example.

I fixed some typos in the docstrings of `evaluation/base.py` and made several corrections on the tests: 
- clean dead code add tests for MNE epochs from  `tests/paradigms.py`,
- add the "ssvep" in the `tests/datasets.py`, 
- add a test for MNE epochs in `tests/evaluations.py`
- fix some potential import error in `moabb/utils.py`:  MNE is imported directly, thus loading matplotlib. This could cause error on headless server when making `import moabb` if matplotlib is not configured. Corrected also an `import *` in `evaluations/__init__.py`.