### PR TITLE
Correct TRCA

### DIFF
--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -1,0 +1,38 @@
+name: Check What's new update
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  check-whats-news:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for file changes in PR
+        run: |
+          pr_number=${{ github.event.pull_request.number }}
+          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/files")
+
+          file_changed=false
+          file_to_check="docs/whats_new.rst" # Specify the path to your file
+
+          for file in $(echo "${response}" | jq -r '.[] | .filename'); do
+            if [ "$file" == "$file_to_check" ]; then
+              file_changed=true
+              break
+            fi
+          done
+
+          if $file_changed; then
+            echo "File ${file_to_check} has been changed in the PR."
+          else
+            echo "File ${file_to_check} has not been changed in the PR."
+            echo "::error::File ${file_to_check} has not been changed in the PR."
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -18,7 +18,7 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/files")
 
           file_changed=false
-          file_to_check="docs/whats_new.rst" # Specify the path to your file
+          file_to_check="docs/source/whats_new.rst" # Specify the path to your file
 
           for file in $(echo "${response}" | jq -r '.[] | .filename'); do
             if [ "$file" == "$file_to_check" ]; then

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -23,7 +23,7 @@ Enhancements
 Bugs
 ~~~~
 
-- None
+- Fix TRCA implementation for different stimulation freqs and for signal filtering (:gh:522 by `Sylvain Chevallier`_)
 
 API changes
 ~~~~~~~~~~~

--- a/examples/plot_cross_subject_ssvep.py
+++ b/examples/plot_cross_subject_ssvep.py
@@ -104,9 +104,7 @@ pipelines = {}
 pipelines["CCA"] = make_pipeline(SSVEP_CCA(interval=interval, freqs=freqs, n_harmonics=2))
 
 pipelines_TRCA = {}
-pipelines_TRCA["TRCA"] = make_pipeline(
-    SSVEP_TRCA(interval=interval, freqs=freqs, n_fbands=5)
-)
+pipelines_TRCA["TRCA"] = make_pipeline(SSVEP_TRCA(interval=interval, freqs=freqs))
 
 pipelines_MSET_CCA = {}
 pipelines_MSET_CCA["MSET_CCA"] = make_pipeline(SSVEP_MsetCCA(freqs=freqs))

--- a/moabb/pipelines/classification.py
+++ b/moabb/pipelines/classification.py
@@ -114,9 +114,6 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
         Frequencies corresponding to the SSVEP components. These are
         necessary to design the filterbank bands.
 
-    n_fbands : int, default=5
-        Number of sub-bands considered for filterbank analysis.
-
     downsample: int, default=1
         Factor by which downsample the data. A downsample value of N will result
         on a sampling frequency of (sfreq // N) by taking one sample every N of
@@ -188,7 +185,6 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
         self,
         interval,
         freqs,
-        n_fbands=5,
         downsample=1,
         is_ensemble=True,
         method="original",
@@ -196,7 +192,7 @@ class SSVEP_TRCA(BaseEstimator, ClassifierMixin):
     ):
         self.freqs = freqs
         self.peaks = np.array([float(f) for f in freqs.keys()])
-        self.n_fbands = n_fbands
+        self.n_fbands = len(self.peaks)
         self.downsample = downsample
         self.interval = interval
         self.slen = interval[1] - interval[0]

--- a/moabb/pipelines/utils.py
+++ b/moabb/pipelines/utils.py
@@ -329,7 +329,7 @@ def filterbank(X, sfreq, idx_fb, peaks):
     Wp = [passband[idx_fb] / sfreq, top / sfreq]
     Ws = [stopband[idx_fb] / sfreq, (top + 20) / sfreq]
 
-    N, Wn = scp.cheb1ord(Wp, Ws, 3, 40)  # Chebyshev type I filter order selection.
+    N, Wn = scp.cheb1ord(Wp, Ws, 3, 15)  # Chebyshev type I filter order selection.
 
     B, A = scp.cheby1(N, 0.5, Wn, btype="bandpass")  # Chebyshev type I filter design
 


### PR DESCRIPTION
TRCA could results in classification as the `filterbank` method is not correctly paramettrized for signal filtering.
This PR fixes the `filterbank` method and remove unused parameter in TRCA. I think it is not necessary to make a deprecation warning for dropping this parameter as this is an unstable method, that could not be used in its current state.