### PR TITLE
Remove update_path from data_dl

### DIFF
--- a/moabb/__init__.py
+++ b/moabb/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from moabb.utils import set_log_level

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -126,9 +126,7 @@ class Lee2019_MI(BaseDataset):
             url = "{0}session{1}/s{2}/sess{1:02d}_subj{2:02d}_EEG_MI.mat".format(
                 Lee2019_URL, session, subject
             )
-            data_path = dl.data_dl(
-                url, "Lee2019_MI", path, force_update, update_path, verbose
-            )
+            data_path = dl.data_dl(url, "Lee2019_MI", path, force_update, verbose)
             subject_paths.append(data_path)
 
         return subject_paths

--- a/moabb/datasets/Zhou2016.py
+++ b/moabb/datasets/Zhou2016.py
@@ -9,7 +9,7 @@ import zipfile as z
 
 import numpy as np
 from mne.channels import make_standard_montage
-from mne.datasets.utils import _do_path_update, _get_path
+from mne.datasets.utils import _get_path
 from mne.io import read_raw_cnt
 from pooch import retrieve
 
@@ -116,7 +116,6 @@ class Zhou2016(BaseDataset):
             raise (ValueError("Invalid subject number"))
         key = "MNE_DATASETS_ZHOU2016_PATH"
         path = _get_path(path, key, "Zhou 2016")
-        _do_path_update(path, True, key, "Zhou 2016")
         basepath = os.path.join(path, "MNE-zhou-2016")
         if not os.path.isdir(basepath):
             os.makedirs(basepath)

--- a/moabb/datasets/alex_mi.py
+++ b/moabb/datasets/alex_mi.py
@@ -59,4 +59,4 @@ class AlexMI(BaseDataset):
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
         url = "{:s}subject{:d}.raw.fif".format(ALEX_URL, subject)
-        return dl.data_dl(url, "ALEXEEG", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "ALEXEEG", path, force_update, verbose)

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -216,7 +216,7 @@ class BaseDataset(metaclass=abc.ABCMeta):
             will be automatically downloaded to the specified folder.
         force_update : bool
             Force update of the dataset even if a local copy exists.
-        update_path : bool | None
+        update_path : bool | None **Deprecated**
             If True, set the MNE_DATASETS_(dataset)_PATH in mne-python
             config to the given path. If None, the user is prompted.
         verbose : bool, str, int, or None

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -9,7 +9,7 @@ import zipfile as z
 import numpy as np
 from mne import create_info
 from mne.channels import make_standard_montage
-from mne.datasets.utils import _do_path_update, _get_path
+from mne.datasets.utils import _get_path
 from mne.io import RawArray
 from mne.utils import _fetch_file
 from scipy.io import loadmat
@@ -168,8 +168,6 @@ class Shin2017(BaseDataset):
 
         key = "MNE_DATASETS_BBCIFNIRS_PATH"
         path = _get_path(path, key, "BBCI EEG-fNIRS")
-        # FIXME: this always update the path
-        _do_path_update(path, True, key, "BBCI EEG-fNIRS")
         if not op.isdir(op.join(path, "MNE-eegfnirs-data")):
             os.makedirs(op.join(path, "MNE-eegfnirs-data"))
         if self.fnirs:

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -127,4 +127,4 @@ class Cho2017(BaseDataset):
             raise (ValueError("Invalid subject number"))
 
         url = "{:s}s{:02d}.mat".format(GIGA_URL, subject)
-        return dl.data_dl(url, "GIGADB", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "GIGADB", path, force_update, verbose)

--- a/moabb/datasets/mpi_mi.py
+++ b/moabb/datasets/mpi_mi.py
@@ -87,8 +87,8 @@ class MunichMI(BaseDataset):
 
         # download .set
         _set = "{:s}subject{:d}.set".format(DOWNLOAD_URL, subject)
-        set_local = dl.data_dl(_set, "MUNICHMI", path, force_update, update_path, verbose)
+        set_local = dl.data_dl(_set, "MUNICHMI", path, force_update, verbose)
         # download .fdt
         _fdt = "{:s}subject{:d}.fdt".format(DOWNLOAD_URL, subject)
-        dl.data_dl(_fdt, "MUNICHMI", path, force_update, update_path, verbose)
+        dl.data_dl(_fdt, "MUNICHMI", path, force_update, verbose)
         return set_local

