### PR TITLE
A tutorial on how to create and use a MOABB dataset from X y (non continuous, epoched) data

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -33,6 +33,7 @@ Enhancements
 - Adding tutorial on using mne-features (:gh:`762` by `Alexander de Ranitz`_, `Luuk Neervens`_, `Charlynn van Osch`_ and `Bruno Aristimunha`_)
 - Creating tutorial to expose the pre-processing steps (:gh:`771` by `Bruno Aristimunha`_)
 - Add function to auto-generate tables for the paper results documentation page (:gh:`785` by `Lucas Heck`_)
+- A tutorial on how to create and use a MOABB dataset from X y (non continuous, epoched) data (:gh:`800` by `Anton Andreev`_)
 
 Bugs
 ~~~~

--- a/examples/advanced_examples/plot_use_an_X_y_dataset.py
+++ b/examples/advanced_examples/plot_use_an_X_y_dataset.py
@@ -15,9 +15,9 @@ classification is performed.
 
 The dataset provides the X y data as a single user and a single session.
 
-@author: Anton ANDREEV
-
 """
+# Authors: Anton ANDREEV
+
 import numpy as np
 import pandas as pd
 from pyriemann.estimation import XdawnCovariances
@@ -143,10 +143,6 @@ dataset = DummyRawEpochsDataset()
 paradigm = RawEpochParadigm()  # using the new special RawEpochParadigm paradigm
 
 X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[1])
-
-# verify the correct number of trials (epochs)
-# if (X.shape[0] != len(dataset.get_epoch_data()[1])):
-#     raise Exception("Error in dataset/paradigm!")
 
 print("Epochs count before classification", len(labels))
 

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -3,14 +3,14 @@
 =====================================================================
 Tutorial 6: Using X y data (epoched data) instead of continous signal
 =====================================================================
-Sometimes, we have data in the format of X and y, rather than as a continuous 
+Sometimes, we have data in the format of X and y, rather than as a continuous
 signal. In such cases, the data is already segmented into epochs. This creates
 a problem, because MOABB is designed to work with continuous data organized by
 subjects and sessions.
 
-The following tutorial creates a dataset that contains data in the form of 
+The following tutorial creates a dataset that contains data in the form of
 epochs. A special paradigm is provided, which calls an additional method on
-the dataset so that MOABB can process it correctly. After this, a standard 
+the dataset so that MOABB can process it correctly. After this, a standard
 classification is performed.
 
 The dataset provides the X y data as a single user and a single session.
@@ -116,7 +116,7 @@ class DummyRawEpochsDataset(BaseDataset):
         )
         self.n_channels = 8
         self.n_times = 128
-        self.n_trials = 100 # number of epochs
+        self.n_trials = 100  # number of epochs
         self.n_classes = 2
 
     def data_path(

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -115,7 +115,7 @@ class DummyRawEpochsDataset(BaseDataset):
         )
         self.n_channels = 8
         self.n_times = 128
-        self.n_trials = 100 # number of epochs
+        self.n_trials = 100  # number of epochs
         self.n_classes = 2
 
     def data_path(

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -12,6 +12,8 @@ paradigm is provided that uses an extra method on this dataset in order MOABB
 to be able to process this dataset. Next, a standard classification is
 performed.
 
+The dataset provides a signle user, single session with all the data.
+
 @author: Anton ANDREEV
 
 """
@@ -113,7 +115,7 @@ class DummyRawEpochsDataset(BaseDataset):
         )
         self.n_channels = 8
         self.n_times = 128
-        self.n_trials = 100
+        self.n_trials = 100 # number of epochs
         self.n_classes = 2
 
     def data_path(
@@ -127,6 +129,7 @@ class DummyRawEpochsDataset(BaseDataset):
     def get_epoch_data(self, subject=None):
         """
         Simulates epochs: shape (trials, channels, time), and labels
+        Trials is the number of epochs to generate.
         """
         rng = np.random.default_rng(seed=subject)
         X = rng.standard_normal((self.n_trials, self.n_channels, self.n_times))
@@ -144,7 +147,7 @@ X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[1])
 # if (X.shape[0] != len(dataset.get_epoch_data()[1])):
 #     raise Exception("Error in dataset/paradigm!")
 
