### PR TITLE
`BaseBIDSDataset` and `LocalBIDSDataset`

### DIFF
--- a/docs/source/api/datasets.rst
+++ b/docs/source/api/datasets.rst
@@ -120,6 +120,8 @@ Base & Utils
     :template: class.rst
 
     base.BaseDataset
+    base.BaseBIDSDataset
+    base.LocalBIDSDataset
     base.CacheConfig
     fake.FakeDataset
     fake.FakeVirtualRealityDataset

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -21,6 +21,7 @@ Enhancements
 - Reordering the examples in the documentation (:gh:`807` by `Bruno Aristimunha`_)
 - Creating the meta information for the BIDS converted datasets (:gh:`688` by `Bruno Aristimunha`_)
 - Adding :class:`moabb.dataset.Beetl2021A` and :class:`moabb.dataset.Beetl2021B`(:gh:`675` by `Samuel Boehm_`)
+- Adding :class:`moabb.dataset.base.BaseBIDSDataset` and :class:`moabb.dataset.base.LocalBIDSDataset` (:gh:`724` by `Pierre Guetschel`_)
 
 
 Bugs

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -1,7 +1,6 @@
 """Base class for a dataset."""
 
 from __future__ import annotations
-from typing import Any
 
 import abc
 import logging
@@ -10,11 +9,11 @@ import traceback
 from dataclasses import dataclass
 from inspect import signature
 from pathlib import Path
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
+import mne_bids
 import pandas as pd
 from sklearn.pipeline import Pipeline
-import mne_bids
 
 from moabb.datasets.bids_interface import StepType, _interface_map
 from moabb.datasets.preprocessing import SetRawAnnotations
@@ -662,7 +661,7 @@ class BaseDataset(metaclass=MetaclassDataset):
 class BaseBIDSDataset(BaseDataset):
     """Abstract BIDS dataset class.
 
-    This abstract class can be used to facilitate the integration of datasets which are 
+    This abstract class can be used to facilitate the integration of datasets which are
     provided in the Brain Imaging Data Structure (BIDS) format into MOABB.
 
     More information about BIDS can be found at https://bids.neuroimaging.io/.

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -21,6 +21,23 @@ from moabb.datasets.preprocessing import SetRawAnnotations
 
 log = logging.getLogger(__name__)
 
+_RAW_EXTENSIONS = [
+    ".con",
+    ".sqd",
+    ".pdf",
+    ".fif",
+    ".ds",
+    ".vhdr",
+    ".set",
+    ".edf",
+    ".bdf",
+    ".EDF",
+    ".snirf",
+    ".cdt",
+    ".mef",
+    ".nwb",
+]
+
 
 def get_summary_table(paradigm: str, dir_name: str | None = None):
     if dir_name is None:
@@ -675,24 +692,7 @@ class BaseBIDSDataset(BaseDataset):
 
     def _get_path_search_params(self, subject: int | None) -> dict[str, Any]:
         """Return the kwargs for the :func:`mne_bids.find_matching_paths` function."""
-        out = {
-            "extensions": [
-                ".con",
-                ".sqd",
-                ".pdf",
-                ".fif",
-                ".ds",
-                ".vhdr",
-                ".set",
-                ".edf",
-                ".bdf",
-                ".EDF",
-                ".snirf",
-                ".cdt",
-                ".mef",
-                ".nwb",
-            ],
-        }
+        out = {"extensions": _RAW_EXTENSIONS}
         if subject is not None:
             out["subjects"] = str(subject)
         return out

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -309,7 +309,7 @@ class Test_Datasets(unittest.TestCase):
 
     def test_bad_subject_name(self):
         ds = FakeDataset()
-        ds.subject_list = ["1", "2", "3"]
+        ds.subject_list = [1.0, 2.0, 3.0]
         with pytest.raises(ValueError, match=r"Subject names must be "):
             ds.get_data()
 

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -14,10 +14,10 @@ import moabb.datasets.compound_dataset as db_compound
 from moabb.datasets import BNCI2014_001, Cattan2019_VR, Shin2017A, Shin2017B
 from moabb.datasets.base import (
     BaseDataset,
+    LocalBIDSDataset,
     _summary_table,
     is_abbrev,
     is_camel_kebab_case,
-    LocalBIDSDataset,
 )
 from moabb.datasets.compound_dataset import CompoundDataset
 from moabb.datasets.compound_dataset.utils import compound_dataset_list

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -17,6 +17,7 @@ from moabb.datasets.base import (
     _summary_table,
     is_abbrev,
     is_camel_kebab_case,
+    LocalBIDSDataset,
 )
 from moabb.datasets.compound_dataset import CompoundDataset
 from moabb.datasets.compound_dataset.utils import compound_dataset_list
@@ -590,3 +591,40 @@ class TestData:
         np.testing.assert_array_equal(raw.annotations.duration, np.ones(48) * 4.0)
         description = ["tongue", "feet", "right_hand"]
         assert all([a == b for a, b in zip(raw.annotations.description[:3], description)])
+
+
+class TestBIDSDataset:
+    @pytest.fixture(scope="class")
+    def cached_dataset_root(self, tmpdir_factory):
+        root = tmpdir_factory.mktemp("fake_bids")
+        dataset = FakeDataset(
+            event_list=["fake1", "fake2"], n_sessions=2, n_subjects=2, n_runs=1
+        )
+        dataset.get_data(cache_config=dict(save_raw=True, overwrite_raw=False, path=root))
+        return root / "MNE-BIDS-fake-dataset-imagery-2-2--60--120--fake1-fake2--c3-cz-c4"
+
+    def test_local_bids_dataset(self, cached_dataset_root, caplog):
+        with caplog.at_level(logging.WARNING):
+            dataset = LocalBIDSDataset(
+                cached_dataset_root,
+                events={"fake1": 1, "fake2": 2},
+                interval=[0, 3],
+                paradigm="imagery",
+            )
+        log = caplog.text.strip().split("\n")
+        expected = [
+            "Found subjects: ['1', '2']",
+            "Found sessions_per_subject=2",
+        ]
+        assert len(expected) == len(log)
+        for i, regex in enumerate(expected):
+            assert regex in log[i]
+
+        # raw data
+        raw_data = dataset.get_data()
+        assert raw_data.keys() == {"1", "2"}
+        for subject_data in raw_data.values():
+            assert subject_data.keys() == {"0", "1"}
+            for session_data in subject_data.values():
+                assert session_data.keys() == {"0"}
+                assert isinstance(session_data["0"], mne.io.BaseRaw)


### PR DESCRIPTION
This PR adds two new datasets:
- `BaseBIDSDataset` from which we can inherit to facilitate the integration of new datasets which are formated in BIDS to MOABB
- `LocalBIDSDataset` which can be useful to use local/private dataset in BIDS format with the MOABB API, without having to create a new dataset class.