### PR TITLE
Fix incorrect interval in annotations 

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -51,6 +51,7 @@ Bugs
 - MAINT updating the packages pre-release (:gh:`578` by `Bruno Aristimunha`_)
 - Updating the parameters of the SSVEP_TRCA method (:gh:`589` by `Bruno Aristimunha`_)
 - Fix and updating the parameters for the benchmark function (:gh:`588` by `Bruno Aristimunha`_)
+- Fix :class:`moabb.datasets.preprocessing.SetRawAnnotations` setting incorrect annotations when the dataset's interval does not start at 0 (:gh:`607` by `Pierre Guetschel`_)
 
 
 API changes

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -266,7 +266,7 @@ class BaseDataset(metaclass=abc.ABCMeta):
                     StepType.RAW,
                     SetRawAnnotations(
                         self.event_id,
-                        durations=self.interval[1] - self.interval[0],
+                        interval=self.interval,
                     ),
                 ),
             ]

--- a/moabb/paradigms/base.py
+++ b/moabb/paradigms/base.py
@@ -173,7 +173,7 @@ class BaseProcessing(metaclass=abc.ABCMeta):
                     StepType.RAW,
                     SetRawAnnotations(
                         dataset.event_id,
-                        durations=dataset.interval[1] - dataset.interval[0],
+                        interval=dataset.interval,
                     ),
                 )
             )


### PR DESCRIPTION
The annotations added by `SetRawAnnotations` do not take into account the case when a dataset’s interval does not start at 0. This PR fixes it.