### PR TITLE
DOC Add function to auto-generate the paper results tables

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ copy-readme:
 	@cp ../README.md $(SOURCEDIR)/README.md
 
 clean:
-	-rm -rf build source/auto_examples source/generated
+	-rm -rf build source/auto_examples source/generated source/results
 
 # Help target.
 help: copy-readme
@@ -32,10 +32,12 @@ apidoc: copy-readme
 # HTML build target.
 html: copy-readme
 	@python prepare_summary_tables.py ../moabb/datasets $(BUILDDIR)
+	@python prepare_paper_results_tables.py ../results $(SOURCEDIR)/results
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # HTML build target without plot gallery.
 html-noplot: copy-readme
 	@python prepare_summary_tables.py ../moabb/datasets $(BUILDDIR)
+	@python prepare_paper_results_tables.py ../results $(SOURCEDIR)/results
 	@$(SPHINXBUILD) -D plot_gallery=0 -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/prepare_paper_results_tables.py
+++ b/docs/prepare_paper_results_tables.py
@@ -1,0 +1,85 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+import pandas as pd
+
+pipelines_files = {
+    "SSVEP_CCA": "CCA-SSVEP.yml",
+    "SSVEP_MsetCCA": "MsetCCA-SSVEP.yml",
+    "SSVEP_MDM": "MDM-SSVEP.yml",
+    "SSVEP_TS+LR": "TSLR-SSVEP.yml",
+    "SSVEP_TS+SVM": "TSSVM_grid.yml",
+    "SSVEP_TRCA": "TRCA-SSVEP.yml",
+    "XDAWN+LDA": "xDAWN_LDA.yml",
+    "XDAWNCov+MDM": "XdawnCov_MDM.yml",
+    "XDAWNCov+TS+SVM": "XdawnCov_TS_SVM.yml",
+    "ERPCov+MDM": "ERPCov_MDM.yml",
+    "ERPCov(svd_n=4)+MDM": "ERPCov_MDM.yml",
+    "ACM+TS+SVM": "AUG_TANG_SVM_grid.yml",
+    "CSP+LDA": "CSP.yml",
+    "CSP+SVM": "CSP_SVM_grid.yml",
+    "DLCSPauto+shLDA": "regCSP%2BshLDA.yml",
+    "DeepConvNet": "Keras_DeepConvNet.yml",
+    "EEGITNet": "Keras_EEGITNet.yml",
+    "EEGNeX": "Keras_EEGNeX.yml",
+    "EEGNet_8_2": "Keras_EEGNet_8_2.yml",
+    "EEGTCNet": "Keras_EEGITNet.yml",
+    "FilterBank+SVM": "FBCSP.py",
+    "FgMDM": "FgMDM.yml",
+    "LogVariance+LDA": "LogVar_grid.yml",
+    "LogVariance+SVM": "LogVar_grid.yml#L7",
+    "MDM": "MDM.yml",
+    "ShallowConvNet": "Keras_ShallowConvNet.yml",
+    "TRCSP+LDA": "WTRCSP.py",
+    "TS+EL": "EN_grid.yml",
+    "TS+LR": "TSLR.yml",
+    "TS+SVM": "TSSVM_grid.yml",
+}
+
+
+def wrap_pipeline(name: str) -> str:
+    name = name.split("`")[1]
+    file_name = pipelines_files.get(name)
+    if file_name is not None:
+        # Required due to Keras removal from MOABB; prevents broken links.
+        branch = "develop" if "Keras" not in file_name else "v1.1.2"
+        url = f"https://github.com/NeuroTechX/moabb/blob/{branch}/pipelines/{file_name}"
+        return f'<a href="{url}">{name}</a>'
+    return name
+
+
+def wrap_dataset(name: str) -> str:
+    if name == "Pipeline":
+        return name
+
+    name = name.split("`")[1]
+    url = f'<a class="reference internal" href="generated/moabb.datasets.{name}.html#moabb.datasets.{name}" title="moabb.datasets.{name}"><code class="xref py py-class docutils literal notranslate"><span class="pre">{name}</span></code></a>'
+    return url
+
+
+def main(source_dir: str, target_dir: str) -> None:
+    target_path = Path(target_dir)
+    target_path.mkdir(parents=True, exist_ok=True)
+    for file in Path(source_dir).glob("*.csv"):
+        target_file = target_path / file.name
+        print(f"Processing {file} -> {target_file}")
+        df = pd.read_csv(file, index_col=False, header=0, skipinitialspace=True)
+        df.columns = df.columns.map(wrap_dataset)
+        df["Pipeline"] = df["Pipeline"].apply(wrap_pipeline)
+        html_table = df.to_html(
+            index=False,
+            classes=["moabb-table", "sortable", "hover", "row-border", "order-column"],
+            escape=False,
+            table_id=file.stem,
+        )
+        with open(f"{target_path}/{file.stem}.html", "w", encoding="utf-8") as f:
+            f.write(html_table)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("source_dir", type=str)
+    parser.add_argument("target_dir", type=str)
+    args = parser.parse_args()
+    main(args.source_dir, args.target_dir)
+    print(args.target_dir)

