### PR TITLE
Pick all data channels in filter preprocessing step

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -28,6 +28,7 @@ Bugs
 ~~~~
 - Fix caching issue with incomplete results (:gh:`715` by `Sylvain Chevallier`_)
 - Fix learning curve example (:gh:`717` by `Pierre Guetschel`_)
+- Pick all data channels in filter preprocessing step (:gh:`729` by `Pierre Guetschel`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/datasets/preprocessing.py
+++ b/moabb/datasets/preprocessing.py
@@ -286,7 +286,7 @@ def get_filter_pipeline(fmin, fmax):
             l_freq=fmin,
             h_freq=fmax,
             method="iir",
-            picks="eeg",
+            picks="data",
             verbose=False,
         ),
     )


### PR DESCRIPTION
I was trying to epoch ECoG data using `LocalBIDSDataset` and it was not working due to the `pick` argument of the filtering step. 
This PR filters all "data" channels (i.e., EEG, MEG, ECoG... but not stim)