-print("Epochs count before classfication", len(labels))
+print("Epochs count before classification", len(labels))
 
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm, datasets=dataset, overwrite=True, suffix="motan"

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -3,7 +3,7 @@
 =====================================================================
 Tutorial 6: Using X y data (epoched data) instead of continous signal
 =====================================================================
-Sometimes we have the data in the format X y and not as a continous signal. It 
+Sometimes we have the data in the format X y and not as a continous signal. It
 means that we have the data in the form of epochs. This creates a problem,
 because MOABB is designed for continous data from subjects and sessions.
 
@@ -14,23 +14,25 @@ a dataset in order MOABB to be able to process data that comes as epochs.
 
 """
 import numpy as np
-from moabb.datasets.base import BaseDataset
-from moabb.paradigms.base import BaseParadigm
 import pandas as pd
-from sklearn.metrics import make_scorer, accuracy_score
 from pyriemann.estimation import XdawnCovariances
+from pyriemann.tangentspace import TangentSpace
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, make_scorer
 from sklearn.pipeline import make_pipeline
+
+from moabb.datasets.base import BaseDataset
 from moabb.evaluations import (
     WithinSessionEvaluation,
 )
-from sklearn.linear_model import LogisticRegression
-from pyriemann.tangentspace import TangentSpace
+from moabb.paradigms.base import BaseParadigm
+
 
 class RawEpochParadigm(BaseParadigm):
     """
     A minimal paradigm that directly uses dataset.get_epoch_data()
     with no filtering, epoching, or signal processing.
-    
+
     Useful when your data is in the format X, y.
     """
 
@@ -38,35 +40,39 @@ class RawEpochParadigm(BaseParadigm):
         # filters=None indicates no filtering is done
         super().__init__(filters=[])
         self.return_epochs = False
-        
+
     def get_data(self, dataset, subjects, return_epochs=False, **kwargs):
         X_all, y_all, meta_all = [], [], []
-    
+
         for subject in subjects:
-            X, y = dataset.get_epoch_data(subject)  # (n_trials, n_channels, n_times), (n_trials,)
-            
+            X, y = dataset.get_epoch_data(
+                subject
+            )  # (n_trials, n_channels, n_times), (n_trials,)
+
             if isinstance(y, pd.Series):
                 y = y.values
-    
+
             n_trials = len(y)
             X_all.append(X)
             y_all.append(y)
-    
+
             # Build metadata for each trial, filling defaults for session and run
-            meta = pd.DataFrame({
-                "subject": [subject] * n_trials,
-                "session": [1] * n_trials,  # Default to 1 if sessions unknown
-                "run": [1] * n_trials,      # Default to 1 if runs unknown
-                "trial": list(range(n_trials)),
-                "label": y
-            })
-    
+            meta = pd.DataFrame(
+                {
+                    "subject": [subject] * n_trials,
+                    "session": [1] * n_trials,  # Default to 1 if sessions unknown
+                    "run": [1] * n_trials,  # Default to 1 if runs unknown
+                    "trial": list(range(n_trials)),
+                    "label": y,
+                }
+            )
+
             meta_all.append(meta)
-    
+
         X = np.concatenate(X_all, axis=0)
         y = np.concatenate(y_all, axis=0)
         meta = pd.concat(meta_all, ignore_index=True)
-    
+
         return X, y, meta
 
     def is_valid(self, dataset):
@@ -75,19 +81,20 @@ class RawEpochParadigm(BaseParadigm):
     @property
     def scoring(self):
         return make_scorer(accuracy_score)
-    
+
     def used_events(self, dataset):
-    # Return event dict if needed, or {} if irrelevant
+        # Return event dict if needed, or {} if irrelevant
         return {}
 
     @property
     def datasets(self):
         return []
-    
+
     def make_process_pipelines(self, dataset, **kwargs):
-    # Return a dummy no-op processing pipeline
+        # Return a dummy no-op processing pipeline
         return [lambda raw: raw]
-    
+
+
 class DummyRawEpochsDataset(BaseDataset):
     """
     Minimal custom dataset compatible with RawEpochParadigm.
