### PR TITLE
Change n_jobs=-1 to self.n_jobs

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -41,6 +41,7 @@ Bugs
 - Fix downloading path issue for Weibo2014 and Zhou2016, numy error in DemonsP300 (:gh:`315` by `Sylvain Chevallier`_)
 - Fix unzip error for Huebner2017 and Huebner2018 (:gh:`318` by `Sylvain Chevallier`_)
 - Fix n_classes when events set to None (:gh:`337` by `Igor Carrara`_ and `Sylvain Chevallier`_)
+- Change n_jobs=-1 to self.n_jobs in GridSearch (:gh:`344` by `Igor Carrara`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -136,7 +136,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                     param_grid[name],
                     refit=True,
                     cv=cv,
-                    n_jobs=-1,
+                    n_jobs=self.n_jobs,
                     scoring=self.paradigm.scoring,
                     return_train_score=True,
                 )
@@ -430,7 +430,7 @@ class CrossSessionEvaluation(BaseEvaluation):
                     param_grid[name],
                     refit=True,
                     cv=cv,
-                    n_jobs=-1,
+                    n_jobs=self.n_jobs,
                     scoring=self.paradigm.scoring,
                     return_train_score=True,
                 )
@@ -583,7 +583,7 @@ class CrossSubjectEvaluation(BaseEvaluation):
                     param_grid[name],
                     refit=True,
                     cv=cv,
-                    n_jobs=-1,
+                    n_jobs=self.n_jobs,
                     scoring=self.paradigm.scoring,
                     return_train_score=True,
                 )


### PR DESCRIPTION
Currently the GridSearch function the n_jobs to self.n_jobs. Previously n_jobs=-1 that can create problem with DeepLearning model