### PR TITLE
Ensure consistent channel order in paradigm

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -24,12 +24,12 @@ Enhancements
 
 - Avoid information leakage for MNE Epochs pipelines in evaluation (:gh:`222` by `Sylvain Chevallier`_)
 - Correct error in set_download_dir (:gh:`225` by `Sylvain Chevallier`_)
-- Ensure that channel order is consistent across dataset when channel argument is specified in paradigm (:gh:`227` by `Sylvain Chevallier`_)
+- Ensure that channel order is consistent across dataset when channel argument is specified in paradigm (:gh:`229` by `Sylvain Chevallier`_)
 
 API changes
 ~~~~~~~~~~~
 
-- ch_names argument added to init of moabb.datasets.fake.FakeDataset (:gh:`227` by `Sylvain Chevallier`_)
+- ch_names argument added to init of moabb.datasets.fake.FakeDataset (:gh:`229` by `Sylvain Chevallier`_)
 
 Version - 0.4.2 (Stable - PyPi)
 ---------------

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -24,11 +24,12 @@ Enhancements
 
 - Avoid information leakage for MNE Epochs pipelines in evaluation (:gh:`222` by `Sylvain Chevallier`_)
 - Correct error in set_download_dir (:gh:`225` by `Sylvain Chevallier`_)
+- Ensure that channel order is consistent across dataset when channel argument is specified in paradigm (:gh:`227` by `Sylvain Chevallier`_)
 
 API changes
 ~~~~~~~~~~~
 
-- None
+- ch_names argument added to init of moabb.datasets.fake.FakeDataset (:gh:`227` by `Sylvain Chevallier`_)
 
 Version - 0.4.2 (Stable - PyPi)
 ---------------

--- a/moabb/datasets/fake.py
+++ b/moabb/datasets/fake.py
@@ -20,9 +20,11 @@ class FakeDataset(BaseDataset):
         n_runs=2,
         n_subjects=10,
         paradigm="imagery",
+        channels=("C3", "Cz", "C4"),
     ):
         self.n_runs = n_runs
         event_id = {ev: ii + 1 for ii, ev in enumerate(event_list)}
