### PR TITLE
Deploy docs on moabb.github.io

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,10 +50,10 @@ jobs:
           path: docs/build/html/
 
       # Since we want the URL to be neurotechx.github.io/docs/ the html output needs to be put in a ./docs subfolder of the publish_dir
-      - name: Move docs into site folder
-        run: |
-          mkdir site
-          mv docs/build/html site/docs
+      # - name: Move docs into site folder
+      #   run: |
+      #     mkdir site
+      #     mv docs/build/html site/docs
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
@@ -76,9 +76,9 @@ jobs:
           pushd docs/build && rm -Rf ~/moabb/moabb/moabb-ghio/docs && cp -a html ~/moabb/moabb/moabb-ghio/docs && popd
           pushd moabb-ghio && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: site
+      # - name: Deploy
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   if: github.ref == 'refs/heads/master'
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,16 +65,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "NeuroTechX/moabb.github.io"
-          path: moabb.github.io
+          path: moabb-ghio
 
       - name: Deploy on moabb.github.io
         run: |
-          echo "Deploying dev docs.";
-          git config --global user.email "ci@neurotechx.com";
-          git config --global user.name "Github Actions";
-          pushd ~/moabb.github.io && git checkout master && git pull origin master && popd;
-          pushd docs/build && rm -Rf ~/moabb.github.io/docs && cp -a html ~/moabb.github.io/docs && popd;
-          pushd ~/moabb.github.io && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd;
+          echo "Deploying dev docs."
+          git config --global user.email "ci@neurotechx.com"
+          git config --global user.name "Github Actions"
+          pushd moabb-ghio && git checkout master && git pull origin master && popd
+          pushd docs/build && rm -Rf ~/moabb/moabb/moabb-ghio/docs && cp -a html ~/moabb/moabb/moabb-ghio/docs && popd
+          pushd moabb-ghio && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,22 +61,35 @@ jobs:
           key: ${{ secrets.MOABB_DOCS_SSH }}
           known_hosts: ${{ secrets.KNOWN_HOST_GH }}
 
-      - name: Checkout  moabb.github.io
-        uses: actions/checkout@v2
-        with:
-          repository: "NeuroTechX/moabb.github.io"
-          path: moabb-ghio
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+      # - name: Checkout  moabb.github.io
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: "NeuroTechX/moabb.github.io"
+      #     path: moabb-ghio
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     fetch-depth: 0
 
       - name: Deploy on moabb.github.io
         run: |
-          echo "Deploying dev docs."
+          cd ~/work
           git config --global user.email "ci@neurotechx.com"
           git config --global user.name "Github Actions"
-          pushd moabb-ghio && git checkout master && git pull origin master && rm -Rf docs && popd
-          pushd docs/build && cp -a html ~/work/moabb/moabb/moabb-ghio/docs && popd
-          pushd moabb-ghio && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd
+          git clone git@github.com:NeuroTechX/moabb.github.io.git
+          cd moabb.github.io
+          rm -Rf docs
+          cp -a ~/work/moabb/moabb/docs/build/html ./docs
+          git add -A
+          git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)"
+          git push origin master
+
+      # - name: Deploy on moabb.github.io
+      #   run: |
+      #     echo "Deploying dev docs."
+      #     git config --global user.email "ci@neurotechx.com"
+      #     git config --global user.name "Github Actions"
+      #     pushd moabb-ghio && git checkout master && git pull origin master && rm -Rf docs && popd
+      #     pushd docs/build && cp -a html ~/work/moabb/moabb/moabb-ghio/docs && popd
+      #     pushd moabb-ghio && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd
 
       # - name: Deploy
       #   uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,8 +72,10 @@ jobs:
           echo "Deploying dev docs."
           git config --global user.email "ci@neurotechx.com"
           git config --global user.name "Github Actions"