--- a/docs/prepare_paper_results_tables.py
+++ b/docs/prepare_paper_results_tables.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 
+
 pipelines_files = {
     "SSVEP_CCA": "CCA-SSVEP.yml",
     "SSVEP_MsetCCA": "MsetCCA-SSVEP.yml",

--- a/docs/source/paper_results.rst
+++ b/docs/source/paper_results.rst
@@ -26,6 +26,11 @@
     table.dataTable td {
       text-align: left;
     }
+    html[data-theme="dark"] .dtfc-fixed-left,
+    html[data-theme="dark"] .dtfc-fixed-start {
+      background-color: #1e1e1e !important;
+      color: #ffffff !important;
+    }
    </style>
 
 .. currentmodule:: moabb.datasets

--- a/docs/source/paper_results.rst
+++ b/docs/source/paper_results.rst
@@ -9,14 +9,29 @@
 
    <!-- Must import jquery before the datatables css and js files. -->
    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.0.3/css/dataTables.dataTables.css">
-   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.0.3/js/dataTables.js"></script>
-   <div style="font-size: 1em;">
+   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.3.1/css/dataTables.dataTables.css">
+   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.3.1/js/dataTables.js"></script>
+   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedcolumns/5.0.4/css/fixedColumns.dataTables.css">
+   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/fixedcolumns/5.0.4/js/dataTables.fixedColumns.js"></script>
+   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/fixedcolumns/5.0.4/js/fixedColumns.dataTables.js"></script>
+
+   <style>
+    table.dataTable {
+      font-size: 1.05rem;
+    }
+    div.dt-scroll-head div table.dataTable thead th {
+      padding-right: 5px !important;
+      font-size: 1.05rem;
+    }
+    table.dataTable td {
+      text-align: left;
+    }
+   </style>
 
 .. currentmodule:: moabb.datasets
 
 The largest EEG-based Benchmark for Open Science
-=================================================
+================================================
 
 We report the results of the benchmark study performed in:
 `The largest EEG-based BCI reproducibility study for open science: the MOABB benchmark <https://universite-paris-saclay.hal.science/hal-04537061v1/file/MOABB-arXiv.pdf>`_
@@ -36,7 +51,8 @@ If you use the same evaluation procedure, you should expect similar results if y
 **You can copy and use the table in your work**, but please `**cite the paper** <http://moabb.neurotechx.com/docs/cite.html>`_ if you do so.
 
 Motor Imagery
-=============================
+=============
+
 Motor Imagery is a BCI paradigm where the subject imagines performing a movement.
 Each imagery task is associated with a different class, and each task has its difficulty level related to how the brain generates the signal.
 
@@ -51,52 +67,15 @@ All the results here are for **within-session evaluation**, a 5-fold cross-valid
 
 Motor Imagery - Left vs Right Hand
 ===================================
+
+**Left vs Right Hand**: We use only Left Hand and Right Hand classes.
+
+.. raw:: html
+   :file: results/within_session_mi_left_vs_right_hand.html
+
 .. raw:: html
 
    <hr>
-
-**Left vs Right Hand**: We use only the classes Left Hand and Right Hand.
-
-
-.. raw:: html
-  </div>
-  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.0.3/css/dataTables.dataTables.css">
-   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.0.3/js/dataTables.js"></script>
-
-    <table id="mileftvsright" class="hover row-border order-column" style="width:100%">
-        <thead>
-        <tr class="row-odd"><th class="head"><p>Pipelines</p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2014_001.html#moabb.datasets.BNCI2014_001" title="moabb.datasets.BNCI2014_001"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2014_001</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2014_004.html#moabb.datasets.BNCI2014_004" title="moabb.datasets.BNCI2014_004"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2014_004</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Cho2017.html#moabb.datasets.Cho2017" title="moabb.datasets.Cho2017"><code class="xref py py-class docutils literal notranslate"><span class="pre">Cho2017</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.GrosseWentrup2009.html#moabb.datasets.GrosseWentrup2009" title="moabb.datasets.GrosseWentrup2009"><code class="xref py py-class docutils literal notranslate"><span class="pre">GrosseWentrup2009</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Lee2019_MI.html#moabb.datasets.Lee2019_MI" title="moabb.datasets.Lee2019_MI"><code class="xref py py-class docutils literal notranslate"><span class="pre">Lee2019_MI</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.PhysionetMI.html#moabb.datasets.PhysionetMI" title="moabb.datasets.PhysionetMI"><code class="xref py py-class docutils literal notranslate"><span class="pre">PhysionetMI</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Schirrmeister2017.html#moabb.datasets.Schirrmeister2017" title="moabb.datasets.Schirrmeister2017"><code class="xref py py-class docutils literal notranslate"><span class="pre">Schirrmeister2017</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Shin2017A.html#moabb.datasets.Shin2017A" title="moabb.datasets.Shin2017A"><code class="xref py py-class docutils literal notranslate"><span class="pre">Shin2017A</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Weibo2014.html#moabb.datasets.Weibo2014" title="moabb.datasets.Weibo2014"><code class="xref py py-class docutils literal notranslate"><span class="pre">Weibo2014</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Zhou2016.html#moabb.datasets.Zhou2016" title="moabb.datasets.Zhou2016"><code class="xref py py-class docutils literal notranslate"><span class="pre">Zhou2016</span></code></a></p></th>
-        </tr>
-        </thead>
-    </table>
-   <script type="text/javascript">
-        $(document).ready(function() {
-           $('#mileftvsright').DataTable( {
-              "ajax": 'https://raw.githubusercontent.com/NeuroTechX/moabb/develop/results/within_session_mi_left_vs_right_hand.json',
-              "order": [[ 1, "desc" ]],
-              "bJQueryUI": true,
-              "scrollX": true,
-              "paging": false,
-              "info": false,
-              "searching": false,
-           } );
-        } );
-   </script>
-   <hr>
-
-
-
 
 Motor Imagery - Right Hand vs Feet
 ==================================
@@ -104,130 +83,36 @@ Motor Imagery - Right Hand vs Feet
 **Right Hand vs Feet**: We use only Right Hand and Feet classes.
 
 .. raw:: html
-   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.0.3/css/dataTables.dataTables.css">
-   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.0.3/js/dataTables.js"></script>
+   :file: results/within_session_mi_right_hand_vs_feet.html
 
-    <table id="mirightvsfeet" class="hover row-border order-column" style="width:100%">
-        <thead>
-        <tr class="row-odd"><th class="head"><p>Pipeline</p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.AlexMI.html#moabb.datasets.AlexMI" title="moabb.datasets.AlexMI"><code class="xref py py-class docutils literal notranslate"><span class="pre">AlexMI</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2014_001.html#moabb.datasets.BNCI2014_001" title="moabb.datasets.BNCI2014_001"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2014_001</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2014_002.html#moabb.datasets.BNCI2014_002" title="moabb.datasets.BNCI2014_002"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2014_002</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2015_001.html#moabb.datasets.BNCI2015_001" title="moabb.datasets.BNCI2015_001"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2015_001</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2015_004.html#moabb.datasets.BNCI2015_004" title="moabb.datasets.BNCI2015_004"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2015_004</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.PhysionetMI.html#moabb.datasets.PhysionetMI" title="moabb.datasets.PhysionetMI"><code class="xref py py-class docutils literal notranslate"><span class="pre">PhysionetMI</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Schirrmeister2017.html#moabb.datasets.Schirrmeister2017" title="moabb.datasets.Schirrmeister2017"><code class="xref py py-class docutils literal notranslate"><span class="pre">Schirrmeister2017</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Weibo2014.html#moabb.datasets.Weibo2014" title="moabb.datasets.Weibo2014"><code class="xref py py-class docutils literal notranslate"><span class="pre">Weibo2014</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Zhou2016.html#moabb.datasets.Zhou2016" title="moabb.datasets.Zhou2016"><code class="xref py py-class docutils literal notranslate"><span class="pre">Zhou2016</span></code></a></p></th>
-        </tr>
-        </thead>
-    </table>
-
-
-   <script type="text/javascript">
-        $(document).ready(function() {
-           $('#mirightvsfeet').DataTable( {
-              "ajax": 'https://raw.githubusercontent.com/NeuroTechX/moabb/develop/results/within_session_mi_right_hand_vs_feet.json',
-              "order": [[ 1, "desc" ]],
-              "bJQueryUI": true,
-              "scrollX": true,
-              "paging": false,
-              "info": false,
-              "searching": false,
-           } );
-        } );
-   </script>
-
-
-
-Motor Imagery - All classes
-===================================
 .. raw:: html
 
-   <p></p>
    <hr>
 
+Motor Imagery - All classes
+===========================
 
-
-**All classes**: We use all the classes in the dataset, when there are more than classes that are not Left Hand and Right Hand.
+**All classes**: We use all the classes in the dataset, when there are more classes that are not Left Hand and Right Hand.
 
 .. raw:: html
-   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.0.3/css/dataTables.dataTables.css">
-   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.0.3/js/dataTables.js"></script>
+   :file: results/within_session_mi_all_classes.html
 
-    <table id="mi-all" class="hover row-border order-column" style="width:100%">
-        <thead>
-        <tr class="row-odd"><th class="head"><p>Pipelines</p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.AlexMI.html#moabb.datasets.AlexMI" title="moabb.datasets.AlexMI"><code class="xref py py-class docutils literal notranslate"><span class="pre">AlexMI</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2014_001.html#moabb.datasets.BNCI2014_001" title="moabb.datasets.BNCI2014_001"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2014_001</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.PhysionetMI.html#moabb.datasets.PhysionetMI" title="moabb.datasets.PhysionetMI"><code class="xref py py-class docutils literal notranslate"><span class="pre">PhysionetMI</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Schirrmeister2017.html#moabb.datasets.Schirrmeister2017" title="moabb.datasets.Schirrmeister2017"><code class="xref py py-class docutils literal notranslate"><span class="pre">Schirrmeister2017</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Weibo2014.html#moabb.datasets.Weibo2014" title="moabb.datasets.Weibo2014"><code class="xref py py-class docutils literal notranslate"><span class="pre">Weibo2014</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Zhou2016.html#moabb.datasets.Zhou2016" title="moabb.datasets.Zhou2016"><code class="xref py py-class docutils literal notranslate"><span class="pre">Zhou2016</span></code></a></p></th>
-        </tr>
-        </thead>
-    </table>
-    <script type="text/javascript">
-        $(document).ready(function() {
-           $('#mi-all').DataTable( {
-              "ajax": 'https://raw.githubusercontent.com/NeuroTechX/moabb/develop/results/within_session_mi_all_classes.json',
-              "order": [[ 1, "desc" ]],
-              "bJQueryUI": true,
-              "scrollX": true,
-              "paging": false,
-              "searching": false,
-              "info": false,
-           } );
-        } );
-    </script>
+.. raw:: html
 
-
+   <hr>
 
 SSVEP (All classes)
-======================
+===================
 
 Here, we have the results of the within-session evaluation, a 5-fold cross-validation, over the subject's session.
 We use all the classes available in the dataset.
 
 .. raw:: html
+   :file: results/within_session_ssvep_all_classes.html
 
-   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-   <link href="https://cdn.datatables.net/v/dt/dt-2.0.4/b-3.0.2/b-html5-3.0.2/datatables.min.css" rel="stylesheet">
-   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/v/dt/dt-2.0.4/b-3.0.2/b-html5-3.0.2/datatables.min.js"></script>
+.. raw:: html
 
-    <table id="ssvep" class="hover row-border order-column" style="width:100%">
-        <thead>
-        <tr class="row-odd"><th class="head"><p>Pipeline</p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Kalunga2016.html#moabb.datasets.Kalunga2016" title="moabb.datasets.Kalunga2016"><code class="xref py py-class docutils literal notranslate"><span class="pre">Kalunga2016</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Lee2019_SSVEP.html#moabb.datasets.Lee2019_SSVEP" title="moabb.datasets.Lee2019_SSVEP"><code class="xref py py-class docutils literal notranslate"><span class="pre">Lee2019_SSVEP</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.MAMEM1.html#moabb.datasets.MAMEM1" title="moabb.datasets.MAMEM1"><code class="xref py py-class docutils literal notranslate"><span class="pre">MAMEM1</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.MAMEM2.html#moabb.datasets.MAMEM2" title="moabb.datasets.MAMEM2"><code class="xref py py-class docutils literal notranslate"><span class="pre">MAMEM2</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.MAMEM3.html#moabb.datasets.MAMEM3" title="moabb.datasets.MAMEM3"><code class="xref py py-class docutils literal notranslate"><span class="pre">MAMEM3</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Nakanishi2015.html#moabb.datasets.Nakanishi2015" title="moabb.datasets.Nakanishi2015"><code class="xref py py-class docutils literal notranslate"><span class="pre">Nakanishi2015</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Wang2016.html#moabb.datasets.Wang2016" title="moabb.datasets.Wang2016"><code class="xref py py-class docutils literal notranslate"><span class="pre">Wang2016</span></code></a></p></th>
-        </tr>
-        </thead>
-    </table>
-
-
-   <script type="text/javascript">
-        $(document).ready(function() {
-           $('#ssvep').DataTable( {
-              "ajax": 'https://raw.githubusercontent.com/NeuroTechX/moabb/develop/results/within_session_ssvep_all_classes.json',
-              "order": [[ 1, "desc" ]],
-              "bJQueryUI": true,
-              "scrollX": true,
-              "paging": false,
-              "searching": false,
-              "info": false,
-			  "buttons": ["copyHtml5","csvHtml5"],
-           } );
-        } );
-   </script>
-
-
+   <hr>
 
 P300/ERP (All classes)
 ======================
@@ -236,77 +121,30 @@ Here, we have the results of the within-session evaluation, a 5-fold cross-valid
 We use all the classes available in the dataset.
 
 .. raw:: html
+   :file: results/within_session_erp_p300_all_classes.html
 
-    <table id="p300" class="hover row-border order-column" style="width:100%">
-        <thead>
-        <tr class="row-odd"><th class="head"><p>Pipelines</p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2014_008.html#moabb.datasets.BNCI2014_008" title="moabb.datasets.BNCI2014_008"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2014_008</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2014_009.html#moabb.datasets.BNCI2014_009" title="moabb.datasets.BNCI2014_009"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2014_009</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BNCI2015_003.html#moabb.datasets.BNCI2015_003" title="moabb.datasets.BNCI2015_003"><code class="xref py py-class docutils literal notranslate"><span class="pre">BNCI2015_003</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BI2012.html#moabb.datasets.BI2012" title="moabb.datasets.BI2012"><code class="xref py py-class docutils literal notranslate"><span class="pre">BI2012</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BI2013a.html#moabb.datasets.BI2013a" title="moabb.datasets.BI2013a"><code class="xref py py-class docutils literal notranslate"><span class="pre">BI2013a</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BI2014a.html#moabb.datasets.BI2014a" title="moabb.datasets.BI2014a"><code class="xref py py-class docutils literal notranslate"><span class="pre">BI2014a</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BI2014b.html#moabb.datasets.BI2014b" title="moabb.datasets.BI2014b"><code class="xref py py-class docutils literal notranslate"><span class="pre">BI2014b</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BI2015a.html#moabb.datasets.BI2015a" title="moabb.datasets.BI2015a"><code class="xref py py-class docutils literal notranslate"><span class="pre">BI2015a</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.BI2015b.html#moabb.datasets.BI2015b" title="moabb.datasets.BI2015b"><code class="xref py py-class docutils literal notranslate"><span class="pre">BI2015b</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Cattan2019_VR.html#moabb.datasets.Cattan2019_VR" title="moabb.datasets.Cattan2019_VR"><code class="xref py py-class docutils literal notranslate"><span class="pre">Cattan2019_VR</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.EPFLP300.html#moabb.datasets.EPFLP300" title="moabb.datasets.EPFLP300"><code class="xref py py-class docutils literal notranslate"><span class="pre">EPFLP300</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Huebner2017.html#moabb.datasets.Huebner2017" title="moabb.datasets.Huebner2017"><code class="xref py py-class docutils literal notranslate"><span class="pre">Huebner2017</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Huebner2018.html#moabb.datasets.Huebner2018" title="moabb.datasets.Huebner2018"><code class="xref py py-class docutils literal notranslate"><span class="pre">Huebner2018</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Lee2019_ERP.html#moabb.datasets.Lee2019_ERP" title="moabb.datasets.Lee2019_ERP"><code class="xref py py-class docutils literal notranslate"><span class="pre">Lee2019_ERP</span></code></a></p></th>
-        <th class="head"><p><a class="reference internal" href="api/generated/moabb.datasets.Sosulski2019.html#moabb.datasets.Sosulski2019" title="moabb.datasets.Sosulski2019"><code class="xref py py-class docutils literal notranslate"><span class="pre">Sosulski2019</span></code></a></p></th>
-        </tr>
-        </thead>
-    </table>
+.. raw:: html
 
+   <hr>
 
-   <script type="text/javascript">
-        $(document).ready(function() {
-           $('#p300').DataTable( {
-              "ajax": 'https://raw.githubusercontent.com/NeuroTechX/moabb/develop/results/within_session_erp_p300_all_classes.json',
-              "order": [[ 1, "desc" ]],
-              "bJQueryUI": true,
-              "scrollX": true,
-              "paging": false,
-              "searching": false,
-              "info": false,
-			  "buttons": ["copyHtml5","csvHtml5"],
-           } );
-        } );
+  <script type="text/javascript">
+     $(document).ready(function() {
+       $(".sortable").each(function() {
+         const $table = $(this);
+
+         $table.DataTable({
+           fixedColumns: true,
+           order: [[1, "desc"]],
+           bJQueryUI: true,
+           scrollX: true,
+           paging: false,
+           scrollCollapse: true,
+           info: false,
+           searching: false,
+         });
+       });
+     });
    </script>
-   <p></p>
-
-
-.. _SSVEP_CCA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/CCA-SSVEP.yml
-.. _SSVEP_MsetCCA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/MsetCCA-SSVEP.yml
-.. _SSVEP_MDM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/MDM-SSVEP.yml
-.. _SSVEP_TS+LR: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/TSLR-SSVEP.yml
-.. _SSVEP_TS+SVM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/TSSVM_grid.yml
-.. _SSVEP_TRCA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/TRCA-SSVEP.yml
-.. _XDAWN+LDA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/xDAWN_LDA.yml
-.. _XDAWNCov+MDM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/XdawnCov_MDM.yml
-.. _XDAWNCov+TS+SVM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/XdawnCov_TS_SVM.yml
-.. _ERPCov+MDM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/ERPCov_MDM.yml
-.. _ERPCov(svd_n=4)+MDM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/ERPCov_MDM.yml
-.. _ACM+TS+SVM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/AUG_TANG_SVM_grid.yml
-.. _CSP+LDA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/CSP.yml
-.. _CSP+SVM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/CSP_SVM_grid.yml
-.. _DLCSPauto+shLDA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/regCSP%2BshLDA.yml
-.. _DeepConvNet: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/Keras_DeepConvNet.yml
-.. _EEGITNet: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/Keras_EEGITNet.yml
-.. _EEGNeX: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/Keras_EEGNeX.yml
-.. _EEGNet_8_2: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/Keras_EEGNet_8_2.yml
-.. _EEGTCNet: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/Keras_EEGITNet.yml
-.. _FilterBank+SVM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/FBCSP.py
-.. _FgMDM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/FgMDM.yml
-.. _LogVariance+LDA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/LogVar_grid.yml
-.. _LogVariance+SVM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/LogVar_grid.yml#L7
-.. _MDM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/MDM.yml
-.. _ShallowConvNet: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/Keras_ShallowConvNet.yml
-.. _TRCSP+LDA: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/WTRCSP.py
-.. _TS+EL: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/EN_grid.yml
-.. _TS+LR: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/TSLR.yml
-.. _TS+SVM: https://github.com/NeuroTechX/moabb/blob/develop/pipelines/TSSVM_grid.yml
 
 .. toctree::
    :glob:

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -32,6 +32,7 @@ Enhancements
 - Improve the dataset model cards in each API page (:gh:`765` by `Pierre Guetschel`_)
 - Adding tutorial on using mne-features (:gh:`762` by `Alexander de Ranitz`_, `Luuk Neervens`_, `Charlynn van Osch`_ and `Bruno Aristimunha`_)
 - Creating tutorial to expose the pre-processing steps (:gh:`771` by `Bruno Aristimunha`_)
+- Add function to auto-generate tables for the paper results documentation page (:gh:`785` by `Lucas Heck`_) 
 
 Bugs
 ~~~~

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -32,7 +32,7 @@ Enhancements
 - Improve the dataset model cards in each API page (:gh:`765` by `Pierre Guetschel`_)
 - Adding tutorial on using mne-features (:gh:`762` by `Alexander de Ranitz`_, `Luuk Neervens`_, `Charlynn van Osch`_ and `Bruno Aristimunha`_)
 - Creating tutorial to expose the pre-processing steps (:gh:`771` by `Bruno Aristimunha`_)
-- Add function to auto-generate tables for the paper results documentation page (:gh:`785` by `Lucas Heck`_) 
+- Add function to auto-generate tables for the paper results documentation page (:gh:`785` by `Lucas Heck`_)
 
 Bugs
 ~~~~


### PR DESCRIPTION
This PR automates table generation for the paper results with the new file `prepare_paper_results_tables.py`, which converts CSV results to HTML tables using CSV files directly (replacing JSON and then dropping Ajax use). 

The `paper_results.rst` has been modified to use these new tables and has some CSS/DataTables tweaks for better visualization. 

This should help with the documentation maintenance.