### PR TITLE
Fix issue with WithinSessionEvaluation with multiple datasets

### DIFF
--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 
+import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import GridSearchCV
 
@@ -170,6 +171,8 @@ class BaseEvaluation(ABC):
         for _, pipeline in pipelines.items():
             if not (isinstance(pipeline, BaseEstimator)):
                 raise (ValueError("pipelines must only contains Pipelines " "instance"))
+
+        res_per_db = []
         for dataset in self.datasets:
             log.info("Processing dataset: {}".format(dataset.code))
             process_pipeline = self.paradigm.make_process_pipelines(
@@ -189,10 +192,13 @@ class BaseEvaluation(ABC):
             )
             for res in results:
                 self.push_result(res, pipelines, process_pipeline)
+            res_per_db.append(
+                self.results.to_dataframe(
+                    pipelines=pipelines, process_pipeline=process_pipeline
+                )
+            )
 
-        return self.results.to_dataframe(
-            pipelines=pipelines, process_pipeline=process_pipeline
-        )
+        return pd.concat(res_per_db, ignore_index=True)
 
     def push_result(self, res, pipelines, process_pipeline):
         message = "{} | ".format(res["pipeline"])


### PR DESCRIPTION
This PR addresses the issue with the WithinSessionEvaluation when multiple datasets are provided. Issue #514 .
The problem was in the conversion of the results to dataframe, since the process_pipeline names depend on the datasets and therefore have different digests.