### PR TITLE
Changed channels CB1 and CB2's type from 'misc' to 'eeg' from Wang2016 dataset

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -41,6 +41,7 @@ Bugs
 - Fix download issue with Schirrmeister2017 dataset (:gh:`751` by `Zheyu Yao`_)
 - Fix code carbon example code (:gh:`777` by `Amar Enkhbat`_)
 - Including the fix_bad_channels for the :class:`moabb.datasets.Stieger2021` (:gh:`783` by `Bruno Aristimunha`_)
+- Fix the :class:`moabb.datasets.Wang2016` (:gh:`781` by `Ulysse Durand`_)
 
 API changes
 ~~~~~~~~~~~
@@ -558,7 +559,7 @@ API changes
 .. _AFF: https://github.com/allwaysFindFood
 .. _Marco Congedo: https://github.com/Marco-Congedo
 .. _Samuel Boehm: https://github.com/Samuel-Boehm
-.. _Amar Enkhbat https://github.com/amar-enkhbat
+.. _Amar Enkhbat: https://github.com/amar-enkhbat
 .. _Alexander de Ranitz: https://github.com/alexander-de-ranitz
 .. _Luuk Neervens: https://github.com/LuukNeervens
 .. _Charlynn van Osch: https://github.com/charlynnvanosch
@@ -566,3 +567,4 @@ API changes
 .. _Thomas Kooiman: https://github.com/jellymace
 .. _Jorge Sanmartin Martinez: https://github.com/jorgesanmar
 .. _Radovan Vodila: https://github.com/rvodila
+.. _UlysseDurand: https://github.com/UlysseDurand

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -71,6 +71,22 @@ class Wang2016(BaseDataset):
     group (eight subjects, S01-S08) and a ‘naive’ group (27 subjects, S09-S35)
     according to their experience in SSVEP-based BCIs.
 
+    Warning
+    -------
+    The original dataset includes two channels labeled 'CB1' and 'CB2',
+    which are **not part of the standard 10-20 EEG montage**.
+    Although the authors of Wang2016 state that the 10-20 layout was used,
+    the provided channel location file suggests that 'CB1' and 'CB2'
+    may correspond approximately to 'P9' and 'P10'. However, this mapping is
+    **not confirmed**, and the exact locations remain uncertain.
+
+    In this implementation, we treat 'CB1' and 'CB2' as standard EEG channels,
+    following the approach used by the authors.
+
+    Users should be aware of this ambiguity when interpreting spatial analyses
+    or when comparing to other datasets with strictly standard montages.
+
+
     References
     ----------
     .. [1] Y. Wang, X. Chen, X. Gao and S. Gao, 2017, "A Benchmark Dataset for

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -134,7 +134,7 @@ class Wang2016(BaseDataset):
         buff = (data.shape[0], n_channels + 1, 50)
         data = np.concatenate([np.zeros(buff), data, np.zeros(buff)], axis=2)
 
-        ch_types = ["eeg"] * 59 + ["misc"] + 3 * ["eeg"] + ["misc", "stim"]
+        ch_types = ["eeg"] * 64 + ["stim"]
         sfreq = 250
         info = create_info(self._ch_names, sfreq, ch_types)
         raw = RawArray(data=np.concatenate(list(data), axis=1), info=info, verbose=False)

--- a/moabb/datasets/summary_ssvep.csv
+++ b/moabb/datasets/summary_ssvep.csv
@@ -5,4 +5,4 @@ MAMEM1,10,256,5,12-15,3,250,1,https://paperswithcode.com/dataset/mamem1-moabb
 MAMEM2,10,256,5,20-30,3,250,1,https://paperswithcode.com/dataset/mamem2-moabb
 MAMEM3,10,14,4,20-30,3,128,1,https://paperswithcode.com/dataset/mamem3-moabb
 Nakanishi2015,9,8,12,15,4.15,256,1,https://paperswithcode.com/dataset/nakanishi2015-moabb
-Wang2016,34,62,40,6,5,250,1,https://paperswithcode.com/dataset/wang2016-moabb
+Wang2016,34,64,40,6,5,250,1,https://paperswithcode.com/dataset/wang2016-moabb


### PR DESCRIPTION
As discussed in #780, the Wang2016 dataset has 64 channels, not 62. I changed the part of the code which is responsible for that as in the paper there is no mention of CB1 and CB2 not being EEG channels, they even have a location in the 64-channels.loc file from the dataset.

I wasn't able to generate the doc (running sphinx made me download MOABB datasets I didn't want to download) to check if this change in the code changed the `#Chan` from 62 to 64 in the doc.

Thank you