### PR TITLE
Speeding the AugmentedDataset

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -28,6 +28,7 @@ Enhancements
 - Adding saving option for the models (:gh:`401` by `Bruno Aristimunha`_ and `Igor Carrara`_)
 - Adding example to load different type of models (:gh:`401` by `Bruno Aristimunha`_ and `Igor Carrara`_)
 - Add resting state paradigm with dataset and example (:gh:`400` by `Gregoire Cattan`_ and `Pedro L. C. Rodrigues`_)
+- Speeding the augmentation method by 400% with NumPy vectorization  (:gh:`419` by `Bruno Aristimunha`_)
 
 Bugs
 ~~~~

--- a/moabb/pipelines/features.py
+++ b/moabb/pipelines/features.py
@@ -1,6 +1,7 @@
 import mne
 import numpy as np
 import scipy.signal as signal
+from numpy import concatenate, ndarray
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.preprocessing import StandardScaler
 
@@ -76,31 +77,27 @@ class AugmentedDataset(BaseEstimator, TransformerMixin):
            https://doi.org/10.48550/arXiv.2302.04508
     """
 
-    def __init__(self, order=1, lag=1):
+    def __init__(self, order: int = 1, lag: int = 1):
         self.order = order
         self.lag = lag
 
-    def fit(self, X, y):
+    def fit(self, X: ndarray, y: ndarray):
         return self
 
-    def transform(self, X):
+    def transform(self, X: ndarray):
         if self.order == 1:
-            X_fin = X
+            X_fin: ndarray = X
         else:
-            X_fin = []
-
-            for i in np.arange(X.shape[0]):
-                X_p = X[i][:, : -self.order * self.lag]
-                X_p = np.concatenate(
-                    [X_p]
-                    + [
-                        X[i][:, p * self.lag : -(self.order - p) * self.lag]
-                        for p in range(1, self.order)
-                    ],
-                    axis=0,
-                )
-                X_fin.append(X_p)
-            X_fin = np.array(X_fin)
+            X_p = X[:, :, : -self.order * self.lag]
+            X_p = concatenate(
+                [X_p]
+                + [
+                    X[:, :, p * self.lag : -(self.order - p) * self.lag]
+                    for p in range(1, self.order)
+                ],
+                axis=1,
+            )
+            X_fin = X_p
 
         return X_fin
 


### PR DESCRIPTION
The AugmentedDataset method gives good results. However, when combined with grid search, it is expensive to compute all the feature space. In this PR, I slightly changed the implementation to remove a `for` to replace it with a numpy vectorization. The speed gain we had from this pull request is 487% in one of my tests compared to before.

![image](https://github.com/NeuroTechX/moabb/assets/42702466/b81c542e-06db-4823-a615-21454b6c4ade)

Ps. Given the complexity of formats and types, I tried to optimize more using Python and couldn't.
Igor, you owe me a beer or wine :) I leave you the merge 