### PR TITLE
Update paths of BIDS cache

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -22,6 +22,7 @@ Enhancements
 - Update version of pyRiemann to 0.7 (:gh:`671` by `Gregoire Cattan`_)
 - Add columns definitions in the datasets doc (:gh:`672` by `Pierre Guetschel`_)
 - Add ERP CORE datasets :class:`moabb.datasets.ErpCore2021` dataset (:gh:`627` by `Taha Habib`_)
+- Update paths of BIDS cache to better follow the standards. Cache created in previous MOABB versions should still be compatible (:gh:`707` by `Pierre Guetschel`_)
 
 Bugs
 ~~~~

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -184,7 +184,7 @@ class BIDSInterfaceBase(abc.ABC):
             descriptions=self.desc,
             extensions=self._extension,
             check=self._check,
-            datatypes="eeg",
+            # datatypes="eeg", # commented for compatibility with cache saved in previous versions
             suffixes=self._suffix,
         )
         sessions_data = {}

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -121,7 +121,7 @@ class BIDSInterfaceBase(abc.ABC):
         """Return the representation of the BIDSInterface."""
         return (
             f"{self.dataset.code!r} sub-{self.subject} "
-            f"datatype-{self._datatype} desc-{self.desc:.7}"
+            f"suffix-{self._suffix} desc-{self.desc:.7}"
         )
 
     @property
@@ -184,8 +184,8 @@ class BIDSInterfaceBase(abc.ABC):
             descriptions=self.desc,
             extensions=self._extension,
             check=self._check,
-            datatypes=self._datatype,
-            suffixes=self._datatype,
+            datatypes="eeg",
+            suffixes=self._suffix,
         )
         sessions_data = {}
         for path in paths:
@@ -252,8 +252,8 @@ class BIDSInterfaceBase(abc.ABC):
                     **run_kwargs,
                     description=self.desc,
                     extension=self._extension,
-                    datatype=self._datatype,
-                    suffix=self._datatype,
+                    datatype="eeg",
+                    suffix=self._suffix,
                     check=self._check,
                 )
 
@@ -286,7 +286,7 @@ class BIDSInterfaceBase(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def _datatype(self):
+    def _suffix(self):
         pass
 
 
@@ -305,7 +305,7 @@ class BIDSInterfaceRawEDF(BIDSInterfaceBase):
         return True
 
     @property
-    def _datatype(self):
+    def _suffix(self):
         return "eeg"
 
     def _load_file(self, bids_path, preload):
@@ -378,9 +378,7 @@ class BIDSInterfaceEpochs(BIDSInterfaceBase):
         return False
 
     @property
-    def _datatype(self):
-        # because of mne conventions, we need the suffix to be "epo"
-        # because of mne_bids conventions, we need datatype and suffix to match
+    def _suffix(self):
         return "epo"
 
     def _load_file(self, bids_path, preload):
@@ -410,7 +408,7 @@ class BIDSInterfaceNumpyArray(BIDSInterfaceBase):
         return False
 
     @property
-    def _datatype(self):
+    def _suffix(self):
         return "array"
 
     def _load_file(self, bids_path, preload):

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -154,10 +154,10 @@ class Test_Datasets(unittest.TestCase):
                 )
             print("\n".join(cm.output))
             expected = [
-                "Attempting to retrieve cache .* datatype-eeg",  # empty pipeline
+                "Attempting to retrieve cache .* suffix-eeg",  # empty pipeline
                 "No cache found at",
-                "Starting caching .* datatype-eeg",
-                "Finished caching .* datatype-eeg",
+                "Starting caching .* suffix-eeg",
+                "Finished caching .* suffix-eeg",
             ]
             assert len(expected) == len(cm.output)
             for i, regex in enumerate(expected):
@@ -178,8 +178,8 @@ class Test_Datasets(unittest.TestCase):
                 )
             print("\n".join(cm.output))
             expected = [
-                "Attempting to retrieve cache .* datatype-eeg",
-                "Finished reading cache .* datatype-eeg",
+                "Attempting to retrieve cache .* suffix-eeg",
+                "Finished reading cache .* suffix-eeg",
             ]
             assert len(expected) == len(cm.output)
             for i, regex in enumerate(expected):
