### PR TITLE
Hotfix _simplify_names

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,7 +72,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
     "gh_substitutions",
-    "m2r2",
+    #  "m2r2",
     "numpydoc",
 ]
 

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -26,6 +26,7 @@ Bugs
 - Correct CI error due to black (:gh:`292` by `Sylvain Chevallier`_)
 - Preload Schirrmeister2017 raw files (:gh:`290` by `Pierre Guetschel`_)
 - Incorrect event assignation for Lee2019 in MNE >= 1.0.0 (:gh:`298` by `Sylvain Chevallier`_)
+- Correct usage of name simplification function in analyze (:gh:`306` by `Divyesh Narayanan`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/analysis/plotting.py
+++ b/moabb/analysis/plotting.py
@@ -45,7 +45,12 @@ def score_plot(data, pipelines=None):
         Dictionary with the facecolor
     """
     data = collapse_session_scores(data)
-    data["dataset"] = data["dataset"].apply(_simplify_names)
+    unique_ids = data["dataset"].apply(_simplify_names)
+    if len(unique_ids) != len(set(unique_ids)):
+        log.warning("Dataset names are too similar, turning off name shortening")
+    else:
+        data["dataset"] = unique_ids
+
     if pipelines is not None:
         data = data[data.pipeline.isin(pipelines)]
     fig = plt.figure(figsize=(8.5, 11))
@@ -202,6 +207,11 @@ def meta_analysis_plot(stats_df, alg1, alg2):  # noqa: C901
     df_bk = stats_df.loc[(stats_df.pipe1 == alg2) & (stats_df.pipe2 == alg1)]
     df_bk = df_bk.sort_values(by="pipe1")
     dsets = df_fw.dataset.unique()
+    simplify = True
+    unique_ids = [_simplify_names(x) for x in dsets]
+    if len(unique_ids) != len(set(unique_ids)):
+        log.warning("Dataset names are too similar, turning off name shortening")
+        simplify = False
     ci = []
     fig = plt.figure()
     gs = gridspec.GridSpec(1, 5)
@@ -209,7 +219,10 @@ def meta_analysis_plot(stats_df, alg1, alg2):  # noqa: C901
     pvals = []
     ax = fig.add_subplot(gs[0, :-1])
     ax.set_yticks(np.arange(len(dsets) + 1))
-    ax.set_yticklabels(["Meta-effect"] + [_simplify_names(d) for d in dsets])
+    if simplify:
+        ax.set_yticklabels(["Meta-effect"] + [d for d in unique_ids])
+    else:
+        ax.set_yticklabels(["Meta-effect"] + [d for d in dsets])
     pval_ax = fig.add_subplot(gs[0, -1], sharey=ax)
     plt.setp(pval_ax.get_yticklabels(), visible=False)
     _min = 0

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -53,7 +53,7 @@ class SSVEPExo(BaseDataset):
             subjects=list(range(1, 13)),
             sessions_per_subject=1,
             events={"13": 2, "17": 3, "21": 4, "rest": 1},
-            code="SSVEP Exoskeleton",
+            code="Exoskeleton_SSVEP",
             interval=[2, 4],
             paradigm="ssvep",
             doi="10.1016/j.neucom.2016.01.007",

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -108,13 +108,13 @@ class BaseMAMEM(BaseDataset):
             if fnamed[4] == "x":
                 continue
             session_name = "session_0"
-            if self.code == "SSVEP MAMEM3":
+            if self.code == "MAMEM3_SSVEP":
                 repetition = len(fnamed) - 10
                 run_name = f"run_{(ord(fnamed[4])-97)*2 + repetition}"
             else:
                 run_name = f"run_{ord(fnamed[4])-97}"
 
-            if self.code == "SSVEP MAMEM3":
+            if self.code == "MAMEM3_SSVEP":
                 m = loadmat(fpath)
                 ch_names = [e[0] for e in m["info"][0, 0][9][0]]
                 sfreq = 128
@@ -125,7 +125,7 @@ class BaseMAMEM(BaseDataset):
                 ch_names = [f"E{i + 1}" for i in range(0, 256)]
                 ch_names.append("stim")
                 sfreq = 250
-                if self.code == "SSVEP MAMEM2":
+                if self.code == "MAMEM2_SSVEP":
                     labels = m["labels"]
                 else:
                     labels = None

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -150,7 +150,7 @@ class BaseMAMEM(BaseDataset):
             raise (ValueError("Invalid subject number"))
 
         sub = f"{subject:02d}"
-        sign = self.code.split()[1]
+        sign = self.code.split("_")[0]
         key_dest = f"MNE-{sign.lower():s}-data"
         path = osp.join(get_dataset_path(sign, path), key_dest)
 

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -271,7 +271,7 @@ class MAMEM1(BaseMAMEM):
             events={"6.66": 1, "7.50": 2, "8.57": 3, "10.00": 4, "12.00": 5},
             sessions_per_subject=1,
             # 5 runs per sessions, except 3 for S001, S003, S008, 4 for S004
-            code="SSVEP MAMEM1",
+            code="MAMEM1_SSVEP",
             doi="https://arxiv.org/abs/1602.00904",
             figshare_id=2068677,
         )
@@ -355,7 +355,7 @@ class MAMEM2(BaseMAMEM):
         super().__init__(
             events={"6.66": 1, "7.50": 2, "8.57": 3, "10.00": 4, "12.00": 5},
             sessions_per_subject=1,
-            code="SSVEP MAMEM2",
+            code="MAMEM2_SSVEP",
             doi="https://arxiv.org/abs/1602.00904",
             figshare_id=3153409,
         )
@@ -454,7 +454,7 @@ class MAMEM3(BaseMAMEM):
                 "12.00": 33025,
             },
             sessions_per_subject=1,
-            code="SSVEP MAMEM3",
+            code="MAMEM3_SSVEP",
             doi="https://arxiv.org/abs/1602.00904",
             figshare_id=3413851,
         )

--- a/moabb/datasets/ssvep_nakanishi.py
+++ b/moabb/datasets/ssvep_nakanishi.py
@@ -54,7 +54,7 @@ class Nakanishi2015(BaseDataset):
                 "12.75": 11,
                 "14.75": 12,
             },
-            code="SSVEP Nakanishi",
+            code="Nakanishi_SSVEP",
             interval=[0.15, 4.3],
             paradigm="ssvep",
             doi="doi.org/10.1371/journal.pone.0140703",

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -104,7 +104,7 @@ class Wang2016(BaseDataset):
             subjects=list(range(1, 35)),
             sessions_per_subject=1,
             events=self._events,
-            code="SSVEP Wang",
+            code="Wang_SSVEP",
             interval=[0.5, 5.5],
             paradigm="ssvep",
             doi="doi://10.1109/TNSRE.2016.2627556",


### PR DESCRIPTION
Found an issue where _simplify_names was being called on dataset names without checking for uniqueness.

- Adding checks of uniqueness for all uses of _simplify_names
- Slightly more standardized naming (code) of the SSVEP datasets