### PR TITLE
Accept licence term for downloading Shin2017 datasets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,19 +33,17 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Cache poetry, datasets and docs
-        id: cached-poetry-dataset-docs
+      - name: Cache datasets and docs
+        id: cached-dataset-docs
         uses: actions/cache@v2
         with:
-          key:
-            ${{ runner.os }}-${{ hashFiles('moabb/datasets/**', '**/poetry.lock') }}-doc
+          key: doc-${{ github.head_ref }}-${{ hashFiles('moabb/datasets/**') }}
           path: |
             ~/mne_data
-            .venv
             docs/build
 
       - name: Install dependencies
-        if: steps.cached-poetry-dataset-docs.outputs.cache-hit != 'true'
+        if: steps.cached-dataset-docs.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root -E external
 
       - name: Install library
@@ -71,15 +69,19 @@ jobs:
         os: [ubuntu-18.04]
 
     steps:
-      - name: Cache poetry, datasets and docs
-        id: cached-poetry-dataset-docs
+      - uses: actions/checkout@v2
+
+      - name: Create local data folder
+        run: |
+          mkdir ~/mne_data
+
+      - name: Cache datasets and docs
+        id: cached-dataset-docs
         uses: actions/cache@v2
         with:
-          key:
-            ${{ runner.os }}-${{ hashFiles('moabb/datasets/**', '**/poetry.lock') }}-doc
+          key: doc-${{ github.head_ref }}-${{ hashFiles('moabb/datasets/**') }}
           path: |
             ~/mne_data
-            .venv
             docs/build
 
       - name: Checkout moabb.github.io

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -33,14 +33,16 @@ Enhancements
 - Use MNE epoch in evaluation (:gh:`192` by `Sylvain Chevallier`_)
 - Allow changing of storage location (:gh:`192` by `Divyesh Narayanan`_ and `Sylvain Chevallier`_)
 - Deploy docs on moabb.github.io (:gh:`196` by `Sylvain Chevallier`_)
-- Broadening subject_list type  (:gh:`198` by `Sylvain Chevallier`_)
-
+- Broadening subject_list type for :func:`moabb.datasets.BaseDataset` (:gh:`198` by `Sylvain Chevallier`_)
+- Adding this what's new (:gh:`200` by `Sylvain Chevallier`_)
+- Improving cache usage and save computation time in CI (:gh:`200` by `Sylvain Chevallier`_)
 
 
 Bugs
 ~~~~
 - Restore basic logging (:gh:`177` by `Jan Sosulski`_)
 - Correct wrong type of results dataframe columns (:gh:`188` by `Sylvain Chevallier`_)