@@ -200,10 +200,10 @@ class Test_Datasets(unittest.TestCase):
                 )
             print("\n".join(cm.output))
             expected = [
-                "Starting erasing cache .* datatype-eeg",
-                "Finished erasing cache .* datatype-eeg",
-                "Starting caching .* datatype-eeg",
-                "Finished caching .* datatype-eeg",
+                "Starting erasing cache .* suffix-eeg",
+                "Finished erasing cache .* suffix-eeg",
+                "Starting caching .* suffix-eeg",
+                "Finished caching .* suffix-eeg",
             ]
             assert len(expected) == len(cm.output)
             for i, regex in enumerate(expected):

--- a/moabb/tests/test_paradigms.py
+++ b/moabb/tests/test_paradigms.py
@@ -187,21 +187,21 @@ class TestMotorImagery(unittest.TestCase):
             )
         print("\n".join(cm.output))
         expected = [
-            "Attempting to retrieve cache .* datatype-array",
+            "Attempting to retrieve cache .* suffix-array",
             "No cache found at",
-            "Attempting to retrieve cache .* datatype-epo",
+            "Attempting to retrieve cache .* suffix-epo",
             "No cache found at",
-            "Attempting to retrieve cache .* datatype-eeg",  # raw_pipeline
+            "Attempting to retrieve cache .* suffix-eeg",  # raw_pipeline
             "No cache found at",
-            "Attempting to retrieve cache .* datatype-eeg",
+            "Attempting to retrieve cache .* suffix-eeg",
             # SetRawAnnotations pipeline
             "No cache found at",
-            "Starting caching .* datatype-eeg",
-            "Finished caching .* datatype-eeg",
-            "Starting caching .* datatype-epo",
-            "Finished caching .* datatype-epo",
-            "Starting caching .* datatype-array",
-            "Finished caching .* datatype-array",
+            "Starting caching .* suffix-eeg",
+            "Finished caching .* suffix-eeg",
+            "Starting caching .* suffix-epo",
+            "Finished caching .* suffix-epo",
+            "Starting caching .* suffix-array",
+            "Finished caching .* suffix-array",
         ]
         assert len(expected) == len(cm.output)
         for i, regex in enumerate(expected):
@@ -225,8 +225,8 @@ class TestMotorImagery(unittest.TestCase):
             )
         print("\n".join(cm.output))
         expected = [
-            "Attempting to retrieve cache .* datatype-array",
-            "Finished reading cache .* datatype-array",
+            "Attempting to retrieve cache .* suffix-array",
+            "Finished reading cache .* suffix-array",
         ]
         assert len(expected) == len(cm.output)
         for i, regex in enumerate(expected):
@@ -250,10 +250,10 @@ class TestMotorImagery(unittest.TestCase):
             )
         print("\n".join(cm.output))
         expected = [
-            "Starting erasing cache .* datatype-array",
-            "Finished erasing cache .* datatype-array",
-            "Attempting to retrieve cache .* datatype-epo",
-            "Finished reading cache .* datatype-epo",
+            "Starting erasing cache .* suffix-array",
+            "Finished erasing cache .* suffix-array",
+            "Attempting to retrieve cache .* suffix-epo",
+            "Finished reading cache .* suffix-epo",
         ]
         assert len(expected) == len(cm.output)
         for i, regex in enumerate(expected):
@@ -277,12 +277,12 @@ class TestMotorImagery(unittest.TestCase):
             )
         print("\n".join(cm.output))
         expected = [
-            "Attempting to retrieve cache .* datatype-array",
+            "Attempting to retrieve cache .* suffix-array",
             "No cache found at",
-            "Starting erasing cache .* datatype-epo",
-            "Finished erasing cache .* datatype-epo",
-            "Attempting to retrieve cache .* datatype-eeg",
-            "Finished reading cache .* datatype-eeg",
+            "Starting erasing cache .* suffix-epo",
+            "Finished erasing cache .* suffix-epo",
+            "Attempting to retrieve cache .* suffix-eeg",
+            "Finished reading cache .* suffix-eeg",
         ]
         assert len(expected) == len(cm.output)
         for i, regex in enumerate(expected):


### PR DESCRIPTION
This PR does small adjustments to the paths used to save the cache. Now the `datatype` is always `”eeg”` and only the `suffix` is changed. This way, the raw cache is now a “real” BIDS dataset