-          pushd moabb-ghio && git checkout master && git pull origin master && popd
-          pushd docs/build && rm -Rf ~/moabb/moabb/moabb-ghio/docs && cp -a html ~/moabb/moabb/moabb-ghio/docs && popd
+          pushd moabb-ghio && git checkout master && git pull origin master && rm -Rf docs && popd
+          pushd moabb-ghio && echo "ls moabb-ghio" && ls && echo && echo $(pwd) && popd
+          pushd docs/build && echo "ls docs/build" && ls && echo && echo $(pwd) &&  popd
+          pushd docs/build && cp -a html ~/moabb/moabb/moabb-ghio/docs && popd
           pushd moabb-ghio && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd
 
       # - name: Deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,11 +55,11 @@ jobs:
       #     mkdir site
       #     mv docs/build/html site/docs
 
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.MOABB_DOCS_SSH }}
-          known_hosts: ${{ secrets.KNOWN_HOST_GH }}
+      # - name: Install SSH key
+      #   uses: shimataro/ssh-key-action@v2
+      #   with:
+      #     key: ${{ secrets.MOABB_DOCS_SSH }}
+      #     known_hosts: ${{ secrets.KNOWN_HOST_GH }}
 
       - name: Checkout moabb.github.io
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,26 +61,42 @@ jobs:
           key: ${{ secrets.MOABB_DOCS_SSH }}
           known_hosts: ${{ secrets.KNOWN_HOST_GH }}
 
-      # - name: Checkout  moabb.github.io
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: "NeuroTechX/moabb.github.io"
-      #     path: moabb-ghio
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     fetch-depth: 0
+      - name: Checkout moabb.github.io
+        uses: actions/checkout@v2
+        with:
+          repository: "NeuroTechX/moabb.github.io"
+          path: moabb-ghio
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Deploy on moabb.github.io
+      - name: Add html files
         run: |
-          cd ~/work
-          git config --global user.email "ci@neurotechx.com"
-          git config --global user.name "Github Actions"
-          git clone git@github.com:NeuroTechX/moabb.github.io.git
-          cd moabb.github.io
+          cd ~/work/moabb/moabb/moabb-ghio
           rm -Rf docs
           cp -a ~/work/moabb/moabb/docs/build/html ./docs
-          git add -A
-          git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)"
-          git push origin master
+          git config --global user.email "ci@neurotechx.com"
+          git config --global user.name "Github Actions"
+          git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)" -a
+
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.MOABB_DOC_TOKEN }}
+          repository: "NeuroTechX/moabb.github.io"
+
+      # - name: Deploy on moabb.github.io
+      #   run: |
+      #     cd ~/work
+      #     git config --global user.email "ci@neurotechx.com"
+      #     git config --global user.name "Github Actions"
+      #     git clone git@github.com:NeuroTechX/moabb.github.io.git
+      #     cd moabb.github.io
+      #     rm -Rf docs
+      #     cp -a ~/work/moabb/moabb/docs/build/html ./docs
+      #     git add -A
+      #     git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)"
+      #     git push origin master
 
       # - name: Deploy on moabb.github.io
       #   run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,6 +66,8 @@ jobs:
         with:
           repository: "NeuroTechX/moabb.github.io"
           path: moabb-ghio
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Deploy on moabb.github.io
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.MOABB_DOCS_SSH }}
-          name: id_rsa-moabb
+          known_hosts: ${{ secrets.KNOWN_HOST_GH }}
 
       - name: Checkout  moabb.github.io
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,7 +66,6 @@ jobs:
         with:
           repository: "NeuroTechX/moabb.github.io"
           path: moabb-ghio
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -82,7 +81,7 @@ jobs:
       - name: Push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.MOABB_DOC_TOKEN }}
