### PR TITLE
Elicit warning if lambda functions are used

### DIFF
--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import os.path as osp
 import re
+import warnings
 from datetime import datetime
 
 import h5py
@@ -17,6 +18,15 @@ def get_string_rep(obj):
         str_repr = repr(obj.get_params())
     else:
         str_repr = repr(obj)
+    if "<lambda> at " in str_repr:
+        warnings.warn(
+            "You are probably using a classifier with a lambda function"
+            " as an attribute. Lambda functions can only be identified"
+            " by memory address which MOABB does not consider. To avoid"
+            " issues you can use named functions defined using the def"
+            " keyword instead.",
+            RuntimeWarning,
+        )
     str_no_addresses = re.sub("0x[a-z0-9]*", "0x__", str_repr)
     return str_no_addresses.replace("\n", "").encode("utf8")
 

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -2,6 +2,7 @@ import os
 import os.path as osp
 import unittest
 import warnings
+import platform
 from collections import OrderedDict
 
 import numpy as np

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -1,8 +1,8 @@
 import os
 import os.path as osp
+import platform
 import unittest
 import warnings
-import platform
 from collections import OrderedDict
 
 import numpy as np
@@ -205,7 +205,7 @@ class Test_LambdaWarning(Test_WithinSess):
 
         self.assertFalse(repr(c1) == repr(c2))
         with self.assertWarns(RuntimeWarning):
-            if platform.system() != 'Windows':
+            if platform.system() != "Windows":
                 self.assertTrue(get_string_rep(c1) == get_string_rep(c2))
 
         # I do not know an elegant way to check for no warnings

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -1,14 +1,17 @@
 import os
 import os.path as osp
 import unittest
+import warnings
 from collections import OrderedDict
 
 import numpy as np
+import sklearn.base
 from pyriemann.estimation import Covariances
 from pyriemann.spatialfilters import CSP
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 from sklearn.pipeline import make_pipeline
 
+from moabb.analysis.results import get_string_rep
 from moabb.datasets.fake import FakeDataset
 from moabb.evaluations import evaluations as ev
 from moabb.paradigms.motor_imagery import FakeImageryParadigm
@@ -19,6 +22,13 @@ pipelines["C"] = make_pipeline(Covariances("oas"), CSP(8), LDA())
 dataset = FakeDataset(["left_hand", "right_hand"], n_subjects=2)
 if not osp.isdir(osp.join(osp.expanduser("~"), "mne_data")):
     os.makedirs(osp.join(osp.expanduser("~"), "mne_data"))
+
+
+class DummyClassifier(sklearn.base.BaseEstimator):
+    __slots__ = "kernel"
+
+    def __init__(self, kernel):
+        self.kernel = kernel
 
 
 class Test_WithinSess(unittest.TestCase):
@@ -175,6 +185,31 @@ class Test_CrossSess(Test_WithinSess):
         # do not raise
         ds = FakeDataset(["left_hand", "right_hand"], n_sessions=2)
         self.assertTrue(self.eval.is_valid(dataset=ds))
+
+
+class Test_LambdaWarning(Test_WithinSess):
+    def setUp(self):
+        self.eval = ev.WithinSessionEvaluation(
+            paradigm=FakeImageryParadigm(), datasets=[dataset]
+        )
+
+    def test_lambda_warning(self):
+        def explicit_kernel(x):
+            return x ** 3
+
+        c1 = DummyClassifier(kernel=lambda x: x ** 2)
+        c2 = DummyClassifier(kernel=lambda x: 5 * x)
+
+        c3 = DummyClassifier(kernel=explicit_kernel)
+
+        self.assertFalse(repr(c1) == repr(c2))
+        with self.assertWarns(RuntimeWarning):
+            self.assertTrue(get_string_rep(c1) == get_string_rep(c2))
+
+        # I do not know an elegant way to check for no warnings
+        with warnings.catch_warnings(record=True) as w:
+            get_string_rep(c3)
+            self.assertTrue(len(w) == 0)
 
 
 if __name__ == "__main__":

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -205,7 +205,8 @@ class Test_LambdaWarning(Test_WithinSess):
 
         self.assertFalse(repr(c1) == repr(c2))
         with self.assertWarns(RuntimeWarning):
-            self.assertTrue(get_string_rep(c1) == get_string_rep(c2))
+            if platform.system() != 'Windows':
+                self.assertTrue(get_string_rep(c1) == get_string_rep(c2))
 
         # I do not know an elegant way to check for no warnings
         with warnings.catch_warnings(record=True) as w:

--- a/moabb/tests/evaluations.py
+++ b/moabb/tests/evaluations.py
@@ -204,8 +204,8 @@ class Test_LambdaWarning(Test_WithinSess):
         c3 = DummyClassifier(kernel=explicit_kernel)
 
         self.assertFalse(repr(c1) == repr(c2))
-        with self.assertWarns(RuntimeWarning):
-            if platform.system() != "Windows":
+        if platform.system() != "Windows":
+            with self.assertWarns(RuntimeWarning):
                 self.assertTrue(get_string_rep(c1) == get_string_rep(c2))
 
         # I do not know an elegant way to check for no warnings


### PR DESCRIPTION
This is a rebased version of #210 and closes #194 

Note that my last information was that this does not work on windows for some reason.