### PR TITLE
Last mini-change to the dataset plot

### DIFF
--- a/examples/advanced_examples/plot_dataset_bubbles.py
+++ b/examples/advanced_examples/plot_dataset_bubbles.py
@@ -144,6 +144,7 @@ plt.show()
 # file, as the figure is quite large and may be long to render.
 
 fig = plot_datasets_grid(n_col=5)
+fig.tight_layout()
 plt.show()
 
 ###############################################################################
@@ -151,4 +152,5 @@ plt.show()
 # function to visualize the datasets in more compact format.
 
 fig = plot_datasets_cluster()
+fig.tight_layout()
 plt.show()

--- a/moabb/datasets/utils.py
+++ b/moabb/datasets/utils.py
@@ -543,7 +543,6 @@ class _BaseDatasetPlotter:
                 scale_ax=False,
                 **self.kwargs,
             )
-        fig.tight_layout()
         return fig
 
 


### PR DESCRIPTION
follow-up of #753 

The annoying part with these `plt.Circle` plot is that they don't get the same scaling as the text. `fig.tight_layeout` changes the scaling. It is problematic when you want multiple figures at the same scale. This should fix things...