### PR TITLE
replacing the np.int to native type int.

### DIFF
--- a/moabb/datasets/neiry.py
+++ b/moabb/datasets/neiry.py
@@ -156,7 +156,7 @@ class DemonsP300(BaseDataset):
             run_data = []
             for eeg, starts, stims in act["sessions"]:
                 starts = starts * self.sampling_rate / self._ms_in_sec
-                starts = starts.round().astype(np.int)
+                starts = starts.round().astype(int)
                 stims = stims + 1
                 stims_channel = np.zeros(eeg.shape[1])
                 target_channel = np.zeros(eeg.shape[1])


### PR DESCRIPTION
I accidentally discovered what was blocking a NumPy version update. In the latest ubuntu docker images, native NumPy is installed with a version above 1.20. It's a bit of work to install the lower version, I thought it best to create this pull request and replace the type alias of NumPy. 

Better explanation in NumPy release notes 1.20: https://numpy.org/devdocs/release/1.20.0-notes.html