### PR TITLE
FIX empty dataset_list in python3.10

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -59,6 +59,7 @@ Bugs
 - Fix :func:`moabb.benchmark` overwriting ``include_datasets`` list (:gh:`408` by `Pierre Guetschel`_)
 - Fix :func:`moabb.paradigms.base.BaseParadigm` using attributes before defining them  (PR :gh:`408`, issue :gh:`425` by `Pierre Guetschel`_)
 - Fix :func:`moabb.paradigms.FakeImageryParadigm`, :func:`moabb.paradigms.FakeP300Paradigm` and :func:`moabb.paradigms.FakeSSVEPParadigm` ``is_valid`` methods to only accept the correct datasets (PR :gh:`408` by `Pierre Guetschel`_)
+- Fix ``dataset_list`` construction, which could be empty due to bad import order (PR :gh:`449` by `Thomas Moreau`_).
 
 API changes
 ~~~~~~~~~~~
@@ -368,3 +369,4 @@ API changes
 .. _Jan Sosulski: https://github.com/jsosulski
 .. _Pierre Guetschel: https://github.com/PierreGtch
 .. _Ludovic Darmet: https://github.com/ludovicdmt
+.. _Thomas Moreau: https://github.com/tommoral

--- a/moabb/datasets/__init__.py
+++ b/moabb/datasets/__init__.py
@@ -46,12 +46,11 @@ from .ssvep_mamem import MAMEM1, MAMEM2, MAMEM3
 from .ssvep_nakanishi import Nakanishi2015
 from .ssvep_wang import Wang2016
 from .upper_limb import Ofner2017
-
-# Call this last in order to make sure the dataset list contains all
-# the datasets imported in this file.
 from .utils import _init_dataset_list
 from .Weibo2014 import Weibo2014
 from .Zhou2016 import Zhou2016
 
 
+# Call this last in order to make sure the dataset list contains all
+# the datasets imported in this file.
 _init_dataset_list()

--- a/moabb/datasets/__init__.py
+++ b/moabb/datasets/__init__.py
@@ -46,10 +46,12 @@ from .ssvep_mamem import MAMEM1, MAMEM2, MAMEM3
 from .ssvep_nakanishi import Nakanishi2015
 from .ssvep_wang import Wang2016
 from .upper_limb import Ofner2017
-from .Weibo2014 import Weibo2014
-from .Zhou2016 import Zhou2016
 
 # Call this last in order to make sure the dataset list contains all
 # the datasets imported in this file.
 from .utils import _init_dataset_list
+from .Weibo2014 import Weibo2014
+from .Zhou2016 import Zhou2016
+
+
 _init_dataset_list()

--- a/moabb/datasets/__init__.py
+++ b/moabb/datasets/__init__.py
@@ -48,3 +48,8 @@ from .ssvep_wang import Wang2016
 from .upper_limb import Ofner2017
 from .Weibo2014 import Weibo2014
 from .Zhou2016 import Zhou2016
+
+# Call this last in order to make sure the dataset list contains all
+# the datasets imported in this file.
+from .utils import _init_dataset_list
+_init_dataset_list()

--- a/moabb/datasets/utils.py
+++ b/moabb/datasets/utils.py
@@ -15,9 +15,6 @@ def _init_dataset_list():
             dataset_list.append(ds[1])
 
 
-_init_dataset_list()
-
-
 def dataset_search(  # noqa: C901
     paradigm=None,
     multi_session=False,

--- a/moabb/tests/datasets.py
+++ b/moabb/tests/datasets.py
@@ -1,17 +1,16 @@
+import inspect
 import shutil
 import tempfile
 import unittest
-import inspect
 
 import mne
 
 from moabb import datasets as db
-from moabb.datasets.base import BaseDataset
 from moabb.datasets import Shin2017A, Shin2017B, VirtualReality
+from moabb.datasets.base import BaseDataset
 from moabb.datasets.compound_dataset import CompoundDataset
 from moabb.datasets.fake import FakeDataset, FakeVirtualRealityDataset
-from moabb.datasets.utils import block_rep
-from moabb.datasets.utils import dataset_list
+from moabb.datasets.utils import block_rep, dataset_list
 from moabb.paradigms import P300
 
 
@@ -152,10 +151,13 @@ class Test_Datasets(unittest.TestCase):
                 self.assertRaises(AttributeError, ds.get_data, [1])
 
     def test_dataset_list(self):
-        all_datasets = len([
-            issubclass(c, BaseDataset) for c in db.__dict__.values()
-            if inspect.isclass(c)
-        ])
+        all_datasets = len(
+            [
+                issubclass(c, BaseDataset)
+                for c in db.__dict__.values()
+                if inspect.isclass(c)
+            ]
+        )
         assert len(dataset_list) == all_datasets
 
 

--- a/moabb/tests/datasets.py
+++ b/moabb/tests/datasets.py
@@ -1,13 +1,17 @@
 import shutil
 import tempfile
 import unittest
+import inspect
 
 import mne
 
+from moabb import datasets as db
+from moabb.datasets.base import BaseDataset
 from moabb.datasets import Shin2017A, Shin2017B, VirtualReality
 from moabb.datasets.compound_dataset import CompoundDataset
 from moabb.datasets.fake import FakeDataset, FakeVirtualRealityDataset
 from moabb.datasets.utils import block_rep
+from moabb.datasets.utils import dataset_list
 from moabb.paradigms import P300
 
 
@@ -146,6 +150,13 @@ class Test_Datasets(unittest.TestCase):
             # if the data is already downloaded:
             if mne.get_config("MNE_DATASETS_BBCIFNIRS_PATH") is None:
                 self.assertRaises(AttributeError, ds.get_data, [1])
+
+    def test_dataset_list(self):
+        all_datasets = len([
+            issubclass(c, BaseDataset) for c in db.__dict__.values()
+            if inspect.isclass(c)
+        ])
+        assert len(dataset_list) == all_datasets
 
 
 class Test_VirtualReality_Dataset(unittest.TestCase):


### PR DESCRIPTION
On python3.10, I got an empty list of datasets from `moabb.datasets.utils`.
This is due to the fact that `utils` was imported before `__init__` was fully set up.

This PR intends to make this determinist, by calling `_init_dataset_list` at the end of the `moabb.datasets.__init__.py`, with a test that checks that the list is complete.