### PR TITLE
Correct Lee dataset loading

### DIFF
--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -150,16 +150,6 @@ class Lee2019(BaseDataset):
             stim_chan[:, None], ["STI 014"], "stim", sfreq, verbose="WARNING"
         )
 
-        # Add events
-        event_arr = [
-            event_times_in_samples,
-            [0] * len(event_times_in_samples),
-            event_id,
-        ]
-        raw.info["events"] = [
-            dict(list=np.array(event_arr).T, channels=None),
-        ]
-
         # Add EMG and stim channels
         raw = raw.add_channels([emg_raw, stim_raw])
         return raw


### PR DESCRIPTION
An error occurs when setting the events in paradigm for Lee SSVEP datasets for newer version of MNE (> 1.0.0).
This PR correct the error reported in #295 and does not generate an error with older version of MNE.

Closes #295