+        self.channels = channels
         super().__init__(
             list(range(1, n_subjects + 1)),
             n_sessions,
@@ -42,21 +44,18 @@ class FakeDataset(BaseDataset):
         return data
 
     def _generate_raw(self):
-
-        ch_names = ["C3", "Cz", "C4"]
-
         montage = make_standard_montage("standard_1005")
         sfreq = 128
         duration = len(self.event_id) * 60
-        eeg_data = 2e-5 * np.random.randn(duration * sfreq, len(ch_names))
+        eeg_data = 2e-5 * np.random.randn(duration * sfreq, len(self.channels))
         y = np.zeros((duration * sfreq))
         for ii, ev in enumerate(self.event_id):
             start_idx = (1 + 5 * ii) * 128
             jump = 5 * len(self.event_id) * 128
             y[start_idx::jump] = self.event_id[ev]
 
-        ch_types = ["eeg"] * len(ch_names) + ["stim"]
-        ch_names = ch_names + ["stim"]
+        ch_types = ["eeg"] * len(self.channels) + ["stim"]
+        ch_names = list(self.channels) + ["stim"]
 
         eeg_data = np.c_[eeg_data, y]
 

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -118,7 +118,9 @@ class BaseParadigm(metaclass=ABCMeta):
         if self.channels is None:
             picks = mne.pick_types(raw.info, eeg=True, stim=False)
         else:
-            picks = mne.pick_types(raw.info, stim=False, include=self.channels)
+            picks = mne.pick_channels(
+                raw.info["ch_names"], include=self.channels, ordered=True
+            )
 
         # pick events, based on event_id
         try:

--- a/moabb/paradigms/p300.py
+++ b/moabb/paradigms/p300.py
@@ -106,10 +106,15 @@ class BaseP300(BaseParadigm):
         else:
             events, _ = mne.events_from_annotations(raw, verbose=False)
 
-        channels = () if self.channels is None else self.channels
-
         # picks channels
+        channels = () if self.channels is None else self.channels
         picks = mne.pick_types(raw.info, eeg=True, stim=False, include=channels)
+        if self.channels is None:
+            picks = mne.pick_types(raw.info, eeg=True, stim=False)
+        else:
+            picks = mne.pick_channels(
+                raw.info["ch_names"], include=channels, ordered=True
+            )
 
         # get event id
         event_id = self.used_events(dataset)

--- a/moabb/tests/paradigms.py
+++ b/moabb/tests/paradigms.py
@@ -51,6 +51,16 @@ class Test_MotorImagery(unittest.TestCase):
         epochs, _, _ = paradigm.get_data(dataset, subjects=[1], return_epochs=True)
         self.assertIsInstance(epochs, BaseEpochs)
 
+    def test_BaseImagery_channel_order(self):
+        """test if paradigm return correct channel order, see issue #227"""
+        datasetA = FakeDataset(paradigm="imagery", channels=["C3", "Cz", "C4"])
+        datasetB = FakeDataset(paradigm="imagery", channels=["Cz", "C4", "C3"])
+        paradigm = SimpleMotorImagery(channels=["C4", "C3", "Cz"])
+
+        ep1, _, _ = paradigm.get_data(datasetA, subjects=[1], return_epochs=True)
+        ep2, _, _ = paradigm.get_data(datasetB, subjects=[1], return_epochs=True)
+        self.assertEqual(ep1.info["ch_names"], ep2.info["ch_names"])
+
     def test_BaseImagery_tmintmax(self):
         self.assertRaises(ValueError, SimpleMotorImagery, tmin=1, tmax=0)
 
@@ -169,8 +179,23 @@ class Test_P300(unittest.TestCase):
         epochs, _, _ = paradigm.get_data(dataset, subjects=[1], return_epochs=True)
         self.assertIsInstance(epochs, BaseEpochs)
 
-    def test_BaseImagery_tmintmax(self):
-        self.assertRaises(ValueError, SimpleMotorImagery, tmin=1, tmax=0)
+    def test_BaseP300_channel_order(self):
+        """test if paradigm return correct channel order, see issue #227"""
+        datasetA = FakeDataset(
+            paradigm="p300",
+            channels=["C3", "Cz", "C4"],
+            event_list=["Target", "NonTarget"],
+        )
+        datasetB = FakeDataset(
+            paradigm="p300",
+            channels=["Cz", "C4", "C3"],
+            event_list=["Target", "NonTarget"],
+        )
+        paradigm = SimpleP300(channels=["C4", "C3", "Cz"])
+
+        ep1, _, _ = paradigm.get_data(datasetA, subjects=[1], return_epochs=True)
+        ep2, _, _ = paradigm.get_data(datasetB, subjects=[1], return_epochs=True)
+        self.assertEqual(ep1.info["ch_names"], ep2.info["ch_names"])
 
     def test_BaseP300_tmintmax(self):
         self.assertRaises(ValueError, SimpleP300, tmin=1, tmax=0)
@@ -246,6 +271,16 @@ class Test_SSVEP(unittest.TestCase):
         # should return epochs
         epochs, _, _ = paradigm.get_data(dataset, subjects=[1], return_epochs=True)
         self.assertIsInstance(epochs, BaseEpochs)
+
+    def test_BaseSSVEP_channel_order(self):
+        """test if paradigm return correct channel order, see issue #227"""
+        datasetA = FakeDataset(paradigm="ssvep", channels=["C3", "Cz", "C4"])
+        datasetB = FakeDataset(paradigm="ssvep", channels=["Cz", "C4", "C3"])
+        paradigm = BaseSSVEP(channels=["C4", "C3", "Cz"])
+
+        ep1, _, _ = paradigm.get_data(datasetA, subjects=[1], return_epochs=True)
+        ep2, _, _ = paradigm.get_data(datasetB, subjects=[1], return_epochs=True)
+        self.assertEqual(ep1.info["ch_names"], ep2.info["ch_names"])
 
     def test_baseSSVEP_tmintmax(self):
         # Verify that tmin < tmax


### PR DESCRIPTION
Channel order could vary depending on the datasets when the channel include list is specified to paradigm.
This PR ensure the behavior is consistent across channel.

To update unit tests, I added a `channels` parameter to `FakeDataset`.
This closes #227 