### PR TITLE
Fix saving to BIDS runs with descriptions in their name

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -25,6 +25,7 @@ Bugs
 ~~~~
 
 - Fix TRCA implementation for different stimulation freqs and for signal filtering (:gh:522 by `Sylvain Chevallier`_)
+- Fix saving to BIDS runs with a description string in their name (:gh:`530` by `Pierre Guetschel`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -56,6 +56,23 @@ def subject_bids_to_moabb(subject: str):
     return int(subject)
 
 
+def run_moabb_to_bids(run: str):
+    """Convert the run to run index plus eventually description."""
+    p = r"([0-9]+)(|[a-zA-Z]+[a-zA-Z0-9]*)"
+    idx, desc = re.fullmatch(p, run).groups()
+    out = {"run": idx}
+    if desc:
+        out["task"] = desc
+    return out
+
+
+def run_bids_to_moabb(path: mne_bids.BIDSPath):
+    """Extracts the run index plus eventually description from a path."""
+    if path.task is None:
+        return path.run
+    return f"{path.run}{path.task}"
+
+
 @dataclass
 class BIDSInterfaceBase(abc.ABC):
     """Base class for BIDSInterface.
@@ -173,7 +190,7 @@ class BIDSInterfaceBase(abc.ABC):
             session_moabb = path.session
             session = sessions_data.setdefault(session_moabb, {})
             run = self._load_file(path, preload=preload)
-            session[path.run] = run
+            session[run_bids_to_moabb(path)] = run
         log.info("Finished reading cache of %s", repr(self))
         return sessions_data
 
@@ -223,12 +240,12 @@ class BIDSInterfaceBase(abc.ABC):
                     )
                     continue
 
+                run_kwargs = run_moabb_to_bids(run)
                 bids_path = mne_bids.BIDSPath(
                     root=self.root,
                     subject=subject_moabb_to_bids(self.subject),
                     session=session,
-                    task=self.dataset.paradigm,
-                    run=run,
+                    **run_kwargs,
                     description=self.desc,
                     extension=self._extension,
                     datatype=self._datatype,

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -62,15 +62,15 @@ def run_moabb_to_bids(run: str):
     idx, desc = re.fullmatch(p, run).groups()
     out = {"run": idx}
     if desc:
-        out["task"] = desc
+        out["recording"] = desc
     return out
 
 
 def run_bids_to_moabb(path: mne_bids.BIDSPath):
     """Extracts the run index plus eventually description from a path."""
-    if path.task is None:
+    if path.recording is None:
         return path.run
-    return f"{path.run}{path.task}"
+    return f"{path.run}{path.recording}"
 
 
 @dataclass
@@ -245,6 +245,7 @@ class BIDSInterfaceBase(abc.ABC):
                     root=self.root,
                     subject=subject_moabb_to_bids(self.subject),
                     session=session,
+                    task=self.dataset.paradigm,
                     **run_kwargs,
                     description=self.desc,
                     extension=self._extension,


### PR DESCRIPTION
Fixes #529 
With this, the description is now saved in the ~~`task` field and the paradigm (that was using the `task` field) is no longer saved.~~ `recording` field (the `task` field must always be specified).