### PR TITLE
Multithread mkdir

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -40,7 +40,7 @@ Bugs
 - Fixing SSLError from BCI competition IV (:gh:`404` by `Bruno Aristimunha`_)
 - Fixing :func:`moabb.dataset.bnci.MNEBNCI.data_path` that returned the data itself instead of paths (:gh:`412` by `Pierre Guetschel`_)
 - Adding :func:`moabb.datasets.fake` in the init file to use in braindecode object (:gh:`414` by `Bruno Aristimunha`_)
-
+- Fixing the parallel download issue when the dataset have the same directory (:gh:`421` by `Sara Sedlar`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/datasets/download.py
+++ b/moabb/datasets/download.py
@@ -147,8 +147,7 @@ def data_dl(url, sign, path=None, force_update=False, verbose=None):
     if not destination.is_file() or force_update:
         if destination.is_file():
             destination.unlink()
-        if not destination.parent.is_dir():
-            destination.parent.mkdir(parents=True)
+        destination.parent.mkdir(parents=True, exist_ok=True)
         known_hash = None
     else:
         known_hash = file_hash(str(destination))


### PR DESCRIPTION
This PR aims to address the problem of the parallel download of the files to the same directory (e.g. in download of the Schirrmeister2017 dataset).
The first thread checks if the directory exists (e.g. '.../train') and if it does not, makes the directory. The second thread finds also that the directory  (e.g. '.../train')  does not exist and tries to create it after the first thread has created it, so the FileExistsError is raised. With the exist_ok=True, this error is ignored.
