### PR TITLE
Set the duration of the annotations during preprocessing

### DIFF
--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -197,7 +197,13 @@ class BaseDataset(metaclass=abc.ABCMeta):
     def _create_process_pipeline(self):
         return Pipeline(
             [
-                (StepType.RAW, SetRawAnnotations(self.event_id)),
+                (
+                    StepType.RAW,
+                    SetRawAnnotations(
+                        self.event_id,
+                        durations=self.interval[1] - self.interval[0],
+                    ),
+                ),
             ]
         )
 

--- a/moabb/datasets/preprocessing.py
+++ b/moabb/datasets/preprocessing.py
@@ -41,12 +41,13 @@ class FixedTransformer(TransformerMixin, BaseEstimator):
 
 
 class SetRawAnnotations(FixedTransformer):
-    def __init__(self, event_id):
+    def __init__(self, event_id, durations: Union[float, Dict[str, float]]):
         assert isinstance(event_id, dict)  # not None
         self.event_id = event_id
         if len(set(event_id.values())) != len(event_id):
             raise ValueError("Duplicate event code")
         self.event_desc = dict((code, desc) for desc, code in self.event_id.items())
+        self.durations = durations
 
     def transform(self, raw, y=None):
         if raw.annotations:
@@ -64,6 +65,7 @@ class SetRawAnnotations(FixedTransformer):
             first_samp=raw.first_samp,
             verbose=False,
         )
+        annotations.set_durations(self.durations)
         raw.set_annotations(annotations)
         return raw
 

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -167,7 +167,15 @@ class BaseProcessing(metaclass=abc.ABCMeta):
         process_pipelines = []
         for raw_pipeline in raw_pipelines:
             steps = []
-            steps.append((StepType.RAW, SetRawAnnotations(dataset.event_id)))
+            steps.append(
+                (
+                    StepType.RAW,
+                    SetRawAnnotations(
+                        dataset.event_id,
+                        durations=dataset.interval[1] - dataset.interval[0],
+                    ),
+                )
+            )
             if raw_pipeline is not None:
                 steps.append((StepType.RAW, raw_pipeline))
             if epochs_pipeline is not None:


### PR DESCRIPTION
Trying to fix #489 

My hypothesis is that the braindecode issue is caused by the annotations durations not being set during preprocessing, causing epochs of length 0 in braindecode. Let's find out