+          github_token: ${{ secrets.MOABB_GHIO }}
           repository: "NeuroTechX/moabb.github.io"
 
       # - name: Deploy on moabb.github.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,27 @@ jobs:
           mkdir site
           mv docs/build/html site/docs
 
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.MOABB_DOCS_SSH }}
+          name: id_rsa-moabb
+
+      - name: Checkout  moabb.github.io
+        uses: actions/checkout@v2
+        with:
+          repository: "NeuroTechX/moabb.github.io"
+          path: moabb.github.io
+
+      - name: Deploy on moabb.github.io
+        run: |
+          echo "Deploying dev docs.";
+          git config --global user.email "ci@neurotechx.com";
+          git config --global user.name "Github Actions";
+          pushd ~/moabb.github.io && git checkout master && git pull origin master && popd;
+          pushd docs/build && rm -Rf ~/moabb.github.io/docs && cp -a html ~/moabb.github.io/docs && popd;
+          pushd ~/moabb.github.io && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd;
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,9 +73,7 @@ jobs:
           git config --global user.email "ci@neurotechx.com"
           git config --global user.name "Github Actions"
           pushd moabb-ghio && git checkout master && git pull origin master && rm -Rf docs && popd
-          pushd moabb-ghio && echo "ls moabb-ghio" && ls && echo && echo $(pwd) && popd
-          pushd docs/build && echo "ls docs/build" && ls && echo && echo $(pwd) &&  popd
-          pushd docs/build && cp -a html ~/moabb/moabb/moabb-ghio/docs && popd
+          pushd docs/build && cp -a html ~/work/moabb/moabb/moabb-ghio/docs && popd
           pushd moabb-ghio && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd
 
       # - name: Deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  build_docs:
     name: ${{ matrix.os }}, py-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -49,12 +49,51 @@ jobs:
           name: DocumentationHTML
           path: docs/build/html/
 
+  deploy_docs:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: build_docs
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04]
+
+    steps:
+      - name: Checkout moabb.github.io
+        uses: actions/checkout@v2
+        with:
+          repository: "NeuroTechX/moabb.github.io"
+          path: moabb-ghio
+          token: ${{ secrets.MOABB_GHIO }}
+
+      - name: Deploy on moabb.github.io
+        run: |
+          git config --global user.email "ci@neurotechx.com"
+          git config --global user.name "Github Actions"
+          cd ~/work/moabb/moabb/moabb-ghio
+          rm -Rf docs
+          cp -a ~/work/moabb/moabb/docs/build/html ./docs
+          git add -A
+          git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)"
+          git push origin master
+
+      # Previous test with moabb GH pages, official docs point to moabb.github.io
+      ###########################################################################
       # Since we want the URL to be neurotechx.github.io/docs/ the html output needs to be put in a ./docs subfolder of the publish_dir
       # - name: Move docs into site folder
       #   run: |
       #     mkdir site
       #     mv docs/build/html site/docs
 
+      # - name: Deploy on moabb gh-pages
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   if: github.ref == 'refs/heads/master'
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: site
+
+      # Using checkout and push actions, not working
+      ##############################################
       # - name: Install SSH key
       #   uses: shimataro/ssh-key-action@v2
       #   with:
@@ -83,50 +122,3 @@ jobs:
       #   with:
       #     github_token: ${{ secrets.MOABB_GHIO }}
       #     repository: "NeuroTechX/moabb.github.io"
