### PR TITLE
Add TRCA algorithm 

### DIFF
--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -28,7 +28,7 @@ import moabb
 from moabb.datasets import SSVEPExo
 from moabb.evaluations import CrossSubjectEvaluation
 from moabb.paradigms import SSVEP, FilterBankSSVEP
-from moabb.pipelines import SSVEP_CCA, ExtendedSSVEPSignal
+from moabb.pipelines import SSVEP_CCA, SSVEP_TRCA, ExtendedSSVEPSignal
 
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
@@ -55,15 +55,17 @@ interval = dataset.interval
 # Choose paradigm
 # ---------------
 #
-# We define the paradigms (SSVEP and FilterBankSSVEP) and use the dataset
+# We define the paradigms (SSVEP, SSSVEP_TRCA and FilterBankSSVEP) and use the dataset
 # SSVEPExo. The SSVEP paradigm applied a bandpass filter (10-25 Hz) on
-# the data while the FilterBankSSVEP paradigm uses as many bandpass filters as
+# the data, SSVEP_TRCA applied a bandpass filter (1-110 Hz) which correspond to almost 
+# no filtering, while the FilterBankSSVEP paradigm uses as many bandpass filters as
 # there are stimulation frequencies (here 2). For each stimulation frequency
 # the EEG is filtered with a 1 Hz-wide bandpass filter centered on the
 # frequency. This results in ``n_classes`` copies of the signal, filtered for each
 # class, as used in filterbank motor imagery paradigms.
 
 paradigm = SSVEP(fmin=10, fmax=25, n_classes=3)
+paradigm_TRCA = SSVEP(fmin=1, fmax=110, n_classes=3)
 paradigm_fb = FilterBankSSVEP(filters=None, n_classes=3)
 
 ###############################################################################
@@ -83,6 +85,7 @@ freqs = paradigm.used_events(dataset)
 # covariance matrices from the signal filtered around the considered
 # frequency and applying a logistic regression in the tangent plane.
 # The second pipeline relies on the above defined CCA classifier.
