### PR TITLE
Fixed bug in BraindecodeDatasetLoader where incorrect y was used in transform calls

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -44,6 +44,9 @@ Bugs
 - Fixing the parallel download issue when the dataset have the same directory (:gh:`421` by `Sara Sedlar`_)
 - Fixing fixes the problem with the annotation loading for the P300 datasets Sosulski2019, Huebner2017 and Huebner2018 (:gh:`396` by `Sara Sedlar`_)
 - Removing the print in the dataset list (:gh:`423` by `Bruno Aristimunha`_)
+- Fixing bug in :func:`moabb.pipeline.utils_pytorch.BraindecodeDatasetLoader` where incorrect y was used in transform calls (:gh:`426` by `Gabriel Schwartz`_)
+- Fixing one test in :func:`moabb.pipeline.utils_pytorch.BraindecodeDatasetLoader` (:gh:`426` by `Bruno Aristimunha`_)
+
 
 API changes
 ~~~~~~~~~~~
@@ -331,6 +334,7 @@ Bugs
 API changes
 ~~~~~~~~~~~
 - None
+.. _Gabriel Schwartz: https://github.com/Kaos9001
 .. _Sara Sedlar: https://github.com/Sara04
 .. _Emmanuel Kalunga: https://github.com/emmanuelkalunga
 .. _Gregoire Cattan: https://github.com/gcattan

--- a/moabb/pipelines/utils_pytorch.py
+++ b/moabb/pipelines/utils_pytorch.py
@@ -48,9 +48,11 @@ class BraindecodeDatasetLoader(BaseEstimator, TransformerMixin):
 
     def transform(self, X, y=None):
         _check_data_format(X)
+        if y is None:
+            y = self.y
         dataset = create_from_X_y(
             X=X.get_data(),
-            y=self.y,
+            y=y,
             window_size_samples=X.get_data().shape[2],
             window_stride_samples=X.get_data().shape[2],
             drop_last_window=self.drop_last_window,

--- a/moabb/tests/util_braindecode.py
+++ b/moabb/tests/util_braindecode.py
@@ -106,9 +106,7 @@ class TestTransformer:
             sfreq=X_train.info["sfreq"],
         )
         transformer = BraindecodeDatasetLoader()
-        dataset_trans = transformer.fit(X=X_train.get_data(), y=y_train).transform(
-            X_train
-        )
+        dataset_trans = transformer.fit(X=X_train, y=y_train).transform(X_train)
         assert isinstance(dataset_trans, BaseConcatDataset)
         assert type(dataset_trans) == type(dataset)
 
@@ -117,6 +115,42 @@ class TestTransformer:
         transformer = BraindecodeDatasetLoader()
         with pytest.raises(ValueError):
             transformer.fit_transform(np.random.normal(size=(2, 1, 10)), y=np.array([0]))
+
+    def test_transformer_transform_with_custom_y(self, data):
+        """Test whether the provided y is used during transform"""
+        X_train, y_train, _, _ = data
+        transformer = BraindecodeDatasetLoader()
+
+        # Create test data with different y values
+        X_test = X_train.copy()
+        y_test = y_train + 1
+
+        # Fit the transformer with training data and custom y
+        transformer.fit(X_train, y_train)
+
+        # Transform the test data with custom y
+        dataset_test = transformer.transform(X_test, y=y_test)
+
+        # Verify that the transformed dataset contains the test data's x values and the custom y values
+        assert len(dataset_test) == len(X_test)
+        assert np.array_equal(dataset_test[0][1], y_test[0])
+        assert np.array_equal(dataset_test[1][1], y_test[1])
+
+    def test_transformer_transform_with_default_y(self, data):
+        """Test whether self.y is used when y is not provided during transform"""
+        X_train, y_train, _, _ = data
+        transformer = BraindecodeDatasetLoader()
+
+        # Fit the transformer with training data and default y
+        transformer.fit(X_train, y_train)
+
+        # Transform the test data without providing y
+        dataset_test = transformer.transform(X_train)
+
+        # Verify that the transformed dataset contains the training data's x values and the default y values
+        assert len(dataset_test) == len(X_train)
+        assert np.array_equal(dataset_test[0][1], y_train[0])
+        assert np.array_equal(dataset_test[1][1], y_train[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A common use scenario for a `BraindecodeDatasetLoader` instance is as a step in a pipeline of transforms. 
In a situation where the pipeline receives separate `x=data` and `y=labels` values instead of bundled `x=(data, labels)` and `y=None`, calling `fit(x, y)` on that pipeline works as expected, however `BraindecodeDatasetLoader`, as currently implemented, saves the `y` values assigned in the `fit` call and always reuses them on subsequent `transform` calls, even when the user inputs a different `y` into the pipeline. 
This is relevant in situations where, for example, the user creates a pipeline, trains it by calling `fit` with training data of size A and subsequently feeds the trained pipeline to a scorer alongside test data of size B. As currently implemented, this would result in the dataset returned by the `transform` method containing the test data's `x` values and the training data's `y` values, which can cause confusing errors to occur even if the `y` value is not relevant, as many libraries check for size mismatches between the set of data points and the set of labels. 
By checking if the user has specified an `y` during execution, this issue is avoided and default behaviour is unchanged, as `self.y` is still used when user-assigned `y` is `None`.