### PR TITLE
Fix seed in permutation test

### DIFF
--- a/moabb/analysis/meta_analysis.py
+++ b/moabb/analysis/meta_analysis.py
@@ -148,7 +148,7 @@ def _pairedttest_random(data, nperms, seed=None):
     return out / nperms
 
 
-def compute_pvals_perm(df, order=None):
+def compute_pvals_perm(df, order=None, seed=None):
     """Compute permutation test on aggregated results.
 
     Returns kxk matrix of p-values computed via permutation test,
@@ -161,6 +161,8 @@ def compute_pvals_perm(df, order=None):
         and values are scores
     order: list
         list of length (num algorithms) with names corresponding to df columns
+    seed: int | None
+        random seed for reproducibility
 
     Returns
     -------
@@ -181,7 +183,7 @@ def compute_pvals_perm(df, order=None):
             data[:, i, j] = df.loc[:, pipe1] - df.loc[:, pipe2]
             data[:, j, i] = df.loc[:, pipe2] - df.loc[:, pipe1]
     if data.shape[0] > 13:
-        p = _pairedttest_random(data, 10000)
+        p = _pairedttest_random(data, 10000, seed=seed)
     else:
         p = _pairedttest_exhaustive(data)
     return p

--- a/moabb/tests/test_analysis.py
+++ b/moabb/tests/test_analysis.py
@@ -129,7 +129,7 @@ class TestStats:
         ), f"P-values should be equal to 1 - 1/n_perms {pvals}"
 
     def test_perm_random(self):
-        rng = np.random.default_rng(12)
+        rng = np.random.RandomState(12)
         data = (
             self.return_df((18, 5)) * 0
         )  # We provide the exact same data for each pipeline
@@ -160,7 +160,7 @@ class TestStats:
         assert p1vsp2 == 1 / n_perms, f"P-values cannot be zero {pvals}"
 
     def test_compute_pvals_random_cannot_be_zero(self):
-        rng = np.random.default_rng(12)
+        rng = np.random.RandomState(12)
         df = pd.DataFrame({"pipeline_1": [1] * 18, "pipeline_2": [0] * 18})
         n_perms = 10000  # hardcoded in _pairedttest_random
         pvals = ma.compute_pvals_perm(df, seed=rng)

--- a/moabb/tests/test_analysis.py
+++ b/moabb/tests/test_analysis.py
@@ -129,12 +129,13 @@ class TestStats:
         ), f"P-values should be equal to 1 - 1/n_perms {pvals}"
 
     def test_perm_random(self):
+        rng = np.random.default_rng(12)
         data = (
             self.return_df((18, 5)) * 0
         )  # We provide the exact same data for each pipeline
         n_perms = 10000  # hardcoded in _pairedttest_random
 
-        pvals = ma.compute_pvals_perm(data)
+        pvals = ma.compute_pvals_perm(data, seed=rng)
         assert np.all(
             pvals == 1 - 1 / n_perms
         ), f"P-values should be equal to 1 - 1/n_perms {pvals}"
@@ -159,9 +160,10 @@ class TestStats:
         assert p1vsp2 == 1 / n_perms, f"P-values cannot be zero {pvals}"
 
     def test_compute_pvals_random_cannot_be_zero(self):
+        rng = np.random.default_rng(12)
         df = pd.DataFrame({"pipeline_1": [1] * 18, "pipeline_2": [0] * 18})
         n_perms = 10000  # hardcoded in _pairedttest_random
-        pvals = ma.compute_pvals_perm(df)
+        pvals = ma.compute_pvals_perm(df, seed=rng)
         p1vsp2 = pvals[0, 1]
         assert p1vsp2 >= 1 / n_perms, "P-values cannot be zero "
 


### PR DESCRIPTION
Follow-up of #735 
This PR fixes the random seed in the test to ensure they are reproducible.

@gcattan @bruAristimunha do you think we should expose the seed parameter in function `compute_pvals_perm` or define it from within the function to avoid seed optimisation?