+- Add ``accept`` arg to acknowledge licence for :func:`moabb.datasets.Shin2017A` and :func:`moabb.datasets.Shin2017B` (:gh:`201` by `Sylvain Chevallier`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -3,6 +3,7 @@ Base class for a dataset
 """
 import abc
 import logging
+from inspect import signature
 
 
 log = logging.getLogger(__name__)
@@ -120,6 +121,7 @@ class BaseDataset(metaclass=abc.ABCMeta):
         path=None,
         force_update=False,
         update_path=None,
+        accept=False,
         verbose=None,
     ):
         """Download all data from the dataset.
@@ -144,6 +146,8 @@ class BaseDataset(metaclass=abc.ABCMeta):
         update_path : bool | None
             If True, set the MNE_DATASETS_(dataset)_PATH in mne-python
             config to the given path. If None, the user is prompted.
+        accept: bool
+            Accept licence term to download the data, if any. Default: False
         verbose : bool, str, int, or None
             If not None, override default verbose level
             (see :func:`mne.verbose`).
@@ -151,13 +155,25 @@ class BaseDataset(metaclass=abc.ABCMeta):
         if subject_list is None:
             subject_list = self.subject_list
         for subject in subject_list:
-            self.data_path(
-                subject=subject,
-                path=path,
-                force_update=force_update,
-                update_path=update_path,
-                verbose=verbose,
-            )
+            # check if accept is needed
+            sig = signature(self.data_path)
+            if "accept" in [str(p) for p in sig.parameters]:
+                self.data_path(
+                    subject=subject,
+                    path=path,
+                    force_update=force_update,
+                    update_path=update_path,
+                    verbose=verbose,
+                    accept=accept,
+                )
+            else:
+                self.data_path(
+                    subject=subject,
+                    path=path,
+                    force_update=force_update,
+                    update_path=update_path,
+                    verbose=verbose,
+                )
 
     @abc.abstractmethod
     def _get_single_subject_data(self, subject):

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -89,6 +89,7 @@ class Shin2017(BaseDataset):
 
         self.motor_imagery = motor_imagery
         self.mental_arithmetic = mental_arithmetic
+        self.accept = accept
 
         super().__init__(
             subjects=list(range(1, 30)),
@@ -107,6 +108,11 @@ class Shin2017(BaseDataset):
 
     def _get_single_subject_data(self, subject):
         """return data for a single subject"""
+        if not self.accept:
+            raise AttributeError(
+                "You must accept licence term to download this dataset,"
+                "set accept=True when instanciating the dataset."
+            )
         fname, fname_mrk = self.data_path(subject)
         data = loadmat(fname, squeeze_me=True, struct_as_record=False)["cnt"]
         mrk = loadmat(fname_mrk, squeeze_me=True, struct_as_record=False)["mrk"]

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -266,8 +266,10 @@ class Shin2017A(Shin2017):
            `<https://www.gnu.org/licenses/gpl-3.0.txt>`_
     """
 
-    def __init__(self):
-        super().__init__(fnirs=False, motor_imagery=True, mental_arithmetic=False)
+    def __init__(self, accept=False):
+        super().__init__(
+            fnirs=False, motor_imagery=True, mental_arithmetic=False, accept=accept
+        )
         self.code = "Shin2017A"
 
 
@@ -366,6 +368,8 @@ class Shin2017B(Shin2017):
            `<https://www.gnu.org/licenses/gpl-3.0.txt>`_
     """
 
-    def __init__(self):
-        super().__init__(fnirs=False, motor_imagery=False, mental_arithmetic=True)
+    def __init__(self, accept=False):
+        super().__init__(
+            fnirs=False, motor_imagery=False, mental_arithmetic=True, accept=accept
+        )
         self.code = "Shin2017B"

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -65,7 +65,9 @@ def fnirs_data_path(path, subject):
 class Shin2017(BaseDataset):
     """Not to be used."""
 
-    def __init__(self, fnirs=False, motor_imagery=True, mental_arithmetic=False):
+    def __init__(
+        self, fnirs=False, motor_imagery=True, mental_arithmetic=False, accept=False
+    ):
         if not any([motor_imagery, mental_arithmetic]):
             raise (
                 ValueError(
@@ -162,6 +164,9 @@ class Shin2017A(Shin2017):
 
     Dataset from [1]_.
 
+    You should accept the licence term [2]_ to download this dataset, using::
+        Shin2017A(accept=True)
+
     **Data Acquisition**
 
     EEG and NIRS data was collected in an ordinary bright room. EEG data was
@@ -251,7 +256,8 @@ class Shin2017A(Shin2017):
            Hwang, H.J. and Müller, K.R., 2017. Open access dataset for EEG+NIRS
            single-trial classification. IEEE Transactions on Neural Systems
            and Rehabilitation Engineering, 25(10), pp.1735-1745.
-
+    .. [2] GNU General Public License, Version 3
+           `<https://www.gnu.org/licenses/gpl-3.0.txt>`_
     """
 
     def __init__(self):
@@ -263,6 +269,9 @@ class Shin2017B(Shin2017):
     """Mental Arithmetic Dataset from Shin et al 2017
 
     Dataset from [1]_.
+
+    You should accept the licence term [2]_ to download this dataset, using::
+        Shin2017A(accept=True)
 
     **Data Acquisition**
 
@@ -347,6 +356,8 @@ class Shin2017B(Shin2017):
            Hwang, H.J. and Müller, K.R., 2017. Open access dataset for EEG+NIRS
            single-trial classification. IEEE Transactions on Neural Systems
            and Rehabilitation Engineering, 25(10), pp.1735-1745.
+    .. [2] GNU General Public License, Version 3
+           `<https://www.gnu.org/licenses/gpl-3.0.txt>`_
     """
 
     def __init__(self):

--- a/moabb/datasets/utils.py
+++ b/moabb/datasets/utils.py
@@ -149,4 +149,4 @@ def _download_all(update_path=True, verbose=None):
     # iterate over dataset
     for ds in dataset_list:
         # call download
-        ds().download(update_path=True, verbose=verbose)
+        ds().download(update_path=True, verbose=verbose, accept=True)

--- a/moabb/tests/datasets.py
+++ b/moabb/tests/datasets.py
@@ -2,10 +2,14 @@ import unittest
 
 import mne
 
+from moabb.datasets import Shin2017A, Shin2017B
 from moabb.datasets.fake import FakeDataset
 
 
 _ = mne.set_log_level("CRITICAL")
+
+# List of dataset that requires to accept licence term:
+dataset_w_accept = [Shin2017A(), Shin2017B()]
 
 
 def _run_tests_on_dataset(d):
@@ -58,3 +62,8 @@ class Test_Datasets(unittest.TestCase):
 
             # bad subject id must raise error
             self.assertRaises(ValueError, ds.get_data, [1000])
+
+    def test_dataset_accept(self):
+        """verify that accept licence is working"""
+        for ds in dataset_w_accept:
+            self.assertRaises(AttributeError, ds.get_data, [1])


### PR DESCRIPTION
Closes #80 

Downloading Shin2017 datasets require to accept a licence term. Following MNE, I added `accept` keyword that is set to false by default. An exception is raised when trying to download the datasets without set `accept=True`.

To avoid an issue in _download_all(), I added the accept parameter in BaseDataset.download(), passing it to data_path only if existing.