### PR TITLE
swap the labels of '17' and '21'

### DIFF
--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -53,7 +53,7 @@ class Kalunga2016(BaseDataset):
         super().__init__(
             subjects=list(range(1, 13)),
             sessions_per_subject=1,
-            events={"13": 2, "17": 3, "21": 4, "rest": 1},
+            events={"13": 2, "17": 4, "21": 3, "rest": 1},
             code="Kalunga2016",
             interval=[2, 4],
             paradigm="ssvep",


### PR DESCRIPTION
This pull request addresses the label mismatch identified in Issue #813 

## Description
In the Kalunga2016 SSVEP dataset, the event IDs for the 17Hz and 21Hz conditions were swapped. 

This PR corrects the event_id mapping within the dataset's implementation to ensure that the labels accurately correspond to the correct stimulation frequencies.

---
This is my first time contributing to a public source code project. If there are any issues with my submission process or anything I should improve, please feel free to let me know. I appreciate any feedback!