### PR TITLE
Hotfix: correct error when downloading Weibo

### DIFF
--- a/moabb/__init__.py
+++ b/moabb/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from moabb.utils import set_log_level

--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -32,7 +32,7 @@ def eeg_data_path(base_path, subject):
     def get_subjects(sub_inds, sub_names, ind):
         dataname = "data{}".format(ind)
         if not os.path.isfile(os.path.join(base_path, dataname + ".zip")):
-            retrieve(FILES[ind], dataname + ".zip", base_path, processor=Unzip())
+            retrieve(FILES[ind], None, dataname + ".zip", base_path, processor=Unzip())
 
         for fname in os.listdir(os.path.join(base_path, dataname + ".zip.unzip")):
             for ind, prefix in zip(sub_inds, sub_names):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "moabb"
-version = "0.4.1"
+version = "0.4.2"
 description = "Mother of All BCI Benchmarks"
 authors = ["Alexandre Barachant", "Vinay Jayaram"]
 maintainers = ["Sylvain Chevallier <sylvain.chevallier@uvsq.fr>"]


### PR DESCRIPTION
Closes #211 

The error comes from the pooch retrieve call that is incorrect.

I'll push a patch version on pypi