+# The third pipeline relies on TRCA algorithm.
 
 pipelines_fb = {}
 pipelines_fb["RG+LogReg"] = make_pipeline(
@@ -94,6 +97,9 @@ pipelines_fb["RG+LogReg"] = make_pipeline(
 
 pipelines = {}
 pipelines["CCA"] = make_pipeline(SSVEP_CCA(interval=interval, freqs=freqs, n_harmonics=3))
+
+pipelines_TRCA = {}
+pipelines_TRCA["TRCA"] = make_pipeline(SSVEP_TRCA(interval=interval, freqs=freqs, n_fbands=5))
 
 ##############################################################################
 # Evaluation
@@ -123,9 +129,17 @@ evaluation_fb = CrossSubjectEvaluation(
 results_fb = evaluation_fb.process(pipelines_fb)
 
 ###############################################################################
-# After processing the two, we simply concatenate the results.
+# TRCA processing also relies on filter bank that is automatically designed.
 
-results = pd.concat([results, results_fb])
+evaluation_TRCA = CrossSubjectEvaluation(
+    paradigm=paradigm_TRCA, datasets=dataset, overwrite=overwrite
+)
+results_TRCA = evaluation_TRCA.process(pipelines_TRCA)
+
+###############################################################################
+# After processing the three, we simply concatenate the results.
+
+results = pd.concat([results, results_fb, results_TRCA])
 
 ##############################################################################
 # Plot Results

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -57,7 +57,7 @@ interval = dataset.interval
 #
 # We define the paradigms (SSVEP, SSSVEP_TRCA and FilterBankSSVEP) and use the dataset
 # SSVEPExo. The SSVEP paradigm applied a bandpass filter (10-25 Hz) on
-# the data, SSVEP_TRCA applied a bandpass filter (1-110 Hz) which correspond to almost 
+# the data, SSVEP_TRCA applied a bandpass filter (1-110 Hz) which correspond to almost
 # no filtering, while the FilterBankSSVEP paradigm uses as many bandpass filters as
 # there are stimulation frequencies (here 2). For each stimulation frequency
 # the EEG is filtered with a 1 Hz-wide bandpass filter centered on the
@@ -99,7 +99,9 @@ pipelines = {}
 pipelines["CCA"] = make_pipeline(SSVEP_CCA(interval=interval, freqs=freqs, n_harmonics=3))
 
 pipelines_TRCA = {}
-pipelines_TRCA["TRCA"] = make_pipeline(SSVEP_TRCA(interval=interval, freqs=freqs, n_fbands=5))
+pipelines_TRCA["TRCA"] = make_pipeline(
+    SSVEP_TRCA(interval=interval, freqs=freqs, n_fbands=5)
+)
 
 ##############################################################################
 # Evaluation

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -146,8 +146,8 @@ class Results:
                     dset["id"][-1, :] = np.asarray([str(d["subject"]), str(d["session"])])
                     try:
                         add_cols = [d[ac] for ac in self.additional_columns]
-                    except KeyError:
-                        raise ValueError(
+                    except KeyError as ke:
+                        raise ValueError from ke(
                             f"Additional columns: {self.additional_columns} "
                             f"were specified in the evaluation, but results"
                             f" contain only these keys: {d.keys()}."

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -62,8 +62,8 @@ class BaseDataset(metaclass=abc.ABCMeta):
     ):
         try:
             _ = iter(subjects)
-        except TypeError:
-            raise (ValueError("subjects must be a iterable, like a list"))
+        except TypeError as te:
+            raise (ValueError("subjects must be a iterable, like a list")) from te
 
         self.subject_list = subjects
         self.n_sessions = sessions_per_subject

--- a/moabb/pipelines/__init__.py
+++ b/moabb/pipelines/__init__.py
@@ -4,6 +4,6 @@ Pipelines are typically a chain of sklearn compatible transformers and end
 with an sklearn compatible estimator.
 """
 # flake8: noqa
-from .classification import SSVEP_CCA
+from .classification import SSVEP_CCA, SSVEP_TRCA
 from .features import FM, ExtendedSSVEPSignal, LogVariance
 from .utils import FilterBank, create_pipeline_from_config

--- a/moabb/pipelines/classification.py
+++ b/moabb/pipelines/classification.py
@@ -1,6 +1,14 @@
 import numpy as np
+import scipy.linalg as linalg
+
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.cross_decomposition import CCA
+from sklearn.utils.validation import check_is_fitted
+
+from pyriemann.estimation import Covariances
+from pyriemann.utils.mean import mean_covariance
+
+from .utils import schaefer_strimmer_cov, filterbank 
 
 
 class SSVEP_CCA(BaseEstimator, ClassifierMixin):
@@ -74,3 +82,447 @@ class SSVEP_CCA(BaseEstimator, ClassifierMixin):
                     S_x, S_y = self.cca.fit_transform(x.T, self.Yf[f].T)
                     P[i, j] = np.corrcoef(S_x.T, S_y.T)[0, 1]
         return P / np.resize(P.sum(axis=1), P.T.shape).T
+
+
+class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
+    """Classifier based on the Task-Related Component Analysis method [1] for SSVEP. 
+
+    Parameters
+    ----------
+
+    sfreq : float
+        Sampling frequency of the data to be analyzed.
+
+    freqs : dict with n_classes keys
+        Frequencies corresponding to the SSVEP components. These are
+        necessary to design the filterbank bands.
+
+    n_fbands : int, default=5
+        Number of sub-bands considered for filterbank analysis.
+
+    downsample: int, default=1
+        Factor by which downsample the data. A downsample value of N will result
+        on a sampling frequency of (sfreq // N) by taking one sample every N of
+        the original data. In the original TRCA paper [1] data are at 250Hz.
+
+    is_ensemble: bool, default=False
+        If True, predict on new data using the Ensemble-TRCA method described
+        in [1].
+
+    method: str, default='original'
+        'original' computes euclidean mean for S as in the original paper [1].
+        'riemann' variation computes geodesic mean instead. This geodesic
+        mean is more robust to outlier but negatively impacted by ill-conditioned
+        matrices (when only few samples are availble for training for instance).
+        'riemann' variation is then usefull when lots of noisy training data are
+        available.
+
+    regul : str
+        For both methods, regularization to use for covariance matrices estimations.
+        Consider 'schaefer', 'lwf', 'oas' or 'scm' for no regularization.
+        In the original implementation from TRCA paper [1], no regularization
+        is used. So method='original' and regul='scm' is similar to original
+        implementation.
+
+
+    Attributes
+    ----------
+
+    fb_coefs : list of len (n_fb)
+        Alpha coefficients for the fusion of the filterbank sub-bands.
+
+    classes_ : ndarray of shape (n_class,)
+        Array with the class labels extracted at fit time.
+
+    n_class : int
+        Number of unique labels/classes.
+
+    templates_ : ndarray of shape (n_class, n_bands, n_channels, n_samples)
+        Template data obtained by averaging all training trials for a given
+        class. Each class templates is divided in n_fbands sub-bands extracted
+        from the filterbank approach.
+
+    weights_ : ndarray of shape (n_fbands, n_class, n_channels)
+        Weight coefficients for the different electrodes which are used
+        as spatial filters for the data.
+
+    Reference
+    ----------
+
+    [1] - M. Nakanishi, Y. Wang, X. Chen, Y. -T. Wang, X. Gao, and T.-P. Jung,
+          "Enhancing detection of SSVEPs for a high-speed brain speller using 
+          task-related component analysis",
+          IEEE Trans. Biomed. Eng, 65(1):104-112, 2018.
+    
+    Code based on the Matlab implementation from authors of [1]
+    (https://github.com/mnakanishi/TRCA-SSVEP). 
+
+    """
+
+    def __init__(
+        self,
+        interval,
+        freqs,
+        n_fbands=5,
+        downsample=1,
+        is_ensemble=True,
+        method="original",
+        regul="scm",
+        ):
+        self.freqs = freqs
+        self.peaks = np.array([float(f) for f in freqs.keys()])
+        self.n_fbands = n_fbands
+        self.downsample = downsample
+        self.interval = interval
+        self.slen = interval[1] - interval[0]
+        self.is_ensemble = is_ensemble
+        self.fb_coefs = [(x + 1) ** (-1.25) + 0.25 for x in range(self.n_fbands)]
+        if regul == "schaefer":
+            self.regul = schaefer_strimmer_cov
+        else:
+            self.regul = regul
+        self.method = method
+        
+
+    def _compute_trca(self, data):
+        """Computation of TRCA spatial filters.
+
+        Parameters
+        ----------
+
+        data: np.array, shape (trials, channels, samples)
+            Training data
+
+        Returns
+        -------
+
+        W: np.array, shape (channels)
+            Weight coefficients for electrodes which can be used as
+            a spatial filter.
+        """
+
+        # Check if X is a single trial (test data) or not
+        if data.ndim == 2:
+            data = data[np.newaxis, ...]
+
+        # Get data shape
+        n_trials, n_channels, n_samples = data.shape
+
+        X = np.concatenate((data, data), axis=1)
+
+        if self.method == "original":
+            # Initialize S matrix
+            S = np.zeros((n_channels, n_channels))
+
+            # Estimate covariance between every trial and the rest of the trials (excluding itself)
+            for trial_i in range(n_trials - 1):
+                x1 = np.squeeze(data[trial_i, :, :])
+
+                # Mean centering for the selected trial
+                x1 -= np.mean(x1, 0)
+
+                # Select a second trial that is different
+                for trial_j in range(trial_i + 1, n_trials):
+                    x2 = np.squeeze(data[trial_j, :, :])
+
+                    # Mean centering for the selected trial
+                    x2 -= np.mean(x2, 0)
+
+                    # # Put the two trials together
+                    X = np.concatenate((x1, x2))
+
+                    if n_channels == 1:
+                        X = X.reshape((n_channels, len(X)))
+
+                    # Regularized covariance estimate
+                    cov = Covariances(estimator=self.regul).fit_transform(
+                        X[np.newaxis, ...]
+                    )
+                    cov = np.squeeze(cov)
+
+                    # Compute empirical covariance betwwen the two selected trials and sum it
+                    if n_channels > 1:
+                        S = (
+                            S
+                            + cov[:n_channels, n_channels:]
+                            + cov[n_channels:, :n_channels]
+                        )
+
+                    else:
+                        S = S + cov + cov
+
+            # Concatenate all the trials
+            UX = np.zeros((n_channels, n_samples * n_trials))
+
+            for trial_n in range(n_trials):
+                UX[:, trial_n * n_samples : (trial_n + 1) * n_samples] = data[
+                    trial_n, :, :
+                ]
+
+            # Mean centering
+            UX -= np.mean(UX, 1)[:, None]
+            cov = Covariances(estimator=self.regul).fit_transform(UX[np.newaxis, ...])
+            Q = np.squeeze(cov)
+
+        elif self.method == "riemann":
+            # Concatenate all the trials
+            UX = np.zeros((n_channels, n_samples * n_trials))
+
+            for trial_n in range(n_trials):
+                UX[:, trial_n * n_samples : (trial_n + 1) * n_samples] = data[
+                    trial_n, :, :
+                ]
+
+            # Mean centering
+            UX -= np.mean(UX, 1)[:, None]
+
+            # Compute empirical variance of all data (to be bounded)
+            cov = Covariances(estimator=self.regul).fit_transform(UX[np.newaxis, ...])
+            Q = np.squeeze(cov)
+
+            cov = Covariances(estimator=self.regul).fit_transform(X)
+            S = cov[:, :n_channels, n_channels:] + cov[:, n_channels:, :n_channels]
+            try:
+                S = mean_covariance(S, metric="riemann")
+            except:
+                S = (
+                    cov[:, :n_channels, n_channels:]
+                    + cov[:, n_channels:, :n_channels]
+                    + 1e-10 * np.identity(n_channels)
+                )  # Add more regul
+                try:
+                    S = mean_covariance(S, metric="riemann")
+                except:
+                    S = (
+                        cov[:, :n_channels, n_channels:]
+                        + cov[:, n_channels:, :n_channels]
+                        + 1e-8 * np.identity(n_channels)
+                    )
+                    S = mean_covariance(S, metric="riemann")
+
+        else:
+            raise ValueError("Method should be either 'original' or 'riemann'.")
+
+        # Compute eigenvalues and vectors
+        lambdas, W = linalg.eig(S, Q, left=True, right=False)
+
+        # Sort eigenvectors by eigenvalue
+        arr1inds = lambdas.argsort()
+        W = W[:, arr1inds[::-1]]
+
+        return W[:, 0], W
+
+    def fit(self, X, y):
+        """Extract spatial filters and templates from the given calibration data.
+
+        Parameters
+        ----------
+
+        X : ndarray of shape (n_trials, n_channels, n_samples)
+            Training data. Trials are grouped by class, divided in n_fbands bands by
+            the filterbank approach and then used to calculate weight vectors and
+            templates for each class and band.
+
+        y : ndarray of shape (n_trials,)
+            Label vector in respect to X.
+
+        Returns
+        -------
+
+        self: CCA object
+            Instance of classifier.
+        """
+        # Downsample data
+        X = X[:, :, :: self.downsample]
+
+        # Get shape of X and labels
+        n_trials, n_channels, n_samples = X.shape
+
+        self.sfreq = int(n_samples / self.slen)
+        self.sfreq = self.sfreq / self.downsample
+
+        self.classes_ = np.unique(y)
+        self.n_class = len(self.classes_)
+
+        # Initialize the final arrays
+        self.templates_ = np.zeros((self.n_class, self.n_fbands, n_channels, n_samples))
+        self.weights_ = np.zeros((self.n_fbands, self.n_class, n_channels))
+
+        for class_idx in self.classes_:
+            cal_data = X[y == class_idx]  # Select data with a specific label
+            # Filterbank approach
+            for band_n in range(self.n_fbands):
+                # Filter the data and compute TRCA
+                filter_data = filterbank(cal_data, self.sfreq, band_n, self.peaks)
+                w_best, _ = self._compute_trca(filter_data)
+
+                # Get template by averaging trials and take the best filter for this band
+                self.templates_[class_idx, band_n, :, :] = np.mean(filter_data, axis=0)
+                self.weights_[band_n, class_idx, :] = w_best
+
+        return self
+
+    def predict(self, X):
+        """Make predictions on unseen data. 
+        
+        The new data observation X will be filtered
+        with weights previously extracted and compared to the templates to assess
+        similarity with each of them and select a class based on the maximal value.
+
+        Parameters
+        ----------
+
+        X : ndarray of shape (n_trials, n_channels, n_samples)
+            Testing data. This will be divided in self.n_fbands using the filter- bank approach,
+            then it will be transformed by the different spatial filters and compared to the
+            previously fit templates according to the selected method for analysis (ensemble or
+            not). Finally, correlation scores for all sub-bands of each class will be combined,
+            resulting on a single correlation score per class, from which the maximal one is
+            identified as the predicted class of the data.
+
+        Returns
+        -------
+
+        y_pred : ndarray of shape (n_trials,)
+            Prediction vector in respect to X.
+        """
+
+        # Check is fit had been called
+        check_is_fitted(self)
+
+        # Check if X is a single trial or not
+        if X.ndim == 2:
+            X = X[np.newaxis, ...]
+
+        # Downsample data
+        X = X[:, :, :: self.downsample]
+
+        # Get test data shape
+        n_trials, _, _ = X.shape
+
+        # Initialize pred array
+        y_pred = []
+
+        for trial_n in range(n_trials):
+            # Pick trial
+            test_data = X[trial_n, :, :]
+
+            # Initialize correlations array
+            corr_array = np.zeros((self.n_fbands, self.n_class))
+
+            # Filter the data in the corresponding band
+            for band_n in range(self.n_fbands):
+                filter_data = filterbank(test_data, self.sfreq, band_n, self.peaks)
+
+                # Compute correlation with all the templates and bands
+                for class_idx in range(self.n_class):
+                    # Get the corresponding template
+                    template = np.squeeze(self.templates_[class_idx, band_n, :, :])
+
+                    if self.is_ensemble:
+                        w = np.squeeze(
+                            self.weights_[band_n, :, :]
+                        ).T  # (n_class, n_channel)
+                    else:
+                        w = np.squeeze(
+                            self.weights_[band_n, class_idx, :]
+                        ).T  # (n_channel,)
+
+                    # Compute 2D correlation of spatially filtered testdata with ref
+                    r = np.corrcoef(
+                        np.dot(filter_data.T, w).flatten(),
+                        np.dot(template.T, w).flatten(),
+                    )
+                    corr_array[band_n, class_idx] = r[0, 1]
+
+            # Fusion for the filterbank analysis
+            rho = np.dot(self.fb_coefs, corr_array)
+
+            # Select the maximal value and append to preddictions
+            tau = np.argmax(rho)
+            y_pred.append(tau)
+
+        return y_pred
+
+
+    def predict_proba(self, X):
+        """Make predictions on unseen data with the asociated probabilities. 
+        
+        The new data observation X will be filtered
+        with weights previously extracted and compared to the templates to assess
+        similarity with each of them and select a class based on the maximal value.
+
+        Parameters
+        ----------
+
+        X : ndarray of shape (n_trials, n_channels, n_samples)
+            Testing data. This will be divided in self.n_fbands using the filter- bank approach,
+            then it will be transformed by the different spatial filters and compared to the
+            previously fit templates according to the selected method for analysis (ensemble or
+            not). Finally, correlation scores for all sub-bands of each class will be combined,
+            resulting on a single correlation score per class, from which the maximal one is
+            identified as the predicted class of the data.
+
+        Returns
+        -------
+
+        y_pred : ndarray of shape (n_trials,)
+            Prediction vector in respect to X.
+        """
+
+        # Check is fit had been called
+        check_is_fitted(self)
+
+        # Check if X is a single trial or not
+        if X.ndim == 2:
+            X = X[np.newaxis, ...]
+
+        # Downsample data
+        X = X[:, :, :: self.downsample]
+
+        # Get test data shape
+        n_trials, _, _ = X.shape
+
+        # Initialize pred array
+        y_pred = np.zeros((n_trials, len(self.peaks)))
+
+        for trial_n in range(n_trials):
+            # Pick trial
+            test_data = X[trial_n, :, :]
+
+            # Initialize correlations array
+            corr_array = np.zeros((self.n_fbands, self.n_class))
+
+            # Filter the data in the corresponding band
+            for band_n in range(self.n_fbands):
+                filter_data = filterbank(test_data, self.sfreq, band_n, self.peaks)
+
+                # Compute correlation with all the templates and bands
+                for class_idx in range(self.n_class):
+                    # Get the corresponding template
+                    template = np.squeeze(self.templates_[class_idx, band_n, :, :])
+
+                    if self.is_ensemble:
+                        w = np.squeeze(
+                            self.weights_[band_n, :, :]
+                        ).T  # (n_class, n_channel)
+                    else:
+                        w = np.squeeze(
+                            self.weights_[band_n, class_idx, :]
+                        ).T  # (n_channel,)
+
+                    # Compute 2D correlation of spatially filtered testdata with ref
+                    r = np.corrcoef(
+                        np.dot(filter_data.T, w).flatten(),
+                        np.dot(template.T, w).flatten(),
+                    )
+                    corr_array[band_n, class_idx] = r[0, 1]
+
+            normalized_coefs = self.fb_coefs / (np.sum(self.fb_coefs))
+            # Fusion for the filterbank analysis
+            rho = np.dot(normalized_coefs, corr_array)
+
+            rho /= sum(rho)
+            y_pred[trial_n] = rho
+
+        return y_pred

--- a/moabb/pipelines/classification.py
+++ b/moabb/pipelines/classification.py
@@ -1,14 +1,12 @@
 import numpy as np
 import scipy.linalg as linalg
-
+from pyriemann.estimation import Covariances
+from pyriemann.utils.mean import mean_covariance
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.cross_decomposition import CCA
 from sklearn.utils.validation import check_is_fitted
 
-from pyriemann.estimation import Covariances
-from pyriemann.utils.mean import mean_covariance
-
-from .utils import schaefer_strimmer_cov, filterbank 
+from .utils import filterbank, schaefer_strimmer_cov
 
 
 class SSVEP_CCA(BaseEstimator, ClassifierMixin):
@@ -85,7 +83,7 @@ class SSVEP_CCA(BaseEstimator, ClassifierMixin):
 
 
 class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
-    """Classifier based on the Task-Related Component Analysis method [1] for SSVEP. 
+    """Classifier based on the Task-Related Component Analysis method [1] for SSVEP.
 
     Parameters
     ----------
@@ -150,12 +148,12 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
     ----------
 
     [1] - M. Nakanishi, Y. Wang, X. Chen, Y. -T. Wang, X. Gao, and T.-P. Jung,
-          "Enhancing detection of SSVEPs for a high-speed brain speller using 
+          "Enhancing detection of SSVEPs for a high-speed brain speller using
           task-related component analysis",
           IEEE Trans. Biomed. Eng, 65(1):104-112, 2018.
-    
+
     Code based on the Matlab implementation from authors of [1]
-    (https://github.com/mnakanishi/TRCA-SSVEP). 
+    (https://github.com/mnakanishi/TRCA-SSVEP).
 
     """
 
@@ -168,7 +166,7 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
         is_ensemble=True,
         method="original",
         regul="scm",
-        ):
+    ):
         self.freqs = freqs
         self.peaks = np.array([float(f) for f in freqs.keys()])
         self.n_fbands = n_fbands
@@ -182,7 +180,6 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
         else:
             self.regul = regul
         self.method = method
-        
 
     def _compute_trca(self, data):
         """Computation of TRCA spatial filters.
@@ -363,8 +360,8 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
-        """Make predictions on unseen data. 
-        
+        """Make predictions on unseen data.
+
         The new data observation X will be filtered
         with weights previously extracted and compared to the templates to assess
         similarity with each of them and select a class based on the maximal value.
@@ -444,10 +441,9 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
 
         return y_pred
 
-
     def predict_proba(self, X):
-        """Make predictions on unseen data with the asociated probabilities. 
-        
+        """Make predictions on unseen data with the asociated probabilities.
+
         The new data observation X will be filtered
         with weights previously extracted and compared to the templates to assess
         similarity with each of them and select a class based on the maximal value.

--- a/moabb/pipelines/utils.py
+++ b/moabb/pipelines/utils.py
@@ -181,6 +181,7 @@ def filterbank(data, sfreq, idx_fb, peaks):
     diff = max_freq - min_freq
     # Lowcut frequencies for the pass band (depends on the frequencies of SSVEP)
     # No more than 3dB loss in the passband
+
     passband = [min_freq - 2 + x * diff for x in range(7)]
 
     # At least 40db attenuation in the stopband
@@ -197,7 +198,7 @@ def filterbank(data, sfreq, idx_fb, peaks):
 
     N, Wn = scp.cheb1ord(Wp, Ws, 3, 40)  # Chebyshev type I filter order selection.
 
-    B, A = scp.cheby1(N, 0.5, Wn, btype="bandpass")  #  Chebyshev type I filter design
+    B, A = scp.cheby1(N, 0.5, Wn, btype="bandpass")  # Chebyshev type I filter design
 
     y = np.zeros(data.shape)
     if num_trials == 1:  # For testdata

--- a/moabb/pipelines/utils.py
+++ b/moabb/pipelines/utils.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.pipeline import make_pipeline
+import scipy.signal as scp
 
 
 def create_pipeline_from_config(config):
@@ -87,3 +88,147 @@ class FilterBank(BaseEstimator, TransformerMixin):
         return "{}(estimator={}, flatten={})".format(
             estimator_name, estimator_prms, self.flatten
         )
+
+def schaefer_strimmer_cov(X):
+    """Schaefer-Strimmer covariance estimator
+    Shrinkage estimator using method from [1]:
+    .. math::
+            \hat{\Sigma} = (1 - \gamma)\Sigma_{scm} + \gamma T
+    where :math:`T` is the diagonal target matrix:
+    .. math::
+            T_{i,j} = \{ \Sigma_{scm}^{ii} \text{if} i = j, 0 \text{otherwise} \}
+    Note that the optimal :math:`\gamma` is estimate by the authors' method.
+    :param X: Signal matrix, Nchannels X Nsamples
+    :returns: Schaefer-Strimmer shrinkage covariance matrix, Nchannels X Nchannels
+    References
+    ----------
+    [1] Schafer, J., and K. Strimmer. 2005. A shrinkage approach to
+    large-scale covariance estimation and implications for functional
+    genomics. Statist. Appl. Genet. Mol. Biol. 4:32.
+    http://doi.org/10.2202/1544-6115.1175
+    """
+    _, Ns = X.shape[0], X.shape[1]
+    C_scm = np.cov(X, ddof=0)
+    X_c = X - np.tile(X.mean(axis=1), [Ns, 1]).T
+
+    # Compute optimal gamma, the weigthing between SCM and srinkage estimator
+    R = Ns / (Ns - 1.0) * np.corrcoef(X)
+    var_R = (X_c ** 2).dot((X_c ** 2).T) - 2 * C_scm * X_c.dot(X_c.T) + Ns * C_scm ** 2
+    var_R = Ns / ((Ns - 1) ** 3 * np.outer(X.var(axis=1), X.var(axis=1))) * var_R
+    R -= np.diag(np.diag(R))
+    var_R -= np.diag(np.diag(var_R))
+    gamma = max(0, min(1, var_R.sum() / (R ** 2).sum()))
+
+    return (1.0 - gamma) * (Ns / (Ns - 1.0)) * C_scm + gamma * (
+        Ns / (Ns - 1.0)
+    ) * np.diag(np.diag(C_scm))
+
+
+def filterbank(data, sfreq, idx_fb, peaks):
+    """
+    Filter bank design for decomposing EEG data into sub-band components [1]
+
+    Parameters
+    ----------
+
+    data: np.array, shape (trials, channels, samples) or (channels, samples)
+        EEG data to be processed
+
+    sfreq: int
+        Sampling frequency of the data.
+
+    idx_fb: int
+        Index of filters in filter bank analysis
+
+    peaks : list of len (n_classes)
+        Frequencies corresponding to the SSVEP components.
+
+    Returns
+    -------
+
+    y: np.array, shape (trials, channels, samples)
+        Sub-band components decomposed by a filter bank
+
+    Reference:
+      [1] M. Nakanishi, Y. Wang, X. Chen, Y. -T. Wang, X. Gao, and T.-P. Jung,
+          "Enhancing detection of SSVEPs for a high-speed brain speller using
+           task-related component analysis",
+          IEEE Trans. Biomed. Eng, 65(1):104-112, 2018.
+
+    Code based on the Matlab implementation from authors of [1]
+    (https://github.com/mnakanishi/TRCA-SSVEP).
+    """
+
+    # Calibration data comes in batches of trials
+    if data.ndim == 3:
+        num_chans = data.shape[1]
+        num_trials = data.shape[0]
+
+    # Testdata come with only one trial at the time
+    elif data.ndim == 2:
+        num_chans = data.shape[0]
+        num_trials = 1
+
+    sfreq = sfreq / 2
+
+    min_freq = np.min(peaks)
+    max_freq = np.max(peaks)
+
+    if max_freq < 40:
+        top = 90
+    else:
+        top = 115
+    # Check for Nyquist
+    if top >= sfreq:
+        top = sfreq - 10
+
+    diff = max_freq - min_freq
+    # Lowcut frequencies for the pass band (depends on the frequencies of SSVEP)
+    # No more than 3dB loss in the passband
+    passband = [min_freq - 2 + x * diff for x in range(7)]
+
+
+    # At least 40db attenuation in the stopband
+    if min_freq - 4 > 0:
+        stopband = [
+            min_freq - 4 + x * (diff - 2) if x < 3 else min_freq - 4 + x * diff
+            for x in range(7)
+        ]
+    else:
+        stopband = [2 + x * (diff - 2) if x < 3 else 2 + x * diff for x in range(7)]
+
+    Wp = [passband[idx_fb] / sfreq, top / sfreq]
+    Ws = [stopband[idx_fb] / sfreq, (top + 5) / sfreq]
+
+    N, Wn = scp.cheb1ord(Wp, Ws, 3, 40)  # Chebyshev type I filter order selection.
+
+    B, A = scp.cheby1(N, 0.5, Wn, btype="bandpass")  #  Chebyshev type I filter design
+
+    y = np.zeros(data.shape)
+    if num_trials == 1:  # For testdata
+        for ch_i in range(num_chans):
+            try:
+                # The arguments 'axis=0, padtype='odd', padlen=3*(max(len(B),len(A))-1)' correspond
+                # to Matlab filtfilt (https://dsp.stackexchange.com/a/47945)
+                y[ch_i, :] = scp.filtfilt(
+                    B,
+                    A,
+                    data[ch_i, :],
+                    axis=0,
+                    padtype="odd",
+                    padlen=3 * (max(len(B), len(A)) - 1),
+                )
+            except:
+                print(num_chans)
+    else:
+        for trial_i in range(num_trials):  # Filter each trial sequentially
+            for ch_i in range(num_chans):  # Filter each channel sequentially
+                y[trial_i, ch_i, :] = scp.filtfilt(
+                    B,
+                    A,
+                    data[trial_i, ch_i, :],
+                    axis=0,
+                    padtype="odd",
+                    padlen=3 * (max(len(B), len(A)) - 1),
+                )
+    return y

--- a/moabb/pipelines/utils.py
+++ b/moabb/pipelines/utils.py
@@ -175,7 +175,7 @@ def filterbank(data, sfreq, idx_fb, peaks):
     max_freq = np.max(peaks)
 
     if max_freq < 40:
-        top = 90
+        top = 100
     else:
         top = 115
     # Check for Nyquist
@@ -198,7 +198,7 @@ def filterbank(data, sfreq, idx_fb, peaks):
         stopband = [2 + x * (diff - 2) if x < 3 else 2 + x * diff for x in range(7)]
 
     Wp = [passband[idx_fb] / sfreq, top / sfreq]
-    Ws = [stopband[idx_fb] / sfreq, (top + 5) / sfreq]
+    Ws = [stopband[idx_fb] / sfreq, (top + 7) / sfreq]
 
     N, Wn = scp.cheb1ord(Wp, Ws, 3, 40)  # Chebyshev type I filter order selection.
 

--- a/moabb/pipelines/utils.py
+++ b/moabb/pipelines/utils.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 
 import numpy as np
+import scipy.signal as scp
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.pipeline import make_pipeline
-import scipy.signal as scp
 
 
 def create_pipeline_from_config(config):
@@ -89,15 +89,11 @@ class FilterBank(BaseEstimator, TransformerMixin):
             estimator_name, estimator_prms, self.flatten
         )
 
+
 def schaefer_strimmer_cov(X):
     """Schaefer-Strimmer covariance estimator
-    Shrinkage estimator using method from [1]:
-    .. math::
-            \hat{\Sigma} = (1 - \gamma)\Sigma_{scm} + \gamma T
-    where :math:`T` is the diagonal target matrix:
-    .. math::
-            T_{i,j} = \{ \Sigma_{scm}^{ii} \text{if} i = j, 0 \text{otherwise} \}
-    Note that the optimal :math:`\gamma` is estimate by the authors' method.
+    Shrinkage estimator using method from [1]
+    Note that the optimal :math:gamma is estimate by the authors' method.
     :param X: Signal matrix, Nchannels X Nsamples
     :returns: Schaefer-Strimmer shrinkage covariance matrix, Nchannels X Nchannels
     References
@@ -187,7 +183,6 @@ def filterbank(data, sfreq, idx_fb, peaks):
     # No more than 3dB loss in the passband
     passband = [min_freq - 2 + x * diff for x in range(7)]
 
-
     # At least 40db attenuation in the stopband
     if min_freq - 4 > 0:
         stopband = [
@@ -218,7 +213,8 @@ def filterbank(data, sfreq, idx_fb, peaks):
                     padtype="odd",
                     padlen=3 * (max(len(B), len(A)) - 1),
                 )
-            except:
+            except Exception as e:
+                print(e)
                 print(num_chans)
     else:
         for trial_i in range(num_trials):  # Filter each trial sequentially


### PR DESCRIPTION
Hello, 

I propose an implementation of TRCA algorithm from Nakanishi et al. ("Enhancing detection of SSVEPs for a high-speed brain speller using task-related component analysis". IEEE Trans. Biomed. Eng, 65(1):104-112, 2018). 
It also includes a variation with geodesic barycenter for S (inter-trial covariance matrices for samples of the same class, used for the spatial filters computation) instead of computing as originally an arithmetic mean of the inter-trial covariance matrices.
It also offers the possibility of regularized covariance estimation (from Pyriemann `Covariance`) instead of original scm estimator. 

I have added an example in `examples/plot_cross_subject_ssvep.py`. 

Though I have concern regarding the `filterbank` function I have added in  `moabb/pipelines/utils.py`. Indeed TRCA algorithm relies on filter bank approach. Though it is quite different as the filter bank implemented by the paradigm `FilterBankSSVEP`. The TRCA filters are large band and overlapping  (first filter includes SSVEP frequencies and harmonics, second only harmonic, third all harmonics except the frst one, etc..)  while `FilterBankSSVEP` are narrow-band and centered around SSVEP frenquency. 

Thus I don't know if it should be another fonction in `moabb/pipelines/utils.py` or if I should modify `FilterBankSSVEP`. 
It seems to me that it is not a different paradigm but only intern to the algorithm so I choose to change  `moabb/pipelines/utils.py` but I may be wrong.