### PR TITLE
Adding Wiki Meta Information to the documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,8 +5,6 @@ on:
     branches: [master, develop]
   pull_request:
     branches: [master, develop]
-    paths:
-      - "docs/**"
 
 jobs:
   build_docs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ pull request to the master branch referencing the specific issue you addressed.
 ## Setup development environment
 
 1. install `poetry` (only once per machine):\
-   `curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -`\
+   `curl -sSL https://install.python-poetry.org | python3 -`\
    or [checkout installation instruction](https://python-poetry.org/docs/#installation) or
    use [conda forge version](https://anaconda.org/conda-forge/poetry)
 1. (Optional, skip if not sure) Disable automatic environment creation:\

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ one of the sections below, or just scroll down to find out more.
 - [Installation](#installation)
 - [Running](#running)
 - [Supported datasets](#supported-datasets)
-- [Who are we? n](#who-are-we)
+- [Who are we?](#who-are-we)
 - [Get in touch](#contact-us)
 - [Documentation][link_moabb_docs]
 - [Architecture and main concepts](#architecture-and-main-concepts)
@@ -87,7 +87,7 @@ See [Troubleshooting](#Troubleshooting) section if you have a problem.
 You could fork or clone the repository and go to the downloaded directory, then run:
 
 1. install `poetry` (only once per machine):\
-   `curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -`\
+   `curl -sSL https://install.python-poetry.org | python3 -`\
    or [checkout installation instruction](https://python-poetry.org/docs/#installation) or
    use [conda forge version](https://anaconda.org/conda-forge/poetry)
 1. (Optional, skip if not sure) Disable automatic environment creation:\

--- a/docs/source/CONTRIBUTING.md
+++ b/docs/source/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing
+
+Contributions are always welcome, no matter how small.
+
+The following is a small set of guidelines for how to contribute to the project
+
+## Where to start
+
+### Code of Conduct
+
+This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By
+participating you are expected to adhere to these expectations. Please report unacceptable
+behavior to [hi@pushtheworld.us](mailto:hi@pushtheworld.us)
+
+### Contributing on Github
+
+If you're new to Git and want to learn how to fork this repo, make your own additions, and
+include those additions in the master version of this project, check out this
+[great tutorial](http://blog.davidecoppola.com/2016/11/howto-contribute-to-open-source-project-on-github/).
+
+### Community
+
+This project is maintained by the [NeuroTechX](www.neurotechx.com) community. Join the
+[Gitter](https://gitter.im/moabb_dev/community), where discussions about MOABB takes
+place.
+
+## How can I contribute?
+
+If there's a feature you'd be interested in building or you find a bug or have a
+suggestion on how to improve the project, go ahead! Let us know on the
+[Gitter](https://gitter.im/moabb_dev/community) or [open an issue](../../issues) so others
+can follow along and we'll support you as much as we can. When you're finished submit a
+pull request to the master branch referencing the specific issue you addressed.
+
+### Steps to Contribute
+
+1. Look for open issues or open one
+1. Discuss the problem and or propose a solution
+1. Fork it! (and clone fork locally)
+1. Branch from `develop`: `git checkout --track develop`
+1. [Setup development environment](#setup-development-environment)
+1. Create your feature branch: `git checkout -b my-new-feature`
+1. Make changes
+1. Commit your changes: `git commit -m 'Add some feature'`
+1. Don't forget to fix issues from `pre-commit` pipeline (either add changes made by hooks
+   or fix them manually in case of `flake8`)
+1. Push to the branch: `git push origin my-new-feature`
+1. Submit a pull request. Make sure it is based on the `develop` branch when submitting!
+   :D
+1. Don't forget to update the
+   [what's new](http://moabb.neurotechx.com/docs/whats_new.html) and
+   [documentation](http://moabb.neurotechx.com/docs/index.html) pages if needed
+
+## Setup development environment
+
+1. install `poetry` (only once per machine):\
+   `curl -sSL https://install.python-poetry.org | python3 -`\
+   or [checkout installation instruction](https://python-poetry.org/docs/#installation) or
+   use [conda forge version](https://anaconda.org/conda-forge/poetry)
+1. (Optional, skip if not sure) Disable automatic environment creation:\
+   `poetry config virtualenvs.create false`
+1. install all dependencies in one command (have to be run in thibe project directory):\
+   `poetry install`
+1. install `pre-commit` hooks to git repo:\
+   `pre-commit install`
+1. you are ready to code!
+
+_Note 1:_\
+Your first commit will trigger `pre-commit` to download [Code Quality tools](#tools-used).
+That's OK and it is intended behavior. This will be done once per machine automatically.
+
+_Note 2:_\
+By default `poetry` creates separate Python virtual environment for every project ([more details in documentation](https://python-poetry.org/docs/managing-environments/)).
+If you use `conda` or any other way to manage different environments by hand - you need to
+disable `poetry` environment creation. Also in this case be careful with version of Python
+in your environment - it has to satisfy requirements stated in `pyproject.toml`. In case you
+disable `poetry` you are in charge of this.
+
+### Tools used
+
+MOABB uses [poetry](https://python-poetry.org/) for dependency management. This tool
+enables one to have a reproducible environment on all popular OS (Linux, MacOS and
+Windows) and provides easy publishing pipeline.
+
+Another tool that makes development more stable is [pre-commit](https://pre-commit.com/).
+It automatically runs variety of Code Quality instruments against the code you produced.
+
+For Code Quality verification, we use:
+
+- [black](https://github.com/psf/black) - Python code formatting
+- [isort](https://github.com/timothycrosley/isort) - imports sorting and grouping
+- [flake8](https://gitlab.com/pycqa/flake8) - code style checking
+- [prettier](https://github.com/prettier/prettier) - `.yml` and `.md` files formatting
+
+### Generate the documentation
+
+To generate a local version of the documentation:
+
+```
+cd docs
+make html
+```

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -85,7 +85,7 @@ See [Troubleshooting](#Troubleshooting) section if you have a problem.
 You could fork or clone the repository and go to the downloaded directory, then run:
 
 1. install `poetry` (only once per machine):\
-   `curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -`\
+   `curl -sSL https://install.python-poetry.org | python3 -`\
    or [checkout installation instruction](https://python-poetry.org/docs/#installation) or
    use [conda forge version](https://anaconda.org/conda-forge/poetry)
 1. (Optional, skip if not sure) Disable automatic environment creation:\

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,3 +3,4 @@
 .. include:: paradigms.rst
 .. include:: pipelines.rst
 .. include:: analysis.rst
+.. include:: utils.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -232,6 +232,7 @@ html_theme_options = {
     # an arbitrary url.
     "navbar_links": [
         ("What's new", "whats_new"),
+        ("Datasets", "dataset_summary"),
         ("API", "api"),
         ("Gallery", "auto_examples/index"),
         ("Tutorials", "auto_tutorials/index"),

--- a/docs/source/dataset_summary.rst
+++ b/docs/source/dataset_summary.rst
@@ -1,0 +1,56 @@
+MOABB gather many datasets, here is list summarizing important information. Most of the
+datasets are listed here but this list not complete yet, check API for complete
+documentation.
+
+Do not hesitate to help us complete this list. It is also possible to add new datasets,
+there is a tutorial explaining how to do so, and we welcome warmly any new contributions!
+
+See also https://github.com/NeuroTechX/moabb/wiki/Datasets-Support for supplementary
+detail on datasets (class name, size, licence, etc.)
+
+
+=================  =======  =======  ==========  =================  ============  ===============  ===========
+Motor Imagery        #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+=================  =======  =======  ==========  =================  ============  ===============  ===========
+AlexMI                   8       16           3                 20  3s            512Hz                      1
+BNCI2014001             10       22           4                144  4s            250Hz                      2
+BNCI2014002             15       15           2                 80  5s            512Hz                      1
+BNCI2014004             10        3           2                360  4.5s          250Hz                      5
+BNCI2015001             13       13           2                200  5s            512Hz                      2
+BNCI2015004             10       30           5                 80  7s            256Hz                      2
+Cho2017                 53       64           2                100  3s            512Hz                      1
+Lee2019_MI              55       62           2                100  4s            1000Hz                     2
+MunichMI                10      128           2                150  7s            500Hz                      1
+Schirrmeister2017       14      128           4                120  4s            500Hz                      1
+Ofner2017               15       61           7                 60  3s            512Hz                      1
+PhysionetMI            109       64           4                 23  3s            160Hz                      1
+Shin2017A               29       30           2                 30  10s           200Hz                      3
+Shin2017B               29       30           2                 30  10s           200Hz                      3
+Weibo2014               10       60           7                 80  4s            200Hz                      1
+Zhou2016                 4       14           3                160  5s            250Hz                      3
+=================  =======  =======  ==========  =================  ============  ===============  ===========
+
+
+===========  =======  =======  =================  ===============  ===============  ===========
+P300           #Subj    #Chan  #Trials / class    Trials length    Sampling rate      #Sessions
+===========  =======  =======  =================  ===============  ===============  ===========
+BNCI2014008        8        8  3500 NT / 700 T    1s               256Hz                      1
+BNCI2014009       10       16  1440 NT / 288 T    0.8s             256Hz                      3
+BNCI2015003       10        8  1500 NT / 300 T    0.8s             256Hz                      1
+bi2013a           24       16  3200 NT / 640 T    1s               512Hz                      8
+EPFLP300           8       32  2753 NT / 551 T    1s               2048Hz                     4
+Lee2019_ERP       54       62  6900 NT / 1380 T   1s               1000Hz                     2
+===========  =======  =======  =================  ===============  ===============  ===========
+
+
+=============  =======  =======  ==========  =================  ===============  ===============  ===========
+SSVEP            #Subj    #Chan    #Classes    #Trials / class  Trials length    Sampling rate      #Sessions
+=============  =======  =======  ==========  =================  ===============  ===============  ===========
+Lee2019_SSVEP       24       16           4                 25  1s               1000Hz                     1
+SSVEPExo            12        8           4                 16  2s               256Hz                      1
+MAMEM1              10      256           5  12-15              3s               250Hz                      1
+MAMEM2              10      256           5  20-30              3s               250Hz                      1
+MAMEM3              10       14           4  20-30              3s               128Hz                      1
+Nakanishi2015        9        8          12                 15  4.15s            256Hz                      1
+Wang2016            32       62          40                  6  5s               250Hz                      1
+=============  =======  =======  ==========  =================  ===============  ===============  ===========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,5 @@
 .. mdinclude:: README.md
+.. mdinclude:: CONTRIBUTING.md
 
 What's new
 ==========

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,0 +1,27 @@
+=====
+Utils
+=====
+
+.. automodule:: moabb
+
+.. currentmodule:: moabb
+
+---------
+Benchmark
+---------
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    benchmark
+
+-----
+Utils
+-----
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    set_log_level

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -12,7 +12,7 @@ Benchmark
 
 .. autosummary::
     :toctree: generated/
-    :template: class.rst
+    :template: function.rst
 
     benchmark
 
@@ -22,6 +22,6 @@ Utils
 
 .. autosummary::
     :toctree: generated/
-    :template: class.rst
+    :template: function.rst
 
     set_log_level

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -18,7 +18,9 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Switch to python-3.8, update dependencies, fix code link in doc, add `code coverage <https://app.codecov.io/gh/NeuroTechX/moabb>`__ (:gh:`315` by `Sylvain Chevallier`_)
 - Adding a comprehensive benchmarking function (:gh:`264` by `Divyesh Narayanan`_ and `Sylvain Chevallier`_)
+- Add meta-information for datasets in documentation (:gh:`317` by `Bruno Aristimunha`_)
 
 Bugs
 ~~~~
@@ -27,6 +29,7 @@ Bugs
 - Preload Schirrmeister2017 raw files (:gh:`290` by `Pierre Guetschel`_)
 - Incorrect event assignation for Lee2019 in MNE >= 1.0.0 (:gh:`298` by `Sylvain Chevallier`_)
 - Correct usage of name simplification function in analyze (:gh:`306` by `Divyesh Narayanan`_)
+- Fix downloading path issue for Weibo2014 and Zhou2016, numy error in DemonsP300 (:gh:`315` by `Sylvain Chevallier`_)
 
 API changes
 ~~~~~~~~~~~
@@ -270,6 +273,7 @@ API changes
 
 
 
+.. _Bruno Aristimunha: https://github.com/bruAristimunha
 .. _Alexandre Barachant: https://github.com/alexandrebarachant
 .. _Quentin Barthelemy: https://github.com/qbarthelemy
 .. _Erik Bjäreholt: https://github.com/ErikBjare

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -389,6 +389,15 @@ class Lee2019_ERP(Lee2019):
 class Lee2019_SSVEP(Lee2019):
     """BMI/OpenBMI dataset for SSVEP.
 
+    .. note:: Meta-information about the dataset
+
+
+        =============  =======  =======  ==========  =================  ===============  ===============  ===========
+        Name             #Subj    #Chan    #Classes    #Trials / class  Trials length    Sampling rate      #Sessions
+        =============  =======  =======  ==========  =================  ===============  ===============  ===========
+        Lee2019_SSVEP       24       16           4                 25  1s               1000Hz                     1
+        =============  =======  =======  ==========  =================  ===============  ===============  ===========
+
     Dataset from Lee et al 2019 [1]_.
 
     **Dataset Description**

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -299,6 +299,15 @@ class Lee2019_MI(Lee2019):
 class Lee2019_ERP(Lee2019):
     """BMI/OpenBMI dataset for P300.
 
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        Name           #Subj    #Chan  #Trials / class    Trials length    Sampling rate      #Sessions
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        Lee2019_ERP       54       62  6900 NT / 1380 T   1s               1000Hz                     2
+        ===========  =======  =======  =================  ===============  ===============  ===========
+
     Dataset from Lee et al 2019 [1]_.
 
     **Dataset Description**

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -229,6 +229,15 @@ class Lee2019(BaseDataset):
 class Lee2019_MI(Lee2019):
     """BMI/OpenBMI dataset for MI.
 
+    .. note:: Meta-information about the dataset
+
+
+        ==========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name          #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ==========  =======  =======  ==========  =================  ============  ===============  ===========
+        Lee2019_MI       55       62           2                100  4s            1000Hz                     2
+        ==========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset from Lee et al 2019 [1]_.
 
     **Dataset Description**

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -229,7 +229,7 @@ class Lee2019(BaseDataset):
 class Lee2019_MI(Lee2019):
     """BMI/OpenBMI dataset for MI.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ==========  =======  =======  ==========  =================  ============  ===============  ===========
@@ -299,7 +299,7 @@ class Lee2019_MI(Lee2019):
 class Lee2019_ERP(Lee2019):
     """BMI/OpenBMI dataset for P300.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  =================  ===============  ===============  ===========
@@ -389,7 +389,7 @@ class Lee2019_ERP(Lee2019):
 class Lee2019_SSVEP(Lee2019):
     """BMI/OpenBMI dataset for SSVEP.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =============  =======  =======  ==========  =================  ===============  ===============  ===========

--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -64,7 +64,7 @@ def eeg_data_path(base_path, subject):
 class Weibo2014(BaseDataset):
     """Motor Imagery dataset from Weibo et al 2014.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =========  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -64,6 +64,15 @@ def eeg_data_path(base_path, subject):
 class Weibo2014(BaseDataset):
     """Motor Imagery dataset from Weibo et al 2014.
 
+    .. note:: Meta-information about the dataset
+
+
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name         #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Weibo2014       10       60           7                 80  4s            200Hz                      1
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset from the article *Evaluation of EEG oscillatory patterns and
     cognitive process during simple and compound limb motor imagery* [1]_.
 

--- a/moabb/datasets/Zhou2016.py
+++ b/moabb/datasets/Zhou2016.py
@@ -50,6 +50,15 @@ def local_data_path(base_path, subject):
 class Zhou2016(BaseDataset):
     """Motor Imagery dataset from Zhou et al 2016.
 
+    .. note:: Meta-information about the dataset
+
+
+        ========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name        #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ========  =======  =======  ==========  =================  ============  ===============  ===========
+        Zhou2016        4       14           3                160  5s            250Hz                      3
+        ========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset from the article *A Fully Automated Trial Selection Method for
     Optimization of Motor Imagery Based Brain-Computer Interface* [1]_.
     This dataset contains data recorded on 4 subjects performing 3 type of

--- a/moabb/datasets/Zhou2016.py
+++ b/moabb/datasets/Zhou2016.py
@@ -50,7 +50,7 @@ def local_data_path(base_path, subject):
 class Zhou2016(BaseDataset):
     """Motor Imagery dataset from Zhou et al 2016.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ========  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/alex_mi.py
+++ b/moabb/datasets/alex_mi.py
@@ -14,7 +14,7 @@ ALEX_URL = "https://zenodo.org/record/806023/files/"
 class AlexMI(BaseDataset):
     """Alex Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ======  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/alex_mi.py
+++ b/moabb/datasets/alex_mi.py
@@ -14,6 +14,15 @@ ALEX_URL = "https://zenodo.org/record/806023/files/"
 class AlexMI(BaseDataset):
     """Alex Motor Imagery dataset.
 
+    .. note:: Meta-information about the dataset
+
+
+        ======  =======  =======  ==========  =================  ============  ===============  ===========
+        Name      #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ======  =======  =======  ==========  =================  ============  ===============  ===========
+        AlexMI        8       16           3                 20  3s            512Hz                      1
+        ======  =======  =======  ==========  =================  ============  ===============  ===========
+
     Motor imagery dataset from the PhD dissertation of A. Barachant [1]_.
 
     This Dataset contains EEG recordings from 8 subjects, performing 2 task of

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -185,7 +185,7 @@ class Shin2017(BaseDataset):
 class Shin2017A(Shin2017):
     """Motor Imagey Dataset from Shin et al 2017
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =========  =======  =======  ==========  =================  ============  ===============  ===========
@@ -305,7 +305,7 @@ class Shin2017A(Shin2017):
 class Shin2017B(Shin2017):
     """Mental Arithmetic Dataset from Shin et al 2017
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =========  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -185,6 +185,15 @@ class Shin2017(BaseDataset):
 class Shin2017A(Shin2017):
     """Motor Imagey Dataset from Shin et al 2017
 
+    .. note:: Meta-information about the dataset
+
+
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name         #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Shin2017A       29       30           2                 30  10s           200Hz                      3
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset from [1]_.
 
 
@@ -295,6 +304,15 @@ class Shin2017A(Shin2017):
 
 class Shin2017B(Shin2017):
     """Mental Arithmetic Dataset from Shin et al 2017
+
+    .. note:: Meta-information about the dataset
+
+
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name         #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Shin2017B       29       30           2                 30  10s           200Hz                      3
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
 
     Dataset from [1]_.
 

--- a/moabb/datasets/bnci.py
+++ b/moabb/datasets/bnci.py
@@ -887,6 +887,15 @@ class BNCI2014004(MNEBNCI):
 class BNCI2014008(MNEBNCI):
     """BNCI 2014-008 P300 dataset
 
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        Name           #Subj    #Chan  #Trials / class    Trials length    Sampling rate      #Sessions
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        BNCI2014008        8        8  3500 NT / 700 T    1s               256Hz                      1
+        ===========  =======  =======  =================  ===============  ===============  ===========
+
     Dataset from [1]_.
 
     **Dataset description**
@@ -948,6 +957,15 @@ class BNCI2014008(MNEBNCI):
 
 class BNCI2014009(MNEBNCI):
     """BNCI 2014-009 P300 dataset.
+
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        Name           #Subj    #Chan  #Trials / class    Trials length    Sampling rate      #Sessions
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        BNCI2014009       10       16  1440 NT / 288 T    0.8s             256Hz                      3
+        ===========  =======  =======  =================  ===============  ===============  ===========
 
     Dataset from [1]_.
 
@@ -1059,6 +1077,15 @@ class BNCI2015001(MNEBNCI):
 
 class BNCI2015003(MNEBNCI):
     """BNCI 2015-003 P300 dataset.
+
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        Name           #Subj    #Chan  #Trials / class    Trials length    Sampling rate      #Sessions
+        ===========  =======  =======  =================  ===============  ===============  ===========
+        BNCI2015003       10        8  1500 NT / 300 T    0.8s             256Hz                      1
+        ===========  =======  =======  =================  ===============  ===============  ===========
 
     Dataset from [1]_.
 

--- a/moabb/datasets/bnci.py
+++ b/moabb/datasets/bnci.py
@@ -677,7 +677,7 @@ class MNEBNCI(BaseDataset):
 class BNCI2014001(MNEBNCI):
     """BNCI 2014-001 Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  ==========  =================  ============  ===============  ===========
@@ -741,7 +741,7 @@ class BNCI2014001(MNEBNCI):
 class BNCI2014002(MNEBNCI):
     """BNCI 2014-002 Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  ==========  =================  ============  ===============  ===========
@@ -804,7 +804,7 @@ class BNCI2014002(MNEBNCI):
 class BNCI2014004(MNEBNCI):
     """BNCI 2014-004 Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  ==========  =================  ============  ===============  ===========
@@ -887,7 +887,7 @@ class BNCI2014004(MNEBNCI):
 class BNCI2014008(MNEBNCI):
     """BNCI 2014-008 P300 dataset
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  =================  ===============  ===============  ===========
@@ -958,7 +958,7 @@ class BNCI2014008(MNEBNCI):
 class BNCI2014009(MNEBNCI):
     """BNCI 2014-009 P300 dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  =================  ===============  ===============  ===========
@@ -1021,7 +1021,7 @@ class BNCI2014009(MNEBNCI):
 class BNCI2015001(MNEBNCI):
     """BNCI 2015-001 Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  ==========  =================  ============  ===============  ===========
@@ -1078,7 +1078,7 @@ class BNCI2015001(MNEBNCI):
 class BNCI2015003(MNEBNCI):
     """BNCI 2015-003 P300 dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  =================  ===============  ===============  ===========
@@ -1122,7 +1122,7 @@ class BNCI2015003(MNEBNCI):
 class BNCI2015004(MNEBNCI):
     """BNCI 2015-004 Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/bnci.py
+++ b/moabb/datasets/bnci.py
@@ -677,6 +677,15 @@ class MNEBNCI(BaseDataset):
 class BNCI2014001(MNEBNCI):
     """BNCI 2014-001 Motor Imagery dataset.
 
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name           #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        BNCI2014001       10       22           4                144  4s            250Hz                      2
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset IIa from BCI Competition 4 [1]_.
 
     **Dataset Description**
@@ -732,6 +741,15 @@ class BNCI2014001(MNEBNCI):
 class BNCI2014002(MNEBNCI):
     """BNCI 2014-002 Motor Imagery dataset.
 
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name           #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        BNCI2014002       15       15           2                 80  5s            512Hz                      1
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Motor Imagery Dataset from [1]_.
 
     **Dataset description**
@@ -785,6 +803,15 @@ class BNCI2014002(MNEBNCI):
 
 class BNCI2014004(MNEBNCI):
     """BNCI 2014-004 Motor Imagery dataset.
+
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name           #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        BNCI2014004       10        3           2                360  4.5s          250Hz                      5
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
 
     Dataset B from BCI Competition 2008.
 
@@ -976,6 +1003,15 @@ class BNCI2014009(MNEBNCI):
 class BNCI2015001(MNEBNCI):
     """BNCI 2015-001 Motor Imagery dataset.
 
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name           #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        BNCI2015001       13       13           2                200  5s            512Hz                      2
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset from [1]_.
 
     **Dataset description**
@@ -1058,6 +1094,15 @@ class BNCI2015003(MNEBNCI):
 
 class BNCI2015004(MNEBNCI):
     """BNCI 2015-004 Motor Imagery dataset.
+
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name           #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        BNCI2015004       10       30           5                 80  7s            256Hz                      2
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
 
     Dataset from [1]_.
 

--- a/moabb/datasets/braininvaders.py
+++ b/moabb/datasets/braininvaders.py
@@ -395,7 +395,7 @@ class bi2012(BaseDataset):
 class bi2013a(BaseDataset):
     """P300 dataset bi2013a from a "Brain Invaders" experiment
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =======  =======  =======  =================  ===============  ===============  =================

--- a/moabb/datasets/braininvaders.py
+++ b/moabb/datasets/braininvaders.py
@@ -395,6 +395,15 @@ class bi2012(BaseDataset):
 class bi2013a(BaseDataset):
     """P300 dataset bi2013a from a "Brain Invaders" experiment
 
+    .. note:: Meta-information about the dataset
+
+
+        =======  =======  =======  =================  ===============  ===============  =================
+        Name       #Subj    #Chan  #Trials / class    Trials length    Sampling rate    #Sessions
+        =======  =======  =======  =================  ===============  ===============  =================
+        bi2013a       24       16  3200 NT / 640 T    1s               512Hz            (1-7)8 s|(8-24)1s
+        =======  =======  =======  =================  ===============  ===============  =================
+
     Dataset following the setup from [1]_ carried-out at University of
     Grenoble Alpes.
 

--- a/moabb/datasets/epfl.py
+++ b/moabb/datasets/epfl.py
@@ -18,6 +18,15 @@ EPFLP300_URL = "http://documents.epfl.ch/groups/m/mm/mmspg/www/BCI/p300/"
 class EPFLP300(BaseDataset):
     """P300 dataset from Hoffmann et al 2008.
 
+    .. note:: Meta-information about the dataset
+
+
+        ========  =======  =======  =================  ===============  ===============  ===========
+        Name        #Subj    #Chan  #Trials / class    Trials length    Sampling rate      #Sessions
+        ========  =======  =======  =================  ===============  ===============  ===========
+        EPFLP300        8       32  2753 NT / 551 T    1s               2048Hz                     4
+        ========  =======  =======  =================  ===============  ===============  ===========
+
     Dataset from the paper [1]_.
 
     **Dataset Description**

--- a/moabb/datasets/epfl.py
+++ b/moabb/datasets/epfl.py
@@ -18,7 +18,7 @@ EPFLP300_URL = "http://documents.epfl.ch/groups/m/mm/mmspg/www/BCI/p300/"
 class EPFLP300(BaseDataset):
     """P300 dataset from Hoffmann et al 2008.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ========  =======  =======  =================  ===============  ===============  ===========

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -21,7 +21,7 @@ GIGA_URL = "ftp://parrot.genomics.cn/gigadb/pub/10.5524/100001_101000/100295/mat
 class Cho2017(BaseDataset):
     """Motor Imagery dataset from Cho et al 2017.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =======  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -21,6 +21,15 @@ GIGA_URL = "ftp://parrot.genomics.cn/gigadb/pub/10.5524/100001_101000/100295/mat
 class Cho2017(BaseDataset):
     """Motor Imagery dataset from Cho et al 2017.
 
+    .. note:: Meta-information about the dataset
+
+
+        =======  =======  =======  ==========  =================  ============  ===============  ===========
+        Name       #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        =======  =======  =======  ==========  =================  ============  ===============  ===========
+        Cho2017       53       64           2                100  3s            512Hz                      1
+        =======  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset from the paper [1]_.
 
     **Dataset Description**

--- a/moabb/datasets/mpi_mi.py
+++ b/moabb/datasets/mpi_mi.py
@@ -15,7 +15,7 @@ DOWNLOAD_URL = "https://zenodo.org/record/1217449/files/"
 class MunichMI(BaseDataset):
     """Munich Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ========  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/mpi_mi.py
+++ b/moabb/datasets/mpi_mi.py
@@ -15,6 +15,15 @@ DOWNLOAD_URL = "https://zenodo.org/record/1217449/files/"
 class MunichMI(BaseDataset):
     """Munich Motor Imagery dataset.
 
+    .. note:: Meta-information about the dataset
+
+
+        ========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name        #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ========  =======  =======  ==========  =================  ============  ===============  ===========
+        MunichMI       10      128           2                150  7s            500Hz                      1
+        ========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Motor imagery dataset from Grosse-Wentrup et al. 2009 [1]_.
 
     A trial started with the central display of a white fixation cross. After 3

--- a/moabb/datasets/neiry.py
+++ b/moabb/datasets/neiry.py
@@ -14,6 +14,15 @@ from .base import BaseDataset
 class DemonsP300(BaseDataset):
     """Visual P300 dataset recorded in Virtual Reality (VR) game Raccoons versus Demons.
 
+    .. note:: Meta-information about the dataset
+
+
+        ==========  =======  =======  =================  ===============  ===============  ===========
+        Name          #Subj    #Chan  #Trials / class    Trials length    Sampling rate      #Sessions
+        ==========  =======  =======  =================  ===============  ===============  ===========
+        DemonsP300       60        8  935 NT / 50 T      1s               500Hz                      1
+        ==========  =======  =======  =================  ===============  ===============  ===========
+
     .. danger::
 
        This dataset contains major unresolved issues and could removed in the near futur. Use it in a benchmark

--- a/moabb/datasets/neiry.py
+++ b/moabb/datasets/neiry.py
@@ -14,7 +14,7 @@ from .base import BaseDataset
 class DemonsP300(BaseDataset):
     """Visual P300 dataset recorded in Virtual Reality (VR) game Raccoons versus Demons.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ==========  =======  =======  =================  ===============  ===============  ===========

--- a/moabb/datasets/physionet_mi.py
+++ b/moabb/datasets/physionet_mi.py
@@ -16,6 +16,15 @@ BASE_URL = "https://physionet.org/files/eegmmidb/1.0.0/"
 class PhysionetMI(BaseDataset):
     """Physionet Motor Imagery dataset.
 
+    .. note:: Meta-information about the dataset
+
+
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name           #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+        PhysionetMI      109       64           4                 23  3s            160Hz                      1
+        ===========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Physionet MI dataset: https://physionet.org/pn4/eegmmidb/
 
     This data set consists of over 1500 one- and two-minute EEG recordings,

--- a/moabb/datasets/physionet_mi.py
+++ b/moabb/datasets/physionet_mi.py
@@ -16,7 +16,7 @@ BASE_URL = "https://physionet.org/files/eegmmidb/1.0.0/"
 class PhysionetMI(BaseDataset):
     """Physionet Motor Imagery dataset.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ===========  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/schirrmeister2017.py
+++ b/moabb/datasets/schirrmeister2017.py
@@ -17,6 +17,15 @@ GIN_URL = (
 class Schirrmeister2017(BaseDataset):
     """High-gamma dataset discribed in Schirrmeister et al. 2017
 
+    .. note:: Meta-information about the dataset
+
+
+        =================  =======  =======  ==========  =================  ============  ===============  ===========
+        Name                 #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        =================  =======  =======  ==========  =================  ============  ===============  ===========
+        Schirrmeister2017       14      128           4                120  4s            500Hz                      1
+        =================  =======  =======  ==========  =================  ============  ===============  ===========
+
     Dataset from [1]_
 
     Our “High-Gamma Dataset” is a 128-electrode dataset (of which we later only use

--- a/moabb/datasets/schirrmeister2017.py
+++ b/moabb/datasets/schirrmeister2017.py
@@ -17,7 +17,7 @@ GIN_URL = (
 class Schirrmeister2017(BaseDataset):
     """High-gamma dataset discribed in Schirrmeister et al. 2017
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =================  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -14,7 +14,7 @@ SSVEPEXO_URL = "https://zenodo.org/record/2392979/files/"
 class SSVEPExo(BaseDataset):
     """SSVEP Exo dataset
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ========  =======  =======  ==========  =================  ===============  ===============  ===========

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -14,6 +14,15 @@ SSVEPEXO_URL = "https://zenodo.org/record/2392979/files/"
 class SSVEPExo(BaseDataset):
     """SSVEP Exo dataset
 
+    .. note:: Meta-information about the dataset
+
+
+        ========  =======  =======  ==========  =================  ===============  ===============  ===========
+        Name        #Subj    #Chan    #Classes    #Trials / class  Trials length    Sampling rate      #Sessions
+        ========  =======  =======  ==========  =================  ===============  ===============  ===========
+        SSVEPExo       12        8           4                 16  2s               256Hz                      1
+        ========  =======  =======  ==========  =================  ===============  ===============  ===========
+
     SSVEP dataset from E. Kalunga PhD in University of Versailles [1]_.
 
     The datasets contains recording from 12 male and female subjects aged

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -169,6 +169,15 @@ class BaseMAMEM(BaseDataset):
 class MAMEM1(BaseMAMEM):
     """SSVEP MAMEM 1 dataset
 
+    .. note:: Meta-information about the dataset
+
+
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+        Name      #Subj    #Chan    #Classes  #Trials / class    Trials length    Sampling rate      #Sessions
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+        MAMEM1       10      256           5  12-15              3s               250Hz                      1
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+
     Dataset from [1]_.
 
     EEG signals with 256 channels captured from 11 subjects executing a
@@ -280,6 +289,15 @@ class MAMEM1(BaseMAMEM):
 class MAMEM2(BaseMAMEM):
     """SSVEP MAMEM 2 dataset
 
+    .. note:: Meta-information about the dataset
+
+
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+        Name      #Subj    #Chan    #Classes  #Trials / class    Trials length    Sampling rate      #Sessions
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+        MAMEM2       10      256           5  20-30              3s               250Hz                      1
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+
     Dataset from [1]_.
 
     EEG signals with 256 channels captured from 11 subjects executing a
@@ -363,6 +381,15 @@ class MAMEM2(BaseMAMEM):
 
 class MAMEM3(BaseMAMEM):
     """SSVEP MAMEM 3 dataset
+
+    .. note:: Meta-information about the dataset
+
+
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+        Name      #Subj    #Chan    #Classes  #Trials / class    Trials length    Sampling rate      #Sessions
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
+        MAMEM3       10       14           4  20-30              3s               128Hz                      1
+        ======  =======  =======  ==========  =================  ===============  ===============  ===========
 
     Dataset from [1]_.
 

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -169,7 +169,7 @@ class BaseMAMEM(BaseDataset):
 class MAMEM1(BaseMAMEM):
     """SSVEP MAMEM 1 dataset
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ======  =======  =======  ==========  =================  ===============  ===============  ===========
@@ -289,7 +289,7 @@ class MAMEM1(BaseMAMEM):
 class MAMEM2(BaseMAMEM):
     """SSVEP MAMEM 2 dataset
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ======  =======  =======  ==========  =================  ===============  ===============  ===========
@@ -382,7 +382,7 @@ class MAMEM2(BaseMAMEM):
 class MAMEM3(BaseMAMEM):
     """SSVEP MAMEM 3 dataset
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ======  =======  =======  ==========  =================  ===============  ===============  ===========

--- a/moabb/datasets/ssvep_nakanishi.py
+++ b/moabb/datasets/ssvep_nakanishi.py
@@ -22,6 +22,15 @@ NAKAHISHI_URL = "https://github.com/mnakanishi/12JFPM_SSVEP/raw/master/data/"
 class Nakanishi2015(BaseDataset):
     """SSVEP Nakanishi 2015 dataset
 
+    .. note:: Meta-information about the dataset
+
+
+        =============  =======  =======  ==========  =================  ===============  ===============  ===========
+        Name             #Subj    #Chan    #Classes    #Trials / class  Trials length    Sampling rate      #Sessions
+        =============  =======  =======  ==========  =================  ===============  ===============  ===========
+        Nakanishi2015        9        8          12                 15  4.15s            256Hz                      1
+        =============  =======  =======  ==========  =================  ===============  ===============  ===========
+
     This dataset contains 12-class joint frequency-phase modulated steady-state
     visual evoked potentials (SSVEPs) acquired from 10 subjects used to
     estimate an online performance of brain-computer interface (BCI) in the

--- a/moabb/datasets/ssvep_nakanishi.py
+++ b/moabb/datasets/ssvep_nakanishi.py
@@ -22,7 +22,7 @@ NAKAHISHI_URL = "https://github.com/mnakanishi/12JFPM_SSVEP/raw/master/data/"
 class Nakanishi2015(BaseDataset):
     """SSVEP Nakanishi 2015 dataset
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =============  =======  =======  ==========  =================  ===============  ===============  ===========

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -24,7 +24,7 @@ WANG_URL = "ftp://sccn.ucsd.edu/pub/ssvep_benchmark_dataset/"
 class Wang2016(BaseDataset):
     """SSVEP Wang 2016 dataset
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         ========  =======  =======  ==========  =================  ===============  ===============  ===========

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -24,6 +24,15 @@ WANG_URL = "ftp://sccn.ucsd.edu/pub/ssvep_benchmark_dataset/"
 class Wang2016(BaseDataset):
     """SSVEP Wang 2016 dataset
 
+    .. note:: Meta-information about the dataset
+
+
+        ========  =======  =======  ==========  =================  ===============  ===============  ===========
+        Name        #Subj    #Chan    #Classes    #Trials / class  Trials length    Sampling rate      #Sessions
+        ========  =======  =======  ==========  =================  ===============  ===============  ===========
+        Wang2016       32       62          40                  6  5s               250Hz                      1
+        ========  =======  =======  ==========  =================  ===============  ===============  ===========
+
     Dataset from [1]_.
 
     This dataset gathered SSVEP-BCI recordings of 35 healthy subjects (17

--- a/moabb/datasets/upper_limb.py
+++ b/moabb/datasets/upper_limb.py
@@ -13,7 +13,7 @@ UPPER_LIMB_URL = "https://zenodo.org/record/834976/files/"
 class Ofner2017(BaseDataset):
     """Motor Imagery ataset from Ofner et al 2017.
 
-    .. note:: Meta-information about the dataset
+    .. admonition:: Dataset summary
 
 
         =========  =======  =======  ==========  =================  ============  ===============  ===========

--- a/moabb/datasets/upper_limb.py
+++ b/moabb/datasets/upper_limb.py
@@ -13,6 +13,15 @@ UPPER_LIMB_URL = "https://zenodo.org/record/834976/files/"
 class Ofner2017(BaseDataset):
     """Motor Imagery ataset from Ofner et al 2017.
 
+    .. note:: Meta-information about the dataset
+
+
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Name         #Subj    #Chan    #Classes    #Trials / class  Trials len    Sampling rate      #Sessions
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+        Ofner2017       15       61           7                 60  3s            512Hz                      1
+        =========  =======  =======  ==========  =================  ============  ===============  ===========
+
     Upper limb Motor imagery dataset from the paper [1]_.
 
     **Dataset description**


### PR DESCRIPTION
As discussed in today's weekly meeting, this pull request attempts to include meta information in the documentation.

The table in each class was included programmatically. During the review, I noticed that some ERP datasets need the meta information.