--- a/moabb/datasets/schirrmeister2017.py
+++ b/moabb/datasets/schirrmeister2017.py
@@ -80,9 +80,7 @@ class Schirrmeister2017(BaseDataset):
             return "/".join([GIN_URL, prefix, "{:d}.mat".format(subject)])
 
         return [
-            dl.data_dl(
-                _url(t), "SCHIRRMEISTER2017", path, force_update, update_path, verbose
-            )
+            dl.data_dl(_url(t), "SCHIRRMEISTER2017", path, force_update, verbose)
             for t in ["train", "test"]
         ]
 

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -167,8 +167,6 @@ class BaseMAMEM(BaseDataset):
         for f in fsn.keys():
             if f[2:4] == sub:
                 spath.append(gb.fetch(fsn[f]))
-
-        # _do_path_update(path, update_path, key, sign)
         return spath
 
 

--- a/moabb/datasets/ssvep_nakanishi.py
+++ b/moabb/datasets/ssvep_nakanishi.py
@@ -97,4 +97,4 @@ class Nakanishi2015(BaseDataset):
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
         url = "{:s}s{:d}.mat".format(NAKAHISHI_URL, subject)
-        return dl.data_dl(url, "NAKANISHI", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "NAKANISHI", path, force_update, verbose)

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -148,4 +148,4 @@ class Wang2016(BaseDataset):
         if subject not in self.subject_list:
             raise (ValueError("Invalid subject number"))
         url = "{:s}S{:d}.mat".format(WANG_URL, subject)
-        return dl.data_dl(url, "WANG", path, force_update, update_path, verbose)
+        return dl.data_dl(url, "WANG", path, force_update, verbose)

--- a/moabb/datasets/upper_limb.py
+++ b/moabb/datasets/upper_limb.py
@@ -149,7 +149,7 @@ class Ofner2017(BaseDataset):
                 url = (
                     f"{UPPER_LIMB_URL}motor{session}_subject{subject}" + f"_run{run}.gdf"
                 )
-                p = dl.data_dl(url, "UPPERLIMB", path, force_update, update_path, verbose)
+                p = dl.data_dl(url, "UPPERLIMB", path, force_update, verbose)
                 paths.append(p)
 
         return paths

--- a/moabb/tests/download.py
+++ b/moabb/tests/download.py
@@ -1,6 +1,13 @@
 """
 Tests to ensure that datasets download correctly
 """
+import unittest
+
+import mne
+
+from moabb.datasets.bbci_eeg_fnirs import Shin2017
+
+
 # from moabb.datasets.gigadb import Cho2017
 # from moabb.datasets.alex_mi import AlexMI
 # from moabb.datasets.physionet_mi import PhysionetMI
@@ -23,10 +30,6 @@ Tests to ensure that datasets download correctly
 # from moabb.datasets.ssvep_nakanishi import Nakanishi2015
 # from moabb.datasets.ssvep_wang import Wang2016
 
-import unittest
-
-import mne
-
 
 class Test_Downloads(unittest.TestCase):
     def run_dataset(self, dataset, subj=(0, 2)):
@@ -38,7 +41,10 @@ class Test_Downloads(unittest.TestCase):
                 events, _ = mne.events_from_annotations(raw, verbose=False)
             return events
 
-        obj = dataset()
+        if isinstance(dataset(), Shin2017):
+            obj = dataset(accept=True)
+        else:
+            obj = dataset()
         obj.subject_list = obj.subject_list[subj[0] : subj[1]]
         data = obj.get_data(obj.subject_list)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "moabb"
-version = "0.4.0"
+version = "0.4.1"
 description = "Mother of All BCI Benchmarks"
 authors = ["Alexandre Barachant", "Vinay Jayaram"]
 maintainers = ["Sylvain Chevallier <sylvain.chevallier@uvsq.fr>"]


### PR DESCRIPTION
In PR #195 we removed the `update_path` from `moabb.datasets.download.data_dl()`, and deprecated it for `moabb.datasets.download.data_path`. Not all datasets were updated accordingly. This patch correct this error.

I'll make a revision bump from 0.4.0 to 0.4.1 to correct this, as this is a major issue is MOABB does not work to download some datasets.

Closes #206