@@ -100,14 +107,16 @@ class DummyRawEpochsDataset(BaseDataset):
             events={"left": 0, "right": 1},  # required dummy event map
             code="DummyRawEpochsDataset",
             interval=[0, 1],
-            paradigm="RawEpochParadigm"
+            paradigm="RawEpochParadigm",
         )
         self.n_channels = 8
         self.n_times = 128
         self.n_trials = 100
         self.n_classes = 2
 
-    def data_path(self, subject, path=None, force_update=False, update_path=True, verbose=None):
+    def data_path(
+        self, subject, path=None, force_update=False, update_path=True, verbose=None
+    ):
         return None  # Not needed since we generate synthetic data
 
     def _get_single_subject_data(self, subject):
@@ -121,10 +130,11 @@ class DummyRawEpochsDataset(BaseDataset):
         X = rng.standard_normal((self.n_trials, self.n_channels, self.n_times))
         y = rng.integers(low=0, high=self.n_classes, size=self.n_trials)
         return X, y
-    
+
+
 dataset = DummyRawEpochsDataset()
 
-paradigm = RawEpochParadigm() #using the new special RawEpochParadigm paradigm
+paradigm = RawEpochParadigm()  # using the new special RawEpochParadigm paradigm
 
 X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[1])
 
@@ -132,7 +142,7 @@ X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[1])
 # if (X.shape[0] != len(dataset.get_epoch_data()[1])):
 #     raise Exception("Error in dataset/paradigm!")
 
-print("Epochs count before classfication",len(labels))
+print("Epochs count before classfication", len(labels))
 
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm, datasets=dataset, overwrite=True, suffix="motan"
@@ -140,14 +150,14 @@ evaluation = WithinSessionEvaluation(
 
 pipelines = {}
 
-pipelines["XD+TS+LR"]  = make_pipeline(
-                                    XdawnCovariances(nfilter=4, estimator="oas", xdawn_estimator="scm"),
-                                    TangentSpace(), 
-                                    LogisticRegression()
-                                    )
+pipelines["XD+TS+LR"] = make_pipeline(
+    XdawnCovariances(nfilter=4, estimator="oas", xdawn_estimator="scm"),
+    TangentSpace(),
+    LogisticRegression(),
+)
 
 print("Start classification ...")
 scores = evaluation.process(pipelines)
 
-#print results
-print(scores[['score', 'time','samples','dataset', 'pipeline']])
+# print results
+print(scores[["score", "time", "samples", "dataset", "pipeline"]])

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -3,14 +3,14 @@
 =====================================================================
 Tutorial 6: Using X y data (epoched data) instead of continous signal
 =====================================================================
-Sometimes we have the data in the format X y and not as a continous signal. 
-The data in the form of epochs. This creates a problem, because MOABB is 
+Sometimes we have the data in the format X y and not as a continous signal.
+The data in the form of epochs. This creates a problem, because MOABB is
 designed for continous data from subjects and sessions.
 
-The following tutorial creates a dataset that has data as epochs. A special 
+The following tutorial creates a dataset that has data as epochs. A special
 paradigm is provided that uses an extra method on this dataset in order MOABB
-to be able to process this dataset. Next, a standard classification is 
-performed.  
+to be able to process this dataset. Next, a standard classification is
+performed.
 
 @author: Anton ANDREEV
 

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -3,12 +3,14 @@
 =====================================================================
 Tutorial 6: Using X y data (epoched data) instead of continous signal
 =====================================================================
-Sometimes we have the data in the format X y and not as a continous signal. It
-means that we have the data in the form of epochs. This creates a problem,
-because MOABB is designed for continous data from subjects and sessions.
+Sometimes we have the data in the format X y and not as a continous signal. 
+The data in the form of epochs. This creates a problem, because MOABB is 
+designed for continous data from subjects and sessions.
 
-The following example provides a special paradigm that uses an extra method on
-a dataset in order MOABB to be able to process data that comes as epochs.
+The following tutorial creates a dataset that has data as epochs. A special 
+paradigm is provided that uses an extra method on this dataset in order MOABB
+to be able to process this dataset. Next, a standard classification is 
+performed.  
 
 @author: Anton ANDREEV
 

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""
+Sometimes we have the data in the format X y and not a continous signal. We 
+data in the form of epochs, not a continous signal. This creates a problem 
+becase MOABB is designed for continous data from subjects and sessions.
+
+The following example provides a special paradigm that uses an extra method on
+a dataset in order MOABB to be able to process data that comes as epochs.
+
+@author: Anton ANDREEV
+
+"""
+import numpy as np
+from moabb.datasets.base import BaseDataset
+from moabb.paradigms.base import BaseParadigm
+import pandas as pd
+from sklearn.metrics import make_scorer, accuracy_score
+from pyriemann.estimation import XdawnCovariances
+from sklearn.pipeline import make_pipeline
+from moabb.evaluations import (
+    WithinSessionEvaluation,
+)
+from sklearn.linear_model import LogisticRegression
+from pyriemann.tangentspace import TangentSpace
+
+class RawEpochParadigm(BaseParadigm):
+    """
+    A minimal paradigm that directly uses dataset.get_epoch_data()
+    with no filtering, epoching, or signal processing.
+    
+    Useful when your data is in the format X, y.
+    """
+
+    def __init__(self):
+        # filters=None indicates no filtering is done
+        super().__init__(filters=[])
+        self.return_epochs = False
+        
+    def get_data(self, dataset, subjects, return_epochs=False, **kwargs):
+        X_all, y_all, meta_all = [], [], []
+    
+        for subject in subjects:
+            X, y = dataset.get_epoch_data(subject)  # (n_trials, n_channels, n_times), (n_trials,)
+            
+            if isinstance(y, pd.Series):
+                y = y.values
+    
+            n_trials = len(y)
+            X_all.append(X)
+            y_all.append(y)
+    
+            # Build metadata for each trial, filling defaults for session and run
+            meta = pd.DataFrame({
+                "subject": [subject] * n_trials,
+                "session": [1] * n_trials,  # Default to 1 if sessions unknown
+                "run": [1] * n_trials,      # Default to 1 if runs unknown
+                "trial": list(range(n_trials)),
+                "label": y
+            })
+    
+            meta_all.append(meta)
+    
+        X = np.concatenate(X_all, axis=0)
+        y = np.concatenate(y_all, axis=0)
+        meta = pd.concat(meta_all, ignore_index=True)
+    
+        return X, y, meta
+
+    def is_valid(self, dataset):
+        return hasattr(dataset, "get_epoch_data")
+
+    @property
+    def scoring(self):
+        return make_scorer(accuracy_score)
+    
+    def used_events(self, dataset):
+    # Return event dict if needed, or {} if irrelevant
+        return {}
+
+    @property
+    def datasets(self):
+        return []
+    
+    def make_process_pipelines(self, dataset, **kwargs):
+    # Return a dummy no-op processing pipeline
+        return [lambda raw: raw]
+    
+class DummyRawEpochsDataset(BaseDataset):
+    """
+    Minimal custom dataset compatible with RawEpochParadigm.
+    """
+
+    def __init__(self, subjects=[1]):
+        super().__init__(
+            subjects=subjects,
+            sessions_per_subject=1,
+            events={"left": 0, "right": 1},  # required dummy event map
+            code="DummyRawEpochsDataset",
+            interval=[0, 1],
+            paradigm="RawEpochParadigm"
+        )
+        self.n_channels = 8
+        self.n_times = 128
+        self.n_trials = 100
+        self.n_classes = 2
+
+    def data_path(self, subject, path=None, force_update=False, update_path=True, verbose=None):
+        return None  # Not needed since we generate synthetic data
+
+    def _get_single_subject_data(self, subject):
+        raise NotImplementedError("Not used with RawEpochParadigm")
+
+    def get_epoch_data(self, subject=None):
+        """
+        Simulates epochs: shape (trials, channels, time), and labels
+        """
+        rng = np.random.default_rng(seed=subject)
+        X = rng.standard_normal((self.n_trials, self.n_channels, self.n_times))
+        y = rng.integers(low=0, high=self.n_classes, size=self.n_trials)
+        return X, y
+    
+dataset = DummyRawEpochsDataset()
+
+paradigm = RawEpochParadigm() #using the new special RawEpochParadigm paradigm
+
+X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[1])
+
+# verify the correct number of trials (epochs)
+# if (X.shape[0] != len(dataset.get_epoch_data()[1])):
+#     raise Exception("Error in dataset/paradigm!")
+
+print("Epochs count before classfication",len(labels))
+
+evaluation = WithinSessionEvaluation(
+    paradigm=paradigm, datasets=dataset, overwrite=True, suffix="motan"
+)
+
+pipelines = {}
+
+pipelines["XD+TS+LR"]  = make_pipeline(
+                                    XdawnCovariances(nfilter=4, estimator="oas", xdawn_estimator="scm"),
+                                    TangentSpace(), 
+                                    LogisticRegression()
+                                    )
+
+print("Start classification ...")
+scores = evaluation.process(pipelines)
+
+#print results
+print(scores[['score', 'time','samples','dataset', 'pipeline']])

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-Sometimes we have the data in the format X y and not a continous signal. We 
-data in the form of epochs, not a continous signal. This creates a problem 
+Sometimes we have the data in the format X y and not a continous signal. We
+data in the form of epochs, not a continous signal. This creates a problem
 becase MOABB is designed for continous data from subjects and sessions.
 
 The following example provides a special paradigm that uses an extra method on
@@ -11,23 +11,25 @@ a dataset in order MOABB to be able to process data that comes as epochs.
 
 """
 import numpy as np
-from moabb.datasets.base import BaseDataset
-from moabb.paradigms.base import BaseParadigm
 import pandas as pd
-from sklearn.metrics import make_scorer, accuracy_score
 from pyriemann.estimation import XdawnCovariances
+from pyriemann.tangentspace import TangentSpace
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, make_scorer
 from sklearn.pipeline import make_pipeline
+
+from moabb.datasets.base import BaseDataset
 from moabb.evaluations import (
     WithinSessionEvaluation,
 )
-from sklearn.linear_model import LogisticRegression
-from pyriemann.tangentspace import TangentSpace
+from moabb.paradigms.base import BaseParadigm
+
 
 class RawEpochParadigm(BaseParadigm):
     """
     A minimal paradigm that directly uses dataset.get_epoch_data()
     with no filtering, epoching, or signal processing.
-    
+
     Useful when your data is in the format X, y.
     """
 
@@ -35,35 +37,39 @@ class RawEpochParadigm(BaseParadigm):
         # filters=None indicates no filtering is done
         super().__init__(filters=[])
         self.return_epochs = False
-        
+
     def get_data(self, dataset, subjects, return_epochs=False, **kwargs):
         X_all, y_all, meta_all = [], [], []
-    
+
         for subject in subjects:
-            X, y = dataset.get_epoch_data(subject)  # (n_trials, n_channels, n_times), (n_trials,)
-            
+            X, y = dataset.get_epoch_data(
+                subject
+            )  # (n_trials, n_channels, n_times), (n_trials,)
+
             if isinstance(y, pd.Series):
                 y = y.values
-    
+
             n_trials = len(y)
             X_all.append(X)
             y_all.append(y)
-    
+
             # Build metadata for each trial, filling defaults for session and run
-            meta = pd.DataFrame({
-                "subject": [subject] * n_trials,
-                "session": [1] * n_trials,  # Default to 1 if sessions unknown
-                "run": [1] * n_trials,      # Default to 1 if runs unknown
-                "trial": list(range(n_trials)),
-                "label": y
-            })
-    
+            meta = pd.DataFrame(
+                {
+                    "subject": [subject] * n_trials,
+                    "session": [1] * n_trials,  # Default to 1 if sessions unknown
+                    "run": [1] * n_trials,  # Default to 1 if runs unknown
+                    "trial": list(range(n_trials)),
+                    "label": y,
+                }
+            )
+
             meta_all.append(meta)
-    
+
         X = np.concatenate(X_all, axis=0)
         y = np.concatenate(y_all, axis=0)
         meta = pd.concat(meta_all, ignore_index=True)
-    
+
         return X, y, meta
 
     def is_valid(self, dataset):
@@ -72,19 +78,20 @@ class RawEpochParadigm(BaseParadigm):
     @property
     def scoring(self):
         return make_scorer(accuracy_score)
-    
+
     def used_events(self, dataset):
-    # Return event dict if needed, or {} if irrelevant
+        # Return event dict if needed, or {} if irrelevant
         return {}
 
     @property
     def datasets(self):
         return []
-    
+
     def make_process_pipelines(self, dataset, **kwargs):
-    # Return a dummy no-op processing pipeline
+        # Return a dummy no-op processing pipeline
         return [lambda raw: raw]
-    
+
+
 class DummyRawEpochsDataset(BaseDataset):
     """
     Minimal custom dataset compatible with RawEpochParadigm.
@@ -97,14 +104,16 @@ class DummyRawEpochsDataset(BaseDataset):
             events={"left": 0, "right": 1},  # required dummy event map
             code="DummyRawEpochsDataset",
             interval=[0, 1],
-            paradigm="RawEpochParadigm"
+            paradigm="RawEpochParadigm",
         )
         self.n_channels = 8
         self.n_times = 128
         self.n_trials = 100
         self.n_classes = 2
 
-    def data_path(self, subject, path=None, force_update=False, update_path=True, verbose=None):
+    def data_path(
+        self, subject, path=None, force_update=False, update_path=True, verbose=None
+    ):
         return None  # Not needed since we generate synthetic data
 
     def _get_single_subject_data(self, subject):
@@ -118,10 +127,11 @@ class DummyRawEpochsDataset(BaseDataset):
         X = rng.standard_normal((self.n_trials, self.n_channels, self.n_times))
         y = rng.integers(low=0, high=self.n_classes, size=self.n_trials)
         return X, y
-    
+
+
 dataset = DummyRawEpochsDataset()
 
-paradigm = RawEpochParadigm() #using the new special RawEpochParadigm paradigm
+paradigm = RawEpochParadigm()  # using the new special RawEpochParadigm paradigm
 
 X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[1])
 
@@ -129,7 +139,7 @@ X, labels, meta = paradigm.get_data(dataset=dataset, subjects=[1])
 # if (X.shape[0] != len(dataset.get_epoch_data()[1])):
 #     raise Exception("Error in dataset/paradigm!")
 
-print("Epochs count before classfication",len(labels))
+print("Epochs count before classfication", len(labels))
 
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm, datasets=dataset, overwrite=True, suffix="motan"
@@ -137,14 +147,14 @@ evaluation = WithinSessionEvaluation(
 
 pipelines = {}
 
-pipelines["XD+TS+LR"]  = make_pipeline(
-                                    XdawnCovariances(nfilter=4, estimator="oas", xdawn_estimator="scm"),
-                                    TangentSpace(), 
-                                    LogisticRegression()
-                                    )
+pipelines["XD+TS+LR"] = make_pipeline(
+    XdawnCovariances(nfilter=4, estimator="oas", xdawn_estimator="scm"),
+    TangentSpace(),
+    LogisticRegression(),
+)
 
 print("Start classification ...")
 scores = evaluation.process(pipelines)
 
-#print results
-print(scores[['score', 'time','samples','dataset', 'pipeline']])
+# print results
+print(scores[["score", "time", "samples", "dataset", "pipeline"]])

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -159,5 +159,4 @@ pipelines["XD+TS+LR"] = make_pipeline(
 print("Start classification ...")
 scores = evaluation.process(pipelines)
 
-# print results
-print(scores[["score", "time", "samples", "dataset", "pipeline"]])
+print("\n\nResults:", scores[["score", "time", "samples", "dataset", "pipeline"]])

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -159,4 +159,4 @@ pipelines["XD+TS+LR"] = make_pipeline(
 print("Start classification ...")
 scores = evaluation.process(pipelines)
 
-print("\n\nResults:", scores[["score", "time", "samples", "dataset", "pipeline"]])
+print("\n\nResults:\n", scores[["score", "time", "samples", "dataset", "pipeline"]])

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 =====================================================================
-Tutorial 6: Using X y data (epoched data) instead of continous signal
+Tutorial 6: Using X y data (epoched data) instead of continuous signal
 =====================================================================
 Sometimes, we have data in the format of X and y, rather than as a continuous
 signal. In such cases, the data is already segmented into epochs. This creates

--- a/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
+++ b/examples/tutorials/tutorial_6_use_an_X_y_dataset.py
@@ -3,16 +3,17 @@
 =====================================================================
 Tutorial 6: Using X y data (epoched data) instead of continous signal
 =====================================================================
-Sometimes we have the data in the format X y and not as a continous signal.
-The data in the form of epochs. This creates a problem, because MOABB is
-designed for continous data from subjects and sessions.
+Sometimes, we have data in the format of X and y, rather than as a continuous 
+signal. In such cases, the data is already segmented into epochs. This creates
+a problem, because MOABB is designed to work with continuous data organized by
+subjects and sessions.
 
-The following tutorial creates a dataset that has data as epochs. A special
-paradigm is provided that uses an extra method on this dataset in order MOABB
-to be able to process this dataset. Next, a standard classification is
-performed.
+The following tutorial creates a dataset that contains data in the form of 
+epochs. A special paradigm is provided, which calls an additional method on
+the dataset so that MOABB can process it correctly. After this, a standard 
+classification is performed.
 
-The dataset provides a signle user, single session with all the data.
+The dataset provides the X y data as a single user and a single session.
 
 @author: Anton ANDREEV
 
@@ -115,7 +116,7 @@ class DummyRawEpochsDataset(BaseDataset):
         )
         self.n_channels = 8
         self.n_times = 128
-        self.n_trials = 100  # number of epochs
+        self.n_trials = 100 # number of epochs
         self.n_classes = 2
 
     def data_path(


### PR DESCRIPTION
This PR is to allow easier creation of new MOABB compatible datasets from non continuous, epoched data.
This code does not modify the core components of MOABB. It is a standalone example (tutorial).
A new RawEpochParadigm is introduced that allows a non continuous dataset in the form of X y to be processed by MOABB.
The provided random dummy X y dataset in the tutorial can easily be updated to any data you have in the X y format.
Currently this kind of code is needed in two of my projects at work.

AI think it is a good solution because it is confined only to this tutorial. 

It avoids the need to create an artificial continuous signal that is later broken again into the same epochs (if no mistake is made).

Related to: https://github.com/NeuroTechX/moabb/issues/763