### PR TITLE
Issue #503 Fix

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -29,6 +29,7 @@ Bugs
 
 - Fix TRCA implementation for different stimulation freqs and for signal filtering (:gh:522 by `Sylvain Chevallier`_)
 - Fix saving to BIDS runs with a description string in their name (:gh:`530` by `Pierre Guetschel`_)
+- Fix import of keras BatchNormalization for TF 2.13 and higher (:gh:`544` by `Brian Irvine`_)
 
 API changes
 ~~~~~~~~~~~
@@ -418,3 +419,4 @@ API changes
 .. _Ludovic Darmet: https://github.com/ludovicdmt
 .. _Thomas Moreau: https://github.com/tommoral
 .. _Jordy Thielen: https://github.com/thijor
+.. _Brian Irvine: https://github.com/brianjohannes

--- a/moabb/pipelines/deep_learning.py
+++ b/moabb/pipelines/deep_learning.py
@@ -28,8 +28,8 @@ from keras.layers import (
     LayerNormalization,
     MaxPooling2D,
     Permute,
+    BatchNormalization,
 )
-from keras.layers.normalization.batch_normalization import BatchNormalization
 from keras.models import Model, Sequential
 from scikeras.wrappers import KerasClassifier
 

--- a/moabb/pipelines/deep_learning.py
+++ b/moabb/pipelines/deep_learning.py
@@ -17,6 +17,7 @@ from keras.layers import (
     Add,
     AveragePooling2D,
     AvgPool2D,
+    BatchNormalization,
     Concatenate,
     Conv2D,
     Dense,
@@ -28,7 +29,6 @@ from keras.layers import (
     LayerNormalization,
     MaxPooling2D,
     Permute,
-    BatchNormalization,
 )
 from keras.models import Model, Sequential
 from scikeras.wrappers import KerasClassifier

--- a/moabb/pipelines/utils_deep_model.py
+++ b/moabb/pipelines/utils_deep_model.py
@@ -14,12 +14,12 @@ from keras.layers import (
     Activation,
     Add,
     AveragePooling2D,
+    BatchNormalization,
     Conv1D,
     Conv2D,
     DepthwiseConv2D,
     Dropout,
     SeparableConv2D,
-    BatchNormalization,
 )
 
 

--- a/moabb/pipelines/utils_deep_model.py
+++ b/moabb/pipelines/utils_deep_model.py
@@ -19,8 +19,8 @@ from keras.layers import (
     DepthwiseConv2D,
     Dropout,
     SeparableConv2D,
+    BatchNormalization,
 )
-from keras.layers.normalization.batch_normalization import BatchNormalization
 
 
 def EEGNet(


### PR DESCRIPTION
This fixes the issue where the "ModuleNotFoundError: No module named 'keras.layers.normalization'" issue when using TF 2.13.

I tested it with TF 2.12 and nothing seemed to break.