-
-      - name: Checkout moabb.github.io
-        uses: actions/checkout@v2
-        with:
-          repository: "NeuroTechX/moabb.github.io"
-          path: moabb-ghio
-          token: ${{ secrets.MOABB_GHIO }}
-
-      - name: Deploy on moabb.github.io
-        run: |
-          git config --global user.email "ci@neurotechx.com"
-          git config --global user.name "Github Actions"
-          cd ~/work/moabb/moabb/moabb-ghio
-          rm -Rf docs
-          cp -a ~/work/moabb/moabb/docs/build/html ./docs
-          git add -A
-          git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)"
-          git push origin master
-
-      # - name: Deploy on moabb.github.io
-      #   run: |
-      #     cd ~/work
-      #     git config --global user.email "ci@neurotechx.com"
-      #     git config --global user.name "Github Actions"
-      #     git clone git@github.com:NeuroTechX/moabb.github.io.git
-      #     cd ~/work/moabb/moabb/moabb-ghio
-      #     rm -Rf docs
-      #     cp -a ~/work/moabb/moabb/docs/build/html ./docs
-      #     git add -A
-      #     git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)"
-      #     git push origin master
-
-      # - name: Deploy on moabb.github.io
-      #   run: |
-      #     echo "Deploying dev docs."
-      #     git config --global user.email "ci@neurotechx.com"
-      #     git config --global user.name "Github Actions"
-      #     pushd moabb-ghio && git checkout master && git pull origin master && rm -Rf docs && popd
-      #     pushd docs/build && cp -a html ~/work/moabb/moabb/moabb-ghio/docs && popd
-      #     pushd moabb-ghio && git add -A && git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)." && git push origin master && popd
-
-      # - name: Deploy
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   if: github.ref == 'refs/heads/master'
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,28 +61,46 @@ jobs:
       #     key: ${{ secrets.MOABB_DOCS_SSH }}
       #     known_hosts: ${{ secrets.KNOWN_HOST_GH }}
 
+      # - name: Checkout moabb.github.io
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: "NeuroTechX/moabb.github.io"
+      #     path: moabb-ghio
+      #     fetch-depth: 0
+      #     persist-credentials: false
+
+      # - name: Add html files
+      #   run: |
+      #     cd ~/work/moabb/moabb/moabb-ghio
+      #     rm -Rf docs
+      #     cp -a ~/work/moabb/moabb/docs/build/html ./docs
+      #     git config --global user.email "ci@neurotechx.com"
+      #     git config --global user.name "Github Actions"
+      #     git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)" -a
+
+      # - name: Push
+      #   uses: ad-m/github-push-action@master
+      #   with:
+      #     github_token: ${{ secrets.MOABB_GHIO }}
+      #     repository: "NeuroTechX/moabb.github.io"
+
       - name: Checkout moabb.github.io
         uses: actions/checkout@v2
         with:
           repository: "NeuroTechX/moabb.github.io"
           path: moabb-ghio
-          fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.MOABB_GHIO }}
 
-      - name: Add html files
+      - name: Deploy on moabb.github.io
         run: |
+          git config --global user.email "ci@neurotechx.com"
+          git config --global user.name "Github Actions"
           cd ~/work/moabb/moabb/moabb-ghio
           rm -Rf docs
           cp -a ~/work/moabb/moabb/docs/build/html ./docs
-          git config --global user.email "ci@neurotechx.com"
-          git config --global user.name "Github Actions"
-          git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)" -a
-
-      - name: Push
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.MOABB_GHIO }}
-          repository: "NeuroTechX/moabb.github.io"
+          git add -A
+          git commit -m "GH Actions update of docs ($GITHUB_RUN_ID - $GITHUB_RUN_NUMBER)"
+          git push origin master
 
       # - name: Deploy on moabb.github.io
       #   run: |
@@ -90,7 +108,7 @@ jobs:
       #     git config --global user.email "ci@neurotechx.com"
       #     git config --global user.name "Github Actions"
       #     git clone git@github.com:NeuroTechX/moabb.github.io.git
-      #     cd moabb.github.io
+      #     cd ~/work/moabb/moabb/moabb-ghio
       #     rm -Rf docs
       #     cp -a ~/work/moabb/moabb/docs/build/html ./docs
       #     git add -A


### PR DESCRIPTION
The current doc generation creates a gh_pages branch for setting up a Github, but the actual setup rely on the https://github.com/NeuroTechX/moabb.github.io that serves the page from http://moabb.neurotechx.com/docs/index.html
Here is a tentative deploy on moabb.github.io:
- checkout NeuroTechX/moabb.github.io
- remove existing files and copy newly generated docs
- commit changes using a ssh authentication
