### PR TITLE
Fix Schirrmeister2017 error

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -23,7 +23,7 @@ Enhancements
 Bugs
 ~~~~
 
-- None
+- Correcting events management in Schirrmeister2017, renaming session and run (:gh:`255` by `Pierre Guetschel`_ and `Sylvain Chevallier`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/datasets/schirrmeister2017.py
+++ b/moabb/datasets/schirrmeister2017.py
@@ -87,7 +87,7 @@ class Schirrmeister2017(BaseDataset):
     def _get_single_subject_data(self, subject):
         train, test = [BBCIDataset(path) for path in self.data_path(subject)]
         sessions = {}
-        sessions["session_1"] = {"train": train.load(), "test": test.load()}
+        sessions["session_0"] = {"run_0": train.load(), "run_1": test.load()}
         return sessions
 
 
@@ -252,5 +252,7 @@ class BBCIDataset(object):
             [0] * len(event_times_in_samples),
             event_classes,
         ]
-        cnt.info["events"] = np.array(event_arr).T
+        cnt.info["events"] = [
+            dict(list=np.array(event_arr).T, channels=None),
+        ]
         return cnt


### PR DESCRIPTION
Closes #153 

There is a problem when loading event in MNE object for Schirrmeister dataset. This has no impact on evaluation and score computed on the dataset.
This PR implements the fix proposed by @PierreGtch in #153 