### PR TITLE
Update the range of python versions to allow moabb to work with python 3.13.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-         os: [ ubuntu-latest, macOS-latest ]
+        os: [ ubuntu-latest, macOS-latest ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+         os: [ ubuntu-latest, macOS-latest ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     defaults:
       run:

--- a/moabb/tests/test_classification.py
+++ b/moabb/tests/test_classification.py
@@ -7,7 +7,7 @@ from moabb.pipelines import SSVEP_MsetCCA
 
 
 class TestSSVEP_MsetCCA:
-    def setup(self):
+    def setup_method(self):
         # Use moabb generated dataset for test
         dataset = FakeDataset(n_sessions=1, n_runs=1, n_subjects=1, paradigm="ssvep")
         paradigm = SSVEP(n_classes=3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["eeg", "datasets", "reproducibility", "bci", "benchmark"]
 license = "BSD-3-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.14"
+python = ">=3.9"
 numpy = "^1.22"
 scipy = "^1.9.3"
 mne = "^1.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ coverage = "^7.0.1"
 memory-profiler = "^0.61.0"
 edflib-python = "^1.0.6"
 edfio = "^0.4.2"
-pytest = "^7.4.0"
+pytest = "^8.3.5"
 mne-bids = ">=0.14"
 scikit-learn = "<1.6"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["eeg", "datasets", "reproducibility", "bci", "benchmark"]
 license = "BSD-3-Clause"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9,<3.14"
 numpy = "^1.22"
 scipy = "^1.9.3"
 mne = "^1.7.0"


### PR DESCRIPTION
The current constraint states <3.13. Current release is 3.13.2, so MOABB is not easily installable with pip.
Update the value to 3.14 (which is currently a pre-release version).