### PR TITLE
Remove redundant learning curve implementation paths 

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -65,6 +65,8 @@ Bugs
 - Prevent Python mutable default argument when defining CodeCarbon configurations (:gh:`956` by `Ethan Davis`_)
 - Fix copytree FileExistsError in BrainInvaders2013a download by adding dirs_exist_ok=True (by `Bruno Aristimunha`_)
 - Ensure optional additional scoring columns in evaluation results (:gh:`957` by `Ethan Davis`_)
+- Fix pandas ``ArrowStringArray`` shuffle warning by converting ``.unique()`` results to numpy arrays in splitters, avoiding issues with newer pandas versions (:gh:`963` by `Bruno Aristimunha`_)
+- ``LearningCurveSplitter`` now skips training splits that collapse to a single class (e.g., with very small ``data_size``) and emits a ``RuntimeWarning`` instead of producing NaN results (:gh:`963` by `Bruno Aristimunha`_)
 
 Code health
 ~~~~~~~~~~~
@@ -73,8 +75,16 @@ Code health
 
 - Persist docs/test CI MNE dataset cache across runs to reduce cold-cache downloads (:gh:`946` by `Bruno Aristimunha`_)
 - Refactor evaluation scoring into shared utility functions for future improvements (:gh:`948` by `Bruno Aristimunha`_)
-- Centralize CV resolution in BaseEvaluation with new ``_resolve_cv()`` method for consistent cross-validation handling across all evaluation types (:gh:`963` by `Bruno Aristimunha`_)
+- Centralize CV resolution in BaseEvaluation with new ``_resolve_cv()`` method for consistent cross-validation handling across all evaluation types. Add ``_build_result()`` and ``_build_scored_result()`` helpers to centralize result dict construction across WithinSession, CrossSession, and CrossSubject evaluations, replacing manual dict assembly in each (:gh:`963` by `Bruno Aristimunha`_)
 - Remove redundant learning curve methods (``get_data_size_subsets()``, ``score_explicit()``, ``_evaluate_learning_curve()``) from WithinSessionEvaluation in favor of unified splitter-based approach (:gh:`963` by `Bruno Aristimunha`_)
+- Generic metadata column registration: ``LearningCurveSplitter`` declares a ``metadata_columns`` class attribute, and ``BaseEvaluation`` auto-detects it via ``hasattr(cv_class, "metadata_columns")`` instead of hardcoding class checks, making it extensible to future custom splitters (:gh:`963` by `Bruno Aristimunha`_)
+- Fix ``get_n_splits()`` delegation in ``WithinSessionSplitter`` and ``WithinSubjectSplitter`` to properly forward to the inner ``cv_class.get_n_splits()`` instead of hardcoding ``n_folds``, giving correct split counts when using custom CV classes like ``LearningCurveSplitter`` (:gh:`963` by `Bruno Aristimunha`_)
+- Remove duplicate ``get_inner_splitter_metadata()`` from ``WithinSessionSplitter``, ``WithinSubjectSplitter``, and ``CrossSubjectSplitter``. All splitters now store a ``_current_splitter`` reference, and ``BaseEvaluation._build_scored_result()`` reads metadata generically from it (:gh:`963` by `Bruno Aristimunha`_)
+- Extract ``_fit_cv()``, ``_maybe_save_model_cv()``, and ``_attach_emissions()`` into ``BaseEvaluation``, removing duplicated model-fitting, model-saving, and carbon-tracking boilerplate from ``WithinSessionEvaluation``, ``CrossSessionEvaluation``, and ``CrossSubjectEvaluation`` (:gh:`963` by `Bruno Aristimunha`_)
+- Extract ``_load_data()`` helper into ``BaseEvaluation`` to centralize data loading logic (epoch requirement checking and ``paradigm.get_data()`` call) that was duplicated across all three evaluation classes (:gh:`963` by `Bruno Aristimunha`_)
+- Extract ``_get_nchan()`` helper into ``BaseEvaluation`` to replace repeated channel count extraction (``X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]``) in all evaluation classes (:gh:`963` by `Bruno Aristimunha`_)
+- Move ``_pipeline_requires_epochs()`` from ``evaluations.py`` to ``utils.py`` for shared access by ``BaseEvaluation._load_data()`` (:gh:`963` by `Bruno Aristimunha`_)
+- Move ``WithinSessionSplitter`` creation outside the per-session loop in ``WithinSessionEvaluation``, since splitter parameters do not change per session (:gh:`963` by `Bruno Aristimunha`_)
 
 Version 1.4.3 (Stable - PyPi)
 -------------------------------

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -32,6 +32,8 @@ Enhancements
 - Ability to parameterize the scoring rule of paradigms (:gh:`948` by `Ethan Davis`_)
 - Extend scoring configuration to accept lists of metric callables, scorer objects, and tuple kwargs (e.g., `needs_proba`/`needs_threshold`) for multi-metric evaluations (:gh:`948` by `Ethan Davis`_ and `Bruno Aristimunha`_)
 - Implement :class:`moabb.evaluations.WithinSubjectSplitter` for k-fold cross-validation within each subject across all sessions (by `Bruno Aristimunha`_)
+- Add ``cv_class`` and ``cv_kwargs`` parameters to all evaluation classes (WithinSessionEvaluation, CrossSessionEvaluation, CrossSubjectEvaluation) for custom cross-validation strategies (:gh:`963` by `Bruno Aristimunha`_)
+- Implement :class:`moabb.evaluations.splitters.LearningCurveSplitter` as a dedicated sklearn-compatible cross-validator for learning curves, enabling learning curve analysis with any evaluation type (:gh:`963` by `Bruno Aristimunha`_)
 
 API changes
 ~~~~~~~~~~~
@@ -42,6 +44,8 @@ API changes
 - Enable choice of online or offline CodeCarbon through the parameterization of `codecarbon_config` when instantiating a :class:`moabb.evaluations.base.BaseEvaluation` child class (:gh:`956` by `Ethan Davis`_)
 - Renamed stimulus channel from ``stim`` to ``STI`` in BNCI motor imagery and error-related potential datasets for clarity and BIDS compliance (by `Bruno Aristimunha`_).
 - Added four new BNCI P300/ERP dataset classes: :class:`moabb.datasets.BNCI2015_009` (AMUSE), :class:`moabb.datasets.BNCI2015_010` (RSVP), :class:`moabb.datasets.BNCI2015_012` (PASS2D), and :class:`moabb.datasets.BNCI2015_013` (ErrP) (by `Bruno Aristimunha`_).
+- Removed ``data_size`` and ``n_perms`` parameters from :class:`moabb.evaluations.WithinSessionEvaluation`. Use ``cv_class=LearningCurveSplitter`` with ``cv_kwargs=dict(data_size=..., n_perms=...)`` instead (:gh:`963` by `Bruno Aristimunha`_)
+- Learning curve results now automatically include "data_size" and "permutation" columns when using ``LearningCurveSplitter`` (:gh:`963` by `Bruno Aristimunha`_)
 
 Requirements
 ~~~~~~~~~~~~
@@ -69,6 +73,8 @@ Code health
 
 - Persist docs/test CI MNE dataset cache across runs to reduce cold-cache downloads (:gh:`946` by `Bruno Aristimunha`_)
 - Refactor evaluation scoring into shared utility functions for future improvements (:gh:`948` by `Bruno Aristimunha`_)
+- Centralize CV resolution in BaseEvaluation with new ``_resolve_cv()`` method for consistent cross-validation handling across all evaluation types (:gh:`963` by `Bruno Aristimunha`_)
+- Remove redundant learning curve methods (``get_data_size_subsets()``, ``score_explicit()``, ``_evaluate_learning_curve()``) from WithinSessionEvaluation in favor of unified splitter-based approach (:gh:`963` by `Bruno Aristimunha`_)
 
 Version 1.4.3 (Stable - PyPi)
 -------------------------------

--- a/examples/advanced_examples/plot_hinss2021_classification.py
+++ b/examples/advanced_examples/plot_hinss2021_classification.py
@@ -145,7 +145,7 @@ results = evaluation.process(pipelines)
 # in approximately 8 times to the Cov+ElSel+TS+LDA pipeline.
 
 print("Averaging the session performance:")
-print(results.groupby("pipeline").mean("score")[["score", "time"]])
+print(results.groupby("pipeline")[["score", "time"]].mean())
 
 ###############################################################################
 # Plot Results

--- a/examples/external/learning_curve_p300_external.py
+++ b/examples/external/learning_curve_p300_external.py
@@ -36,6 +36,7 @@ from toeplitzlda.classification import EpochsVectorizer, ToeplitzLDA
 import moabb
 from moabb.datasets import BNCI2014_009
 from moabb.evaluations import WithinSessionEvaluation
+from moabb.evaluations.splitters import LearningCurveSplitter
 from moabb.paradigms import P300
 
 
@@ -114,8 +115,8 @@ np.random.seed(7536298)
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm,
     datasets=datasets,
-    data_size=data_size,
-    n_perms=n_perms,
+    cv_class=LearningCurveSplitter,
+    cv_kwargs=dict(data_size=data_size, n_perms=n_perms),
     suffix="examples_lr",
     overwrite=overwrite,
     return_epochs=True,

--- a/examples/external/noplot_learning_curve_p300_external.py
+++ b/examples/external/noplot_learning_curve_p300_external.py
@@ -36,6 +36,7 @@ from tdlda import Vectorizer as JumpingMeansVectorizer
 import moabb
 from moabb.datasets import BNCI2014_009
 from moabb.evaluations import WithinSessionEvaluation
+from moabb.evaluations.splitters import LearningCurveSplitter
 from moabb.paradigms import P300
 
 
@@ -115,8 +116,8 @@ np.random.seed(7536298)
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm,
     datasets=datasets,
-    data_size=data_size,
-    n_perms=n_perms,
+    cv_class=LearningCurveSplitter,
+    cv_kwargs=dict(data_size=data_size, n_perms=n_perms),
     suffix="examples_lr",
     overwrite=overwrite,
 )

--- a/examples/learning_curve/noplot_learning_curve_p300_external.py
+++ b/examples/learning_curve/noplot_learning_curve_p300_external.py
@@ -36,6 +36,7 @@ from tdlda import Vectorizer as JumpingMeansVectorizer
 import moabb
 from moabb.datasets import BNCI2014_009
 from moabb.evaluations import WithinSessionEvaluation
+from moabb.evaluations.splitters import LearningCurveSplitter
 from moabb.paradigms import P300
 
 
@@ -115,8 +116,8 @@ np.random.seed(7536298)
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm,
     datasets=datasets,
-    data_size=data_size,
-    n_perms=n_perms,
+    cv_class=LearningCurveSplitter,
+    cv_kwargs=dict(data_size=data_size, n_perms=n_perms),
     suffix="examples_lr",
     overwrite=overwrite,
 )

--- a/examples/learning_curve/plot_learning_curve_motor_imagery.py
+++ b/examples/learning_curve/plot_learning_curve_motor_imagery.py
@@ -33,6 +33,7 @@ from sklearn.pipeline import make_pipeline
 import moabb
 from moabb.datasets import BNCI2014_001
 from moabb.evaluations import WithinSessionEvaluation
+from moabb.evaluations.splitters import LearningCurveSplitter
 from moabb.paradigms import LeftRightImagery
 
 
@@ -86,8 +87,8 @@ evaluation = WithinSessionEvaluation(
     datasets=datasets,
     suffix="examples",
     overwrite=overwrite,
-    data_size=data_size,
-    n_perms=n_perms,
+    cv_class=LearningCurveSplitter,
+    cv_kwargs=dict(data_size=data_size, n_perms=n_perms),
 )
 
 results = evaluation.process(pipelines)

--- a/examples/learning_curve/plot_learning_curve_p300.py
+++ b/examples/learning_curve/plot_learning_curve_p300.py
@@ -33,6 +33,7 @@ from sklearn.pipeline import make_pipeline
 import moabb
 from moabb.datasets import BNCI2014_009
 from moabb.evaluations import WithinSessionEvaluation
+from moabb.evaluations.splitters import LearningCurveSplitter
 from moabb.paradigms import P300
 
 
@@ -89,8 +90,8 @@ np.random.seed(7536298)
 evaluation = WithinSessionEvaluation(
     paradigm=paradigm,
     datasets=datasets,
-    data_size=data_size,
-    n_perms=n_perms,
+    cv_class=LearningCurveSplitter,
+    cv_kwargs=dict(data_size=data_size, n_perms=n_perms),
     suffix="examples_lr",
     overwrite=overwrite,
 )

--- a/examples/tutorials/tutorial_4_adding_a_dataset.py
+++ b/examples/tutorials/tutorial_4_adding_a_dataset.py
@@ -123,7 +123,7 @@ class ExampleDataset(BaseDataset):
         fs = data["fs"]
         ch_names = ["ch" + str(i) for i in range(8)] + ["stim"]
         ch_types = ["eeg" for i in range(8)] + ["stim"]
-        info = mne.create_info(ch_names, fs, ch_types)
+        info = mne.create_info(ch_names, float(np.squeeze(fs)), ch_types)
         raw = mne.io.RawArray(x, info)
 
         sessions = {}

--- a/moabb/analysis/plotting.py
+++ b/moabb/analysis/plotting.py
@@ -476,7 +476,7 @@ def summary_plot(sig_df, effect_df, p_threshold=0.05, simplify=True):
     if simplify:
         effect_df.columns = effect_df.columns.map(_simplify_names)
         sig_df.columns = sig_df.columns.map(_simplify_names)
-    annot_df = effect_df.copy()
+    annot_df = effect_df.copy().astype(object)
     for row in annot_df.index:
         for col in annot_df.columns:
             if effect_df.loc[row, col] > 0:
@@ -575,10 +575,10 @@ def meta_analysis_plot(stats_df, alg1, alg2):  # noqa: C901
     _min = 0
     _max = 0
     for ind, d in enumerate(dsets):
-        nsub = float(df_fw.loc[df_fw.dataset == d, "nsub"])
+        nsub = df_fw.loc[df_fw.dataset == d, "nsub"].item()
         t_dof = nsub - 1
         ci.append(t.ppf(0.95, t_dof) / np.sqrt(nsub))
-        v = float(df_fw.loc[df_fw.dataset == d, "smd"])
+        v = df_fw.loc[df_fw.dataset == d, "smd"].item()
         if v > 0:
             p = df_fw.loc[df_fw.dataset == d, "p"].item()
             if p < 0.05:

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -232,14 +232,6 @@ class BaseEvaluation(ABC):
             cv_kwargs = {} if self.cv_kwargs is None else dict(self.cv_kwargs)
         return cv_class, cv_kwargs
 
-    def _get_split_metadata(self):
-        """Return metadata from the current inner splitter if available."""
-        splitter = getattr(getattr(self, "cv", None), "_current_splitter", None)
-        if splitter is None or not hasattr(splitter, "get_metadata"):
-            return {}
-        metadata = splitter.get_metadata()
-        return {} if metadata is None else dict(metadata)
-
     def _build_scored_result(
         self,
         dataset,
@@ -253,10 +245,17 @@ class BaseEvaluation(ABC):
         model,
         X_test,
         y_test,
+        split_metadata=None,
         **extra,
     ):
         """Build a result dict and score it in one place."""
-        metadata = self._get_split_metadata()
+        metadata = {}
+        if split_metadata is None:
+            splitter = getattr(getattr(self, "cv", None), "_current_splitter", None)
+            if splitter is not None and hasattr(splitter, "get_metadata"):
+                split_metadata = splitter.get_metadata()
+        if split_metadata:
+            metadata.update(split_metadata)
         metadata.update(extra)
         res = self._build_result(
             dataset,

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -18,6 +18,8 @@ from moabb.evaluations.utils import (
     _create_scorer,
     _DictScorer,
     _ensure_fitted,
+    _get_nchan,
+    _pipeline_requires_epochs,
     _save_model_cv,
     _score_and_update,
     check_search_available,
@@ -236,6 +238,59 @@ class BaseEvaluation(ABC):
             cv_class = self.cv_class
             cv_kwargs = dict(self.cv_kwargs)
         return cv_class, cv_kwargs
+
+    def _load_data(
+        self,
+        dataset,
+        run_pipes,
+        process_pipeline,
+        postprocess_pipeline,
+        subjects=None,
+    ):
+        """Load data for an evaluation, handling epoch requirements.
+
+        Parameters
+        ----------
+        dataset : BaseDataset
+            The dataset to load.
+        run_pipes : dict
+            Pipelines to run (used to check epoch requirements).
+        process_pipeline : Pipeline
+            The processing pipeline.
+        postprocess_pipeline : Pipeline | None
+            Optional post-processing pipeline.
+        subjects : list | None
+            List of subjects to load. If None, loads all subjects.
+
+        Returns
+        -------
+        X : array-like or Epochs
+            The loaded data.
+        y : array-like
+            The labels.
+        metadata : DataFrame
+            The metadata.
+        """
+        requires_epochs = any(
+            _pipeline_requires_epochs(clf) for clf in run_pipes.values()
+        )
+        return_epochs = True if requires_epochs else self.return_epochs
+        kwargs = dict(
+            dataset=dataset,
+            return_epochs=return_epochs,
+            return_raws=self.return_raws,
+            cache_config=self.cache_config,
+            postprocess_pipeline=postprocess_pipeline,
+            process_pipelines=None if requires_epochs else [process_pipeline],
+        )
+        if subjects is not None:
+            kwargs["subjects"] = subjects
+        return self.paradigm.get_data(**kwargs)
+
+    @staticmethod
+    def _get_nchan(X):
+        """Extract number of channels from data (Epochs or ndarray)."""
+        return _get_nchan(X)
 
     def _build_scored_result(
         self,

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -1,6 +1,8 @@
 import logging
 import math
 from abc import ABC, abstractmethod
+from time import perf_counter
+from uuid import uuid4
 from warnings import warn
 
 import pandas as pd
@@ -12,8 +14,11 @@ from moabb.datasets.base import BaseDataset
 from moabb.evaluations.utils import (
     Emissions,
     _convert_sklearn_params_to_optuna,
+    _create_save_path,
     _create_scorer,
     _DictScorer,
+    _ensure_fitted,
+    _save_model_cv,
     _score_and_update,
     check_search_available,
 )
@@ -268,6 +273,44 @@ class BaseEvaluation(ABC):
             **metadata,
         )
         return _score_and_update(res, scorer, model, X_test, y_test)
+
+    def _fit_cv(self, model, X_train, y_train, tracker=None):
+        """Fit a model for a CV fold with optional CodeCarbon tracking."""
+        task_name = None
+        emissions = math.nan
+        if tracker is not None:
+            task_name = str(uuid4())
+            tracker.start_task(task_name)
+        t_start = perf_counter()
+        model.fit(X_train, y_train)
+        duration = perf_counter() - t_start
+        if tracker is not None:
+            emissions_data = tracker.stop_task()
+            emissions = emissions_data.emissions if emissions_data else math.nan
+        _ensure_fitted(model)
+        return duration, emissions, task_name
+
+    def _maybe_save_model_cv(
+        self, model, dataset, subject, session, name, cv_ind, eval_type
+    ):
+        """Save model for a CV fold when saving is enabled."""
+        if self.hdf5_path is None or not self.save_model:
+            return
+        model_save_path = _create_save_path(
+            hdf5_path=self.hdf5_path,
+            code=dataset.code,
+            subject=subject,
+            session=session,
+            name=name,
+            grid=self.search,
+            eval_type=eval_type,
+        )
+        _save_model_cv(model=model, save_path=model_save_path, cv_index=str(cv_ind))
+
+    @staticmethod
+    def _attach_emissions(res, emissions, task_name):
+        res["carbon_emission"] = (1000 * emissions,)
+        res["codecarbon_task_name"] = task_name
 
     def _build_result(
         self,

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -14,6 +14,7 @@ from moabb.evaluations.utils import (
     _convert_sklearn_params_to_optuna,
     _create_scorer,
     _DictScorer,
+    _score_and_update,
     check_search_available,
 )
 from moabb.paradigms.base import BaseParadigm
@@ -230,6 +231,44 @@ class BaseEvaluation(ABC):
             cv_class = self.cv_class
             cv_kwargs = {} if self.cv_kwargs is None else dict(self.cv_kwargs)
         return cv_class, cv_kwargs
+
+    def _get_split_metadata(self):
+        """Return metadata from the current inner splitter if available."""
+        splitter = getattr(getattr(self, "cv", None), "_current_splitter", None)
+        if splitter is None or not hasattr(splitter, "get_metadata"):
+            return {}
+        metadata = splitter.get_metadata()
+        return {} if metadata is None else dict(metadata)
+
+    def _build_scored_result(
+        self,
+        dataset,
+        subject,
+        session,
+        pipeline,
+        n_samples,
+        n_channels,
+        duration,
+        scorer,
+        model,
+        X_test,
+        y_test,
+        **extra,
+    ):
+        """Build a result dict and score it in one place."""
+        metadata = self._get_split_metadata()
+        metadata.update(extra)
+        res = self._build_result(
+            dataset,
+            subject,
+            session,
+            pipeline,
+            n_samples,
+            n_channels,
+            duration,
+            **metadata,
+        )
+        return _score_and_update(res, scorer, model, X_test, y_test)
 
     def _build_result(
         self,

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from abc import ABC, abstractmethod
 from warnings import warn
 
@@ -144,6 +145,11 @@ class BaseEvaluation(ABC):
         if additional_columns is None:
             self.additional_columns = []
 
+        if self.cv_class is not None and hasattr(self.cv_class, "metadata_columns"):
+            for col in self.cv_class.metadata_columns:
+                if col not in self.additional_columns:
+                    self.additional_columns.append(col)
+
         if self.optuna and not optuna_available:
             raise ImportError("Optuna is not available. Please install it first.")
         if (self.time_out != 60 * 15) and not self.optuna:
@@ -224,6 +230,41 @@ class BaseEvaluation(ABC):
             cv_class = self.cv_class
             cv_kwargs = {} if self.cv_kwargs is None else dict(self.cv_kwargs)
         return cv_class, cv_kwargs
+
+    def _build_result(
+        self,
+        dataset,
+        subject,
+        session,
+        pipeline,
+        n_samples,
+        n_channels,
+        duration,
+        **extra,
+    ):
+        """Build a result dictionary with all required columns.
+
+        This is the single place where the evaluation result schema is defined.
+        All evaluation subclasses should use this instead of constructing the
+        dict manually, so the schema stays consistent when columns are added
+        or evaluations are merged.
+
+        Any ``additional_columns`` not provided via *extra* are defaulted to
+        NaN so that ``Results.add()`` never fails on a missing key.
+        """
+        res = {
+            "time": duration,
+            "dataset": dataset,
+            "subject": subject,
+            "session": session,
+            "n_samples": n_samples,
+            "n_channels": n_channels,
+            "pipeline": pipeline,
+        }
+        for col in self.additional_columns:
+            if col not in res:
+                res[col] = extra.get(col, math.nan)
+        return res
 
     def process(self, pipelines, param_grid=None, postprocess_pipeline=None):
         """Runs all pipelines on all datasets.

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -234,7 +234,7 @@ class BaseEvaluation(ABC):
             cv_kwargs = {} if default_kwargs is None else dict(default_kwargs)
         else:
             cv_class = self.cv_class
-            cv_kwargs = {} if self.cv_kwargs is None else dict(self.cv_kwargs)
+            cv_kwargs = dict(self.cv_kwargs)
         return cv_class, cv_kwargs
 
     def _build_scored_result(
@@ -272,7 +272,13 @@ class BaseEvaluation(ABC):
             duration,
             **metadata,
         )
-        return _score_and_update(res, scorer, model, X_test, y_test)
+        try:
+            return _score_and_update(res, scorer, model, X_test, y_test)
+        except ValueError as err:
+            if self.error_score == "raise":
+                raise err
+            res["score"] = self.error_score
+            return res
 
     def _fit_cv(self, model, X_train, y_train, tracker=None):
         """Fit a model for a CV fold with optional CodeCarbon tracking."""

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -28,7 +28,6 @@ from moabb.evaluations.utils import (
     _create_scorer,
     _ensure_fitted,
     _save_model_cv,
-    _score_and_update,
     _update_result_with_scores,
 )
 from moabb.pipelines.classification import SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA
@@ -102,11 +101,6 @@ class WithinSessionEvaluation(BaseEvaluation):
     cv_kwargs: dict, default=None
         Keyword arguments for cv_class.
 
-    Notes
-    -----
-    .. deprecated:: 1.2.0
-        The ``data_size`` and ``n_perms`` parameters are deprecated.
-        Use ``cv_class=LearningCurveSplitter`` with ``cv_kwargs`` instead.
     """
 
     # flake8: noqa: C901
@@ -221,10 +215,9 @@ class WithinSessionEvaluation(BaseEvaluation):
                             )
 
                         _ensure_fitted(cvclf)
-                        score = scorer(cvclf, X_[test], y_[test])
 
                         if is_learning_curve:
-                            res = self._build_result(
+                            res = self._build_scored_result(
                                 dataset,
                                 subject,
                                 session,
@@ -232,14 +225,17 @@ class WithinSessionEvaluation(BaseEvaluation):
                                 len(train),
                                 nchan,
                                 duration,
-                                **self.cv._current_splitter.get_metadata(),
+                                scorer,
+                                cvclf,
+                                X_[test],
+                                y_[test],
                             )
-                            _update_result_with_scores(res, score)
                             if _carbonfootprint:
                                 res["carbon_emission"] = (1000 * emissions,)
                                 res["codecarbon_task_name"] = task_name
                             yield res
                         else:
+                            score = scorer(cvclf, X_[test], y_[test])
                             acc.append(score)
 
                     if _carbonfootprint:
@@ -418,7 +414,7 @@ class CrossSessionEvaluation(BaseEvaluation):
                     _ensure_fitted(cvclf)
                     model_list.append(cvclf)
 
-                    res = self._build_result(
+                    res = self._build_scored_result(
                         dataset,
                         subject,
                         groups[test][0],
@@ -426,8 +422,11 @@ class CrossSessionEvaluation(BaseEvaluation):
                         len(train),
                         nchan,
                         duration,
+                        scorer,
+                        cvclf,
+                        X[test],
+                        y[test],
                     )
-                    _score_and_update(res, scorer, cvclf, X[test], y[test])
 
                     if _carbonfootprint:
                         res["carbon_emission"] = (1000 * emissions,)
@@ -626,7 +625,7 @@ class CrossSubjectEvaluation(BaseEvaluation):
                 for session in np.unique(sessions[test]):
                     ix = sessions[test] == session
 
-                    res = self._build_result(
+                    res = self._build_scored_result(
                         dataset,
                         subject,
                         session,
@@ -634,8 +633,11 @@ class CrossSubjectEvaluation(BaseEvaluation):
                         len(train),
                         nchan,
                         duration,
+                        scorer,
+                        cvclf,
+                        X[test[ix]],
+                        y[test[ix]],
                     )
-                    _score_and_update(res, scorer, cvclf, X[test[ix]], y[test[ix]])
 
                     if _carbonfootprint:
                         res["carbon_emission"] = (1000 * emissions,)

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 from time import perf_counter
-from typing import Optional, Union
+from typing import Union
 from uuid import uuid4
 
 import numpy as np
@@ -11,7 +11,6 @@ from sklearn.model_selection import (
     GroupKFold,
     LeaveOneGroupOut,
     StratifiedKFold,
-    StratifiedShuffleSplit,
 )
 from sklearn.preprocessing import LabelEncoder
 from tqdm import tqdm
@@ -65,27 +64,13 @@ class WithinSessionEvaluation(BaseEvaluation):
     """Performance evaluation within session (k-fold cross-validation)
 
     Within-session evaluation uses k-fold cross_validation to determine train
-    and test sets on separate session for each subject, it is possible to
-    estimate the performance on a subset of training examples to obtain
-    learning curves.
+    and test sets on separate session for each subject.
+
+    For learning curve evaluation, use ``cv_class=LearningCurveSplitter`` with
+    appropriate ``cv_kwargs`` containing ``data_size`` and ``n_perms`` parameters.
 
     Parameters
     ----------
-    n_perms :
-        Number of permutations to perform. If an array
-        is passed it has to be equal in size to the data_size array.
-        Values in this array must be monotonically decreasing (performing
-        more permutations for more data is not useful to reduce standard
-        error of the mean).
-        Default: None
-    data_size :
-        If None is passed, it performs conventional WithinSession evaluation.
-        Contains the policy to pick the datasizes to
-        evaluate, as well as the actual values. The dict has the
-        key 'policy' with either 'ratio' or 'per_class', and the key
-        'value' with the actual values as an numpy array. This array should be
-        sorted, such that values in data_size are strictly monotonically increasing.
-        Default: None
     paradigm : Paradigm instance
         The paradigm to use.
     datasets : List of Dataset instance
@@ -112,52 +97,17 @@ class WithinSessionEvaluation(BaseEvaluation):
         use MNE raw to train pipelines.
     mne_labels: bool, default=False
         if returning MNE epoch, use original dataset label if True
+    cv_class: type, default=None
+        Optional cross-validation class (e.g., LearningCurveSplitter for learning curves).
+    cv_kwargs: dict, default=None
+        Keyword arguments for cv_class.
+
+    Notes
+    -----
+    .. deprecated:: 1.2.0
+        The ``data_size`` and ``n_perms`` parameters are deprecated.
+        Use ``cv_class=LearningCurveSplitter`` with ``cv_kwargs`` instead.
     """
-
-    VALID_POLICIES = ["per_class", "ratio"]
-
-    def __init__(
-        self,
-        n_perms: Optional[Union[int, Vector]] = None,
-        data_size: Optional[dict] = None,
-        **kwargs,
-    ):
-        self.data_size = data_size
-        self.n_perms = n_perms
-        self.calculate_learning_curve = self.data_size is not None
-        if self.calculate_learning_curve:
-            # Check correct n_perms parameter
-            if self.n_perms is None:
-                raise ValueError(
-                    "When passing data_size, please also indicate number of permutations"
-                )
-            if isinstance(n_perms, int):
-                self.n_perms = np.full_like(self.data_size["value"], n_perms, dtype=int)
-            elif len(self.n_perms) != len(self.data_size["value"]):
-                raise ValueError(
-                    "Number of elements in n_perms must be equal "
-                    "to number of elements in data_size['value']"
-                )
-            elif not np.all(np.diff(n_perms) <= 0):
-                raise ValueError(
-                    "If n_perms is passed as an array, it has to be monotonically decreasing"
-                )
-            # Check correct data size parameter
-            if not np.all(np.diff(self.data_size["value"]) > 0):
-                raise ValueError(
-                    "data_size['value'] must be sorted in strictly monotonically increasing order."
-                )
-            if data_size["policy"] not in WithinSessionEvaluation.VALID_POLICIES:
-                raise ValueError(
-                    f"{data_size['policy']} is not valid. Please use one of"
-                    f"{WithinSessionEvaluation.VALID_POLICIES}"
-                )
-            self.test_size = 0.2  # Roughly similar to 5-fold CV
-            add_cols = ["data_size", "permutation"]
-            super().__init__(additional_columns=add_cols, **kwargs)
-        else:
-            # Perform default within session evaluation
-            super().__init__(**kwargs)
 
     # flake8: noqa: C901
     def _evaluate(
@@ -323,183 +273,12 @@ class WithinSessionEvaluation(BaseEvaluation):
                         self._add_cv_metadata(res)
                         yield res
 
-    def get_data_size_subsets(self, y):
-        if self.data_size is None:
-            raise ValueError(
-                "Cannot create data subsets without valid policy for data_size."
-            )
-        if self.data_size["policy"] == "ratio":
-            vals = np.array(self.data_size["value"])
-            if np.any(vals < 0) or np.any(vals > 1):
-                raise ValueError("Data subset ratios must be in range [0, 1]")
-            upto = np.ceil(vals * len(y)).astype(int)
-            indices = [np.array(range(i)) for i in upto]
-        elif self.data_size["policy"] == "per_class":
-            classwise_indices = dict()
-            n_smallest_class = np.inf
-            for cl in np.unique(y):
-                cl_i = np.where(cl == y)[0]
-                classwise_indices[cl] = cl_i
-                n_smallest_class = (
-                    len(cl_i) if len(cl_i) < n_smallest_class else n_smallest_class
-                )
-            indices = []
-            for ds in self.data_size["value"]:
-                if ds > n_smallest_class:
-                    raise ValueError(
-                        f"Smallest class has {n_smallest_class} samples. "
-                        f"Desired samples per class {ds} is too large."
-                    )
-                indices.append(
-                    np.concatenate(
-                        [classwise_indices[cl][:ds] for cl in classwise_indices]
-                    )
-                )
-        else:
-            raise ValueError(f"Unknown policy {self.data_size['policy']}")
-        return indices
-
-    def score_explicit(self, res, clf, X_train, y_train, X_test, y_test):
-        """Fit model and update result dict with scores and duration."""
-        if not self.mne_labels:
-            # convert labels if array, keep them if epochs and mne_labels is set
-            le = LabelEncoder()
-            y_train = le.fit_transform(y_train)
-            y_test = le.transform(y_test)
-        t_start = perf_counter()
-        try:
-            model = clf.fit(X_train, y_train)
-            _ensure_fitted(model)
-            scorer = _create_scorer(model, self.paradigm.scoring)
-            _score_and_update(res, scorer, model, X_test, y_test)
-        except ValueError as e:
-            if self.error_score == "raise":
-                raise e
-            res["score"] = self.error_score
-        res["time"] = perf_counter() - t_start
-
-    def _evaluate_learning_curve(
-        self, dataset, pipelines, process_pipeline, postprocess_pipeline
-    ):
-        # Progressbar at subject level
-        for subject in tqdm(dataset.subject_list, desc=f"{dataset.code}-WithinSession"):
-            # check if we already have result for this subject/pipeline
-            # we might need a better granularity, if we query the DB
-            run_pipes = self.results.not_yet_computed(
-                pipelines, dataset, subject, process_pipeline
-            )
-            if len(run_pipes) == 0:
-                continue
-
-            # get the data
-            X_all, y_all, metadata_all = self.paradigm.get_data(
-                dataset=dataset,
-                subjects=[subject],
-                return_epochs=self.return_epochs,
-                return_raws=self.return_raws,
-                postprocess_pipeline=postprocess_pipeline,
-                process_pipelines=[process_pipeline],
-            )
-            # shuffle_data = True if self.n_perms > 1 else False
-            for session in np.unique(metadata_all.session):
-                sess_idx = metadata_all.session == session
-                X_sess = X_all[sess_idx]
-                y_sess = y_all[sess_idx]
-                # metadata_sess = metadata_all[sess_idx]
-
-                # Initialize tracker once per session instead of per iteration
-                if _carbonfootprint:
-                    tracker = self.emissions.create_tracker()
-                    tracker.start()
-
-                sss = StratifiedShuffleSplit(
-                    n_splits=self.n_perms[0], test_size=self.test_size
-                )
-                for perm_i, (train_idx, test_idx) in enumerate(sss.split(X_sess, y_sess)):
-                    X_train_all = X_sess[train_idx]
-                    y_train_all = y_sess[train_idx]
-                    X_test = X_sess[test_idx]
-                    y_test = y_sess[test_idx]
-                    data_size_steps = self.get_data_size_subsets(y_train_all)
-                    for di, subset_indices in enumerate(data_size_steps):
-                        if perm_i >= self.n_perms[di]:
-                            continue
-                        not_enough_data = False
-                        log.info(
-                            f"Permutation: {perm_i + 1},"
-                            f" Training samples: {len(subset_indices)}"
-                        )
-
-                        if self.return_epochs:
-                            X_train = X_train_all[subset_indices]
-                        else:
-                            X_train = X_train_all[subset_indices, :]
-                        y_train = y_train_all[subset_indices]
-                        # metadata = metadata_perm[:subset_indices]
-
-                        if len(np.unique(y_train)) < 2:
-                            log.warning(
-                                "For current data size, only one class" "would remain."
-                            )
-                            not_enough_data = True
-                        nchan = (
-                            X_train.info["nchan"]
-                            if isinstance(X_train, BaseEpochs)
-                            else X_train.shape[1]
-                        )
-                        for name, clf in run_pipes.items():
-                            res = {
-                                "dataset": dataset,
-                                "subject": subject,
-                                "session": session,
-                                "n_samples": len(y_train),
-                                "n_channels": nchan,
-                                "pipeline": name,
-                                # Additional columns
-                                "data_size": len(subset_indices),
-                                "permutation": perm_i + 1,
-                            }
-                            if not_enough_data:
-                                res["time"] = 0
-                                res["score"] = np.nan
-                                if _carbonfootprint:
-                                    res["carbon_emission"] = (np.nan,)
-                                    res["codecarbon_task_name"] = ""
-                            else:
-                                if _carbonfootprint:
-                                    task_name = str(uuid4())
-                                    tracker.start_task(task_name)
-
-                                self.score_explicit(
-                                    res, deepcopy(clf), X_train, y_train, X_test, y_test
-                                )
-
-                                if _carbonfootprint:
-                                    emissions_data = tracker.stop_task()
-                                    emissions = (
-                                        emissions_data.emissions
-                                        if emissions_data
-                                        else np.nan
-                                    )
-                                    res["carbon_emission"] = (1000 * emissions,)
-                                    res["codecarbon_task_name"] = task_name
-                            yield res
-
-                # Stop tracker after session is complete
-                if _carbonfootprint:
-                    tracker.stop()
-
     def evaluate(
         self, dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline=None
     ):
-        if self.calculate_learning_curve:
-            yield from self._evaluate_learning_curve(
-                dataset, pipelines, process_pipeline, postprocess_pipeline
-            )
-        else:
-            yield from self._evaluate(
-                dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline
-            )
+        yield from self._evaluate(
+            dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline
+        )
 
     def is_valid(self, dataset):
         return True

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -1,8 +1,6 @@
 import logging
 from copy import deepcopy
-from time import perf_counter
 from typing import Union
-from uuid import uuid4
 
 import numpy as np
 from mne.epochs import BaseEpochs
@@ -23,10 +21,7 @@ from moabb.evaluations.splitters import (
 )
 from moabb.evaluations.utils import (
     _average_scores,
-    _create_save_path,
     _create_scorer,
-    _ensure_fitted,
-    _save_model_cv,
     _update_result_with_scores,
 )
 from moabb.pipelines.classification import SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA
@@ -184,36 +179,21 @@ class WithinSessionEvaluation(BaseEvaluation):
                     for cv_ind, (train, test) in enumerate(self.cv.split(y_, meta_)):
                         cvclf = clone(grid_clf)
 
-                        # Fit classifier with tracking
-                        if _carbonfootprint:
-                            task_name = str(uuid4())
-                            tracker.start_task(task_name)
-                        t_start = perf_counter()
-                        cvclf.fit(X_[train], y_[train])
-                        duration = perf_counter() - t_start
-                        if _carbonfootprint:
-                            emissions_data = tracker.stop_task()
-                            emissions = (
-                                emissions_data.emissions if emissions_data else np.nan
-                            )
-
-                        if self.hdf5_path is not None and self.save_model:
-                            model_save_path = _create_save_path(
-                                self.hdf5_path,
-                                dataset.code,
-                                subject,
-                                session,
-                                name,
-                                grid=self.search,
-                                eval_type="WithinSession",
-                            )
-                            _save_model_cv(
-                                model=cvclf,
-                                save_path=model_save_path,
-                                cv_index=cv_ind,
-                            )
-
-                        _ensure_fitted(cvclf)
+                        duration, emissions, task_name = self._fit_cv(
+                            cvclf,
+                            X_[train],
+                            y_[train],
+                            tracker if _carbonfootprint else None,
+                        )
+                        self._maybe_save_model_cv(
+                            cvclf,
+                            dataset,
+                            subject,
+                            session,
+                            name,
+                            cv_ind,
+                            eval_type="WithinSession",
+                        )
                         if per_split:
                             res = self._build_scored_result(
                                 dataset,
@@ -229,8 +209,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                                 y_[test],
                             )
                             if _carbonfootprint:
-                                res["carbon_emission"] = (1000 * emissions,)
-                                res["codecarbon_task_name"] = task_name
+                                self._attach_emissions(res, emissions, task_name)
                             yield res
                         else:
                             score = scorer(cvclf, X_[test], y_[test])
@@ -251,8 +230,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                         )
                         _update_result_with_scores(res, _average_scores(acc))
                         if _carbonfootprint:
-                            res["carbon_emission"] = (1000 * emissions,)
-                            res["codecarbon_task_name"] = task_name
+                            self._attach_emissions(res, emissions, task_name)
                         yield res
 
     def evaluate(
@@ -382,34 +360,21 @@ class CrossSessionEvaluation(BaseEvaluation):
                     model_list = []
                     cvclf = clone(grid_clf)
 
-                    # Fit classifier with tracking
-                    if _carbonfootprint:
-                        task_name = str(uuid4())
-                        tracker.start_task(task_name)
-                    t_start = perf_counter()
-                    cvclf.fit(X[train], y[train])
-                    duration = perf_counter() - t_start
-                    if _carbonfootprint:
-                        emissions_data = tracker.stop_task()
-                        emissions = emissions_data.emissions if emissions_data else np.nan
-
-                    if self.hdf5_path is not None and self.save_model:
-                        model_save_path = _create_save_path(
-                            hdf5_path=self.hdf5_path,
-                            code=dataset.code,
-                            subject=subject,
-                            session="",
-                            name=name,
-                            grid=self.search,
-                            eval_type="CrossSession",
-                        )
-                        _save_model_cv(
-                            model=cvclf,
-                            save_path=model_save_path,
-                            cv_index=str(cv_ind),
-                        )
-
-                    _ensure_fitted(cvclf)
+                    duration, emissions, task_name = self._fit_cv(
+                        cvclf,
+                        X[train],
+                        y[train],
+                        tracker if _carbonfootprint else None,
+                    )
+                    self._maybe_save_model_cv(
+                        cvclf,
+                        dataset,
+                        subject,
+                        "",
+                        name,
+                        cv_ind,
+                        eval_type="CrossSession",
+                    )
                     model_list.append(cvclf)
 
                     res = self._build_scored_result(
@@ -427,8 +392,7 @@ class CrossSessionEvaluation(BaseEvaluation):
                     )
 
                     if _carbonfootprint:
-                        res["carbon_emission"] = (1000 * emissions,)
-                        res["codecarbon_task_name"] = task_name
+                        self._attach_emissions(res, emissions, task_name)
 
                     yield res
 
@@ -589,32 +553,21 @@ class CrossSubjectEvaluation(BaseEvaluation):
                 )
                 cvclf = deepcopy(clf)
 
-                # Fit classifier with tracking
-                if _carbonfootprint:
-                    task_name = str(uuid4())
-                    tracker.start_task(task_name)
-                t_start = perf_counter()
-                cvclf.fit(X[train], y[train])
-                duration = perf_counter() - t_start
-                if _carbonfootprint:
-                    emissions_data = tracker.stop_task()
-                    emissions = emissions_data.emissions if emissions_data else np.nan
-
-                if self.hdf5_path is not None and self.save_model:
-                    model_save_path = _create_save_path(
-                        hdf5_path=self.hdf5_path,
-                        code=dataset.code,
-                        subject=subject,
-                        session="",
-                        name=name,
-                        grid=self.search,
-                        eval_type="CrossSubject",
-                    )
-                    _save_model_cv(
-                        model=cvclf, save_path=model_save_path, cv_index=str(cv_ind)
-                    )
-
-                _ensure_fitted(cvclf)
+                duration, emissions, task_name = self._fit_cv(
+                    cvclf,
+                    X[train],
+                    y[train],
+                    tracker if _carbonfootprint else None,
+                )
+                self._maybe_save_model_cv(
+                    cvclf,
+                    dataset,
+                    subject,
+                    "",
+                    name,
+                    cv_ind,
+                    eval_type="CrossSubject",
+                )
 
                 # Create scorer once per pipeline
                 scorer = _create_scorer(cvclf, self.paradigm.scoring)
@@ -638,8 +591,7 @@ class CrossSubjectEvaluation(BaseEvaluation):
                     )
 
                     if _carbonfootprint:
-                        res["carbon_emission"] = (1000 * emissions,)
-                        res["codecarbon_task_name"] = task_name
+                        self._attach_emissions(res, emissions, task_name)
 
                     yield res
 

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from typing import Union
 
 import numpy as np
-from mne.epochs import BaseEpochs
 from sklearn.base import clone
 from sklearn.model_selection import (
     GroupKFold,
@@ -24,19 +23,6 @@ from moabb.evaluations.utils import (
     _create_scorer,
     _update_result_with_scores,
 )
-from moabb.pipelines.classification import SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA
-
-
-def _pipeline_requires_epochs(pipeline):
-    """Check if any step in the pipeline requires MNE Epochs objects."""
-    # Handle non-pipeline classifiers (like DummyClassifier)
-    if not hasattr(pipeline, "steps"):
-        return isinstance(pipeline, (SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA))
-
-    for name, step in pipeline.steps:
-        if isinstance(step, (SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA)):
-            return True
-    return False
 
 
 try:
@@ -116,35 +102,26 @@ class WithinSessionEvaluation(BaseEvaluation):
             if len(run_pipes) == 0:
                 continue
 
-            # get the data
-            # Force return_epochs=True if any pipeline requires MNE Epochs objects
-            requires_epochs = any(
-                _pipeline_requires_epochs(clf) for clf in run_pipes.values()
-            )
-            return_epochs = True if requires_epochs else self.return_epochs
-            # For pipelines requiring epochs, don't pass process_pipeline to ensure it's created
-            # with return_epochs=True
-            X, y, metadata = self.paradigm.get_data(
-                dataset=dataset,
+            X, y, metadata = self._load_data(
+                dataset,
+                run_pipes,
+                process_pipeline,
+                postprocess_pipeline,
                 subjects=[subject],
-                return_epochs=return_epochs,
-                return_raws=self.return_raws,
-                cache_config=self.cache_config,
-                postprocess_pipeline=postprocess_pipeline,
-                process_pipelines=None if requires_epochs else [process_pipeline],
             )
+
+            cv_class, cv_kwargs = self._resolve_cv(StratifiedKFold)
+            self.cv = WithinSessionSplitter(
+                n_folds=5,
+                shuffle=True,
+                random_state=self.random_state,
+                cv_class=cv_class,
+                **cv_kwargs,
+            )
+
             # iterate over sessions
             for session in np.unique(metadata.session):
                 ix = metadata.session == session
-
-                cv_class, cv_kwargs = self._resolve_cv(StratifiedKFold)
-                self.cv = WithinSessionSplitter(
-                    n_folds=5,
-                    shuffle=True,
-                    random_state=self.random_state,
-                    cv_class=cv_class,
-                    **cv_kwargs,
-                )
 
                 for name, clf in run_pipes.items():
                     inner_cv = StratifiedKFold(
@@ -167,7 +144,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                     meta_ = metadata[ix].reset_index(drop=True)
                     acc = list()
                     durations = []
-                    nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
+                    nchan = self._get_nchan(X)
 
                     if _carbonfootprint:
                         # Initialise CodeCarbon per cross-validation
@@ -318,27 +295,17 @@ class CrossSessionEvaluation(BaseEvaluation):
                 log.info(f"Subject {subject} already processed")
                 continue
 
-            # get the data
-            # Force return_epochs=True if any pipeline requires MNE Epochs objects
-            requires_epochs = any(
-                _pipeline_requires_epochs(clf) for clf in run_pipes.values()
-            )
-            return_epochs = True if requires_epochs else self.return_epochs
-            # For pipelines requiring epochs, don't pass process_pipeline to ensure it's created
-            # with return_epochs=True
-            X, y, metadata = self.paradigm.get_data(
-                dataset=dataset,
+            X, y, metadata = self._load_data(
+                dataset,
+                run_pipes,
+                process_pipeline,
+                postprocess_pipeline,
                 subjects=[subject],
-                return_epochs=return_epochs,
-                return_raws=self.return_raws,
-                cache_config=self.cache_config,
-                postprocess_pipeline=postprocess_pipeline,
-                process_pipelines=None if requires_epochs else [process_pipeline],
             )
             le = LabelEncoder()
             y = y if self.mne_labels else le.fit_transform(y)
             groups = metadata.session.values
-            nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
+            nchan = self._get_nchan(X)
 
             for name, clf in run_pipes.items():
                 # we want to store a results per session
@@ -490,20 +457,11 @@ class CrossSubjectEvaluation(BaseEvaluation):
         if len(run_pipes) == 0:
             return
 
-        # Force return_epochs=True if any pipeline requires MNE Epochs objects
-        requires_epochs = any(
-            _pipeline_requires_epochs(clf) for clf in run_pipes.values()
-        )
-        return_epochs = True if requires_epochs else self.return_epochs
-        # For pipelines requiring epochs, don't pass process_pipeline to ensure it's created
-        # with return_epochs=True
-        X, y, metadata = self.paradigm.get_data(
-            dataset=dataset,
-            return_epochs=return_epochs,
-            return_raws=self.return_raws,
-            cache_config=self.cache_config,
-            postprocess_pipeline=postprocess_pipeline,
-            process_pipelines=None if requires_epochs else [process_pipeline],
+        X, y, metadata = self._load_data(
+            dataset,
+            run_pipes,
+            process_pipeline,
+            postprocess_pipeline,
         )
         le = LabelEncoder()
         y = y if self.mne_labels else le.fit_transform(y)
@@ -512,7 +470,7 @@ class CrossSubjectEvaluation(BaseEvaluation):
         groups = metadata.subject.values
         sessions = metadata.session.values
         n_subjects = len(dataset.subject_list)
-        nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
+        nchan = self._get_nchan(X)
 
         # perform leave one subject out CV
         if self.n_splits is None:

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -137,15 +137,16 @@ class WithinSessionEvaluation(BaseEvaluation):
             for session in np.unique(metadata.session):
                 ix = metadata.session == session
 
+                cv_class, cv_kwargs = self._resolve_cv(StratifiedKFold)
+                self.cv = WithinSessionSplitter(
+                    n_folds=5,
+                    shuffle=True,
+                    random_state=self.random_state,
+                    cv_class=cv_class,
+                    **cv_kwargs,
+                )
+
                 for name, clf in run_pipes.items():
-                    cv_class, cv_kwargs = self._resolve_cv(StratifiedKFold)
-                    self.cv = WithinSessionSplitter(
-                        n_folds=5,
-                        shuffle=True,
-                        random_state=self.random_state,
-                        cv_class=cv_class,
-                        **cv_kwargs,
-                    )
                     inner_cv = StratifiedKFold(
                         3, shuffle=True, random_state=self.random_state
                     )
@@ -165,6 +166,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                     y_ = y[ix] if self.mne_labels else y_cv
                     meta_ = metadata[ix].reset_index(drop=True)
                     acc = list()
+                    durations = []
                     nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
 
                     if _carbonfootprint:
@@ -176,6 +178,10 @@ class WithinSessionEvaluation(BaseEvaluation):
                     scorer = _create_scorer(grid_clf, self.paradigm.scoring)
 
                     per_split = hasattr(self.cv.cv_class, "get_metadata")
+                    # Initialize variables for edge case where CV split returns zero iterations
+                    duration = 0
+                    emissions = np.nan
+                    task_name = None
                     for cv_ind, (train, test) in enumerate(self.cv.split(y_, meta_)):
                         cvclf = clone(grid_clf)
 
@@ -185,6 +191,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                             y_[train],
                             tracker if _carbonfootprint else None,
                         )
+                        durations.append(duration)
                         self._maybe_save_model_cv(
                             cvclf,
                             dataset,
@@ -219,6 +226,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                         tracker.stop()
 
                     if not per_split:
+                        avg_duration = float(np.mean(durations)) if durations else 0.0
                         res = self._build_result(
                             dataset,
                             subject,
@@ -226,7 +234,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                             name,
                             len(y_cv),
                             nchan,
-                            duration / self.cv.n_folds,
+                            avg_duration,
                         )
                         _update_result_with_scores(res, _average_scores(acc))
                         if _carbonfootprint:
@@ -357,7 +365,6 @@ class CrossSessionEvaluation(BaseEvaluation):
                 scorer = _create_scorer(grid_clf, self.paradigm.scoring)
 
                 for cv_ind, (train, test) in enumerate(self.cv.split(y, metadata)):
-                    model_list = []
                     cvclf = clone(grid_clf)
 
                     duration, emissions, task_name = self._fit_cv(
@@ -375,7 +382,6 @@ class CrossSessionEvaluation(BaseEvaluation):
                         cv_ind,
                         eval_type="CrossSession",
                     )
-                    model_list.append(cvclf)
 
                     res = self._build_scored_result(
                         dataset,

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -19,6 +19,7 @@ from moabb.evaluations.base import BaseEvaluation
 from moabb.evaluations.splitters import (
     CrossSessionSplitter,
     CrossSubjectSplitter,
+    LearningCurveSplitter,
     WithinSessionSplitter,
 )
 from moabb.evaluations.utils import (
@@ -176,6 +177,8 @@ class WithinSessionEvaluation(BaseEvaluation):
                     y_ = y[ix] if self.mne_labels else y_cv
                     meta_ = metadata[ix].reset_index(drop=True)
                     acc = list()
+                    nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
+                    is_learning_curve = self.cv_class is LearningCurveSplitter
 
                     if _carbonfootprint:
                         # Initialise CodeCarbon per cross-validation
@@ -218,32 +221,45 @@ class WithinSessionEvaluation(BaseEvaluation):
                             )
 
                         _ensure_fitted(cvclf)
-                        # scorer always returns dict
                         score = scorer(cvclf, X_[test], y_[test])
-                        acc.append(score)
+
+                        if is_learning_curve:
+                            res = self._build_result(
+                                dataset,
+                                subject,
+                                session,
+                                name,
+                                len(train),
+                                nchan,
+                                duration,
+                                **self.cv._current_splitter.get_metadata(),
+                            )
+                            _update_result_with_scores(res, score)
+                            if _carbonfootprint:
+                                res["carbon_emission"] = (1000 * emissions,)
+                                res["codecarbon_task_name"] = task_name
+                            yield res
+                        else:
+                            acc.append(score)
 
                     if _carbonfootprint:
                         tracker.stop()
 
-                    nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
-                    res = {
-                        "time": duration / self.cv.n_folds,  # 5 fold CV
-                        "dataset": dataset,
-                        "subject": subject,
-                        "session": session,
-                        "n_samples": len(y_cv),  # not training sample
-                        "n_channels": nchan,
-                        "pipeline": name,
-                    }
-
-                    mean_scores = _average_scores(acc)
-                    _update_result_with_scores(res, mean_scores)
-
-                    if _carbonfootprint:
-                        res["carbon_emission"] = (1000 * emissions,)
-                        res["codecarbon_task_name"] = task_name
-
-                    yield res
+                    if not is_learning_curve:
+                        res = self._build_result(
+                            dataset,
+                            subject,
+                            session,
+                            name,
+                            len(y_cv),
+                            nchan,
+                            duration / self.cv.n_folds,
+                        )
+                        _update_result_with_scores(res, _average_scores(acc))
+                        if _carbonfootprint:
+                            res["carbon_emission"] = (1000 * emissions,)
+                            res["codecarbon_task_name"] = task_name
+                        yield res
 
     def evaluate(
         self, dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline=None
@@ -342,6 +358,7 @@ class CrossSessionEvaluation(BaseEvaluation):
             le = LabelEncoder()
             y = y if self.mne_labels else le.fit_transform(y)
             groups = metadata.session.values
+            nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
 
             for name, clf in run_pipes.items():
                 # we want to store a results per session
@@ -400,18 +417,16 @@ class CrossSessionEvaluation(BaseEvaluation):
 
                     _ensure_fitted(cvclf)
                     model_list.append(cvclf)
-                    nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
 
-                    res = {
-                        "time": duration,
-                        "dataset": dataset,
-                        "subject": subject,
-                        "session": groups[test][0],
-                        "n_samples": len(train),
-                        "n_channels": nchan,
-                        "pipeline": name,
-                    }
-
+                    res = self._build_result(
+                        dataset,
+                        subject,
+                        groups[test][0],
+                        name,
+                        len(train),
+                        nchan,
+                        duration,
+                    )
                     _score_and_update(res, scorer, cvclf, X[test], y[test])
 
                     if _carbonfootprint:
@@ -530,6 +545,7 @@ class CrossSubjectEvaluation(BaseEvaluation):
         groups = metadata.subject.values
         sessions = metadata.session.values
         n_subjects = len(dataset.subject_list)
+        nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
 
         # perform leave one subject out CV
         if self.n_splits is None:
@@ -609,18 +625,16 @@ class CrossSubjectEvaluation(BaseEvaluation):
                 # Evaluate on each session
                 for session in np.unique(sessions[test]):
                     ix = sessions[test] == session
-                    nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
 
-                    res = {
-                        "time": duration,
-                        "dataset": dataset,
-                        "subject": subject,
-                        "session": session,
-                        "n_samples": len(train),
-                        "n_channels": nchan,
-                        "pipeline": name,
-                    }
-
+                    res = self._build_result(
+                        dataset,
+                        subject,
+                        session,
+                        name,
+                        len(train),
+                        nchan,
+                        duration,
+                    )
                     _score_and_update(res, scorer, cvclf, X[test[ix]], y[test[ix]])
 
                     if _carbonfootprint:

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -19,7 +19,6 @@ from moabb.evaluations.base import BaseEvaluation
 from moabb.evaluations.splitters import (
     CrossSessionSplitter,
     CrossSubjectSplitter,
-    LearningCurveSplitter,
     WithinSessionSplitter,
 )
 from moabb.evaluations.utils import (
@@ -172,7 +171,6 @@ class WithinSessionEvaluation(BaseEvaluation):
                     meta_ = metadata[ix].reset_index(drop=True)
                     acc = list()
                     nchan = X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
-                    is_learning_curve = self.cv_class is LearningCurveSplitter
 
                     if _carbonfootprint:
                         # Initialise CodeCarbon per cross-validation
@@ -182,6 +180,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                     # Create scorer once before CV loop
                     scorer = _create_scorer(grid_clf, self.paradigm.scoring)
 
+                    per_split = hasattr(self.cv.cv_class, "get_metadata")
                     for cv_ind, (train, test) in enumerate(self.cv.split(y_, meta_)):
                         cvclf = clone(grid_clf)
 
@@ -215,8 +214,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                             )
 
                         _ensure_fitted(cvclf)
-
-                        if is_learning_curve:
+                        if per_split:
                             res = self._build_scored_result(
                                 dataset,
                                 subject,
@@ -241,7 +239,7 @@ class WithinSessionEvaluation(BaseEvaluation):
                     if _carbonfootprint:
                         tracker.stop()
 
-                    if not is_learning_curve:
+                    if not per_split:
                         res = self._build_result(
                             dataset,
                             subject,

--- a/moabb/evaluations/splitters.py
+++ b/moabb/evaluations/splitters.py
@@ -88,7 +88,8 @@ class WithinSessionSplitter(BaseCrossValidator):
         all_index = metadata.index.values
 
         # Shuffle subjects if required
-        subjects = metadata["subject"].unique()
+        # Convert to numpy array to avoid ArrowStringArray shuffle warning
+        subjects = np.array(metadata["subject"].unique())
         if self.shuffle:
             self._rng.shuffle(subjects)
 
@@ -99,7 +100,8 @@ class WithinSessionSplitter(BaseCrossValidator):
             y_subject = y[subject_mask]
 
             # Shuffle sessions if required
-            sessions = subject_metadata["session"].unique()
+            # Convert to numpy array to avoid ArrowStringArray shuffle warning
+            sessions = np.array(subject_metadata["session"].unique())
 
             if self.shuffle:
                 self._rng.shuffle(sessions)
@@ -221,7 +223,8 @@ class WithinSubjectSplitter(BaseCrossValidator):
         all_index = metadata.index.values
 
         # Shuffle subjects if required
-        subjects = metadata["subject"].unique()
+        # Convert to numpy array to avoid ArrowStringArray shuffle warning
+        subjects = np.array(metadata["subject"].unique())
         if self.shuffle:
             self._rng.shuffle(subjects)
 
@@ -741,12 +744,21 @@ class LearningCurveSplitter(BaseCrossValidator):
                 if perm_i >= self.n_perms[di]:
                     continue
 
+                # Get the actual training indices (subset of the full training set)
+                train_idx = train_idx_full[subset_indices]
+
+                # Skip splits where training set collapses to single class
+                # (can happen with small data_size values or imbalanced datasets)
+                if len(np.unique(y[train_idx])) < 2:
+                    log.warning(
+                        "Skipping split: training set has only one class "
+                        f"(data_size={len(subset_indices)}, perm={perm_i + 1})"
+                    )
+                    continue
+
                 # Update current split metadata
                 self._current_perm = perm_i + 1  # 1-indexed for user display
                 self._current_data_size = len(subset_indices)
-
-                # Get the actual training indices (subset of the full training set)
-                train_idx = train_idx_full[subset_indices]
 
                 yield train_idx, test_idx
 

--- a/moabb/evaluations/splitters.py
+++ b/moabb/evaluations/splitters.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 from typing import Optional, Union
+from warnings import warn
 
 import numpy as np
 from sklearn.model_selection import (
@@ -82,7 +83,12 @@ class WithinSessionSplitter(BaseCrossValidator):
 
     def get_n_splits(self, metadata):
         num_sessions_subjects = metadata.groupby(["subject", "session"]).ngroups
-        return self.n_folds * num_sessions_subjects
+        splitter = self.cv_class(**self._cv_kwargs)
+        try:
+            inner_splits = splitter.get_n_splits()
+        except TypeError:
+            inner_splits = splitter.get_n_splits(None, None, None)
+        return inner_splits * num_sessions_subjects
 
     def split(self, y, metadata):
         all_index = metadata.index.values
@@ -203,7 +209,12 @@ class WithinSubjectSplitter(BaseCrossValidator):
             The number of splits for the cross-validation
         """
         num_subjects = metadata["subject"].nunique()
-        return self.n_folds * num_subjects
+        splitter = self.cv_class(**self._cv_kwargs)
+        try:
+            inner_splits = splitter.get_n_splits()
+        except TypeError:
+            inner_splits = splitter.get_n_splits(None, None, None)
+        return inner_splits * num_subjects
 
     def split(self, y, metadata):
         all_index = metadata.index.values
@@ -726,9 +737,11 @@ class LearningCurveSplitter(BaseCrossValidator):
                 # Skip splits where training set collapses to single class
                 # (can happen with small data_size values or imbalanced datasets)
                 if len(np.unique(y[train_idx])) < 2:
-                    log.warning(
+                    warn(
                         "Skipping split: training set has only one class "
-                        f"(data_size={len(subset_indices)}, perm={perm_i + 1})"
+                        f"(data_size={len(subset_indices)}, perm={perm_i + 1})",
+                        RuntimeWarning,
+                        stacklevel=2,
                     )
                     continue
 

--- a/moabb/evaluations/splitters.py
+++ b/moabb/evaluations/splitters.py
@@ -6,6 +6,7 @@ from warnings import warn
 import numpy as np
 from sklearn.model_selection import (
     BaseCrossValidator,
+    GroupShuffleSplit,
     LeaveOneGroupOut,
     StratifiedKFold,
     StratifiedShuffleSplit,
@@ -697,7 +698,8 @@ class LearningCurveSplitter(BaseCrossValidator):
         y : array-like of shape (n_samples,)
             Target labels.
         groups : array-like of shape (n_samples,), optional
-            Ignored.
+            Group labels. If provided, splits are made on groups (no group
+            appears in both train and test).
 
         Yields
         ------
@@ -707,18 +709,30 @@ class LearningCurveSplitter(BaseCrossValidator):
             The testing set indices for that split.
         """
         y = np.asarray(y)
+        if groups is not None:
+            groups = np.asarray(groups)
 
-        # Create StratifiedShuffleSplit for the base train/test splits
-        # Use the maximum number of permutations
+        # Create base train/test splits
+        # Use StratifiedShuffleSplit when no groups are provided, otherwise
+        # split by groups to avoid session/subject leakage.
         max_perms = int(np.max(self.n_perms))
-        sss = StratifiedShuffleSplit(
-            n_splits=max_perms,
-            test_size=self.test_size,
-            random_state=self.random_state,
-        )
+        if groups is None:
+            splitter = StratifiedShuffleSplit(
+                n_splits=max_perms,
+                test_size=self.test_size,
+                random_state=self.random_state,
+            )
+            base_splits = splitter.split(X, y)
+        else:
+            splitter = GroupShuffleSplit(
+                n_splits=max_perms,
+                test_size=self.test_size,
+                random_state=self.random_state,
+            )
+            base_splits = splitter.split(X, y, groups=groups)
 
         # Generate all permutations
-        for perm_i, (train_idx_full, test_idx) in enumerate(sss.split(X, y)):
+        for perm_i, (train_idx_full, test_idx) in enumerate(base_splits):
             # For this permutation, get the training data labels
             y_train_full = y[train_idx_full]
 

--- a/moabb/evaluations/splitters.py
+++ b/moabb/evaluations/splitters.py
@@ -381,6 +381,7 @@ class CrossSessionSplitter(BaseCrossValidator):
 
             # by default, I am using LeaveOneGroupOut
             splitter = self.cv_class(**cv_kwargs)
+            self._current_splitter = splitter
 
             # Yield the splits for a given subject
             for train_session_idx, test_session_idx in splitter.split(

--- a/moabb/evaluations/splitters.py
+++ b/moabb/evaluations/splitters.py
@@ -122,20 +122,6 @@ class WithinSessionSplitter(BaseCrossValidator):
 
                     yield indices[train_ix], indices[test_ix]
 
-    def get_inner_splitter_metadata(self):
-        """Get metadata from the current inner splitter if available.
-
-        Returns
-        -------
-        metadata : dict or None
-            Metadata dict if the inner splitter supports it, None otherwise.
-        """
-        if hasattr(self, "_current_splitter") and hasattr(
-            self._current_splitter, "get_metadata"
-        ):
-            return self._current_splitter.get_metadata()
-        return None
-
 
 class WithinSubjectSplitter(BaseCrossValidator):
     """Data splitter for within subject evaluation.
@@ -235,6 +221,9 @@ class WithinSubjectSplitter(BaseCrossValidator):
 
             # Instantiate a new internal splitter for each subject
             splitter = self.cv_class(**self._cv_kwargs)
+
+            # Store reference to the current inner splitter for metadata access
+            self._current_splitter = splitter
 
             # Split using the cross-validation strategy across all sessions of the subject
             for train_ix, test_ix in splitter.split(subject_indices, y_subject):
@@ -487,6 +476,9 @@ class CrossSubjectSplitter(BaseCrossValidator):
 
         splitter = self.cv_class(**self._cv_kwargs)
 
+        # Store reference to the current inner splitter for metadata access
+        self._current_splitter = splitter
+
         # Yield the splits for the entire dataset
         for train_session_idx, test_session_idx in splitter.split(
             X=all_index, y=y, groups=metadata["subject"]
@@ -558,6 +550,7 @@ class LearningCurveSplitter(BaseCrossValidator):
     """
 
     VALID_POLICIES = ["per_class", "ratio"]
+    metadata_columns = ("data_size", "permutation")
 
     def __init__(
         self,

--- a/moabb/evaluations/splitters.py
+++ b/moabb/evaluations/splitters.py
@@ -85,10 +85,18 @@ class WithinSessionSplitter(BaseCrossValidator):
     def get_n_splits(self, metadata):
         num_sessions_subjects = metadata.groupby(["subject", "session"]).ngroups
         splitter = self.cv_class(**self._cv_kwargs)
+        inner_splits = None
         try:
             inner_splits = splitter.get_n_splits()
         except TypeError:
-            inner_splits = splitter.get_n_splits(None, None, None)
+            try:
+                inner_splits = splitter.get_n_splits(None, None, None)
+            except (TypeError, ValueError):
+                inner_splits = None
+        except ValueError:
+            inner_splits = None
+        if inner_splits is None:
+            inner_splits = self.n_folds
         return inner_splits * num_sessions_subjects
 
     def split(self, y, metadata):
@@ -211,10 +219,18 @@ class WithinSubjectSplitter(BaseCrossValidator):
         """
         num_subjects = metadata["subject"].nunique()
         splitter = self.cv_class(**self._cv_kwargs)
+        inner_splits = None
         try:
             inner_splits = splitter.get_n_splits()
         except TypeError:
-            inner_splits = splitter.get_n_splits(None, None, None)
+            try:
+                inner_splits = splitter.get_n_splits(None, None, None)
+            except (TypeError, ValueError):
+                inner_splits = None
+        except ValueError:
+            inner_splits = None
+        if inner_splits is None:
+            inner_splits = self.n_folds
         return inner_splits * num_subjects
 
     def split(self, y, metadata):
@@ -640,7 +656,8 @@ class LearningCurveSplitter(BaseCrossValidator):
         Returns
         -------
         n_splits : int
-            Total number of splits.
+            Total number of splits (upper bound; can be lower if some splits
+            are skipped due to single-class training sets).
         """
         return self.n_splits_
 

--- a/moabb/evaluations/utils.py
+++ b/moabb/evaluations/utils.py
@@ -472,6 +472,27 @@ def _score_and_update(res, scorer, model, X, y_true):
     return _update_result_with_scores(res, score)
 
 
+def _pipeline_requires_epochs(pipeline):
+    """Check if any step in the pipeline requires MNE Epochs objects."""
+    from moabb.pipelines.classification import SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA
+
+    # Handle non-pipeline classifiers (like DummyClassifier)
+    if not hasattr(pipeline, "steps"):
+        return isinstance(pipeline, (SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA))
+
+    for name, step in pipeline.steps:
+        if isinstance(step, (SSVEP_CCA, SSVEP_TRCA, SSVEP_MsetCCA)):
+            return True
+    return False
+
+
+def _get_nchan(X):
+    """Extract number of channels from data (Epochs or ndarray)."""
+    from mne.epochs import BaseEpochs
+
+    return X.info["nchan"] if isinstance(X, BaseEpochs) else X.shape[1]
+
+
 class Emissions:
     def __init__(self, codecarbon_config=None):
         self.codecarbon_config = codecarbon_config

--- a/moabb/tests/test_evaluations.py
+++ b/moabb/tests/test_evaluations.py
@@ -294,7 +294,6 @@ class TestWithinSessLearningCurve:
         with pytest.raises(ValueError):
             evaluation.process(pipelines)
 
-    @pytest.mark.skip(reason="This test is not working")
     def test_data_sanity(self):
         # need this helper to iterate over the generator
         def run_evaluation(eval, dataset, pipelines):
@@ -310,6 +309,7 @@ class TestWithinSessLearningCurve:
             paradigm=FakeImageryParadigm(),
             datasets=[dataset],
             cv_class=LearningCurveSplitter,
+            overwrite=True,
         )
         should_work = ev.WithinSessionEvaluation(
             cv_kwargs={

--- a/moabb/tests/test_evaluations.py
+++ b/moabb/tests/test_evaluations.py
@@ -18,6 +18,7 @@ from moabb.datasets.compound_dataset import compound
 from moabb.datasets.fake import FakeDataset
 from moabb.evaluations import evaluations as ev
 from moabb.evaluations.base import optuna_available
+from moabb.evaluations.splitters import LearningCurveSplitter
 from moabb.evaluations.utils import _create_save_path as create_save_path
 from moabb.evaluations.utils import _save_model_cv as save_model_cv
 from moabb.paradigms.motor_imagery import FakeImageryParadigm
@@ -241,8 +242,11 @@ class TestWithinSessLearningCurve:
         learning_curve_eval = ev.WithinSessionEvaluation(
             paradigm=FakeImageryParadigm(),
             datasets=[dataset],
-            data_size={"policy": "ratio", "value": np.array([0.2, 0.5])},
-            n_perms=np.array([2, 2]),
+            cv_class=LearningCurveSplitter,
+            cv_kwargs={
+                "data_size": {"policy": "ratio", "value": np.array([0.2, 0.5])},
+                "n_perms": np.array([2, 2]),
+            },
         )
         process_pipeline = learning_curve_eval.paradigm.make_process_pipelines(dataset)[0]
         results = [
@@ -257,19 +261,38 @@ class TestWithinSessLearningCurve:
         assert "data_size" in keys
 
     def test_all_policies_work(self):
-        kwargs = dict(paradigm=FakeImageryParadigm(), datasets=[dataset], n_perms=[2, 2])
+        kwargs = dict(
+            paradigm=FakeImageryParadigm(),
+            datasets=[dataset],
+            cv_class=LearningCurveSplitter,
+        )
         # The next two should work without issue
         ev.WithinSessionEvaluation(
-            data_size={"policy": "per_class", "value": [5, 10]}, **kwargs
+            cv_kwargs={
+                "data_size": {"policy": "per_class", "value": [5, 10]},
+                "n_perms": [2, 2],
+            },
+            **kwargs,
         )
         ev.WithinSessionEvaluation(
-            data_size={"policy": "ratio", "value": [0.2, 0.5]}, **kwargs
+            cv_kwargs={
+                "data_size": {"policy": "ratio", "value": [0.2, 0.5]},
+                "n_perms": [2, 2],
+            },
+            **kwargs,
+        )
+        # Invalid policy should raise ValueError when evaluation is run
+        # (LearningCurveSplitter is instantiated at evaluation time, not construction)
+        evaluation = ev.WithinSessionEvaluation(
+            cv_kwargs={
+                "data_size": {"policy": "does_not_exist", "value": [0.2, 0.5]},
+                "n_perms": [2, 2],
+            },
+            overwrite=True,
+            **kwargs,
         )
         with pytest.raises(ValueError):
-            ev.WithinSessionEvaluation(
-                data_size={"policy": "does_not_exist", "value": [0.2, 0.5]},
-                **kwargs,
-            )
+            evaluation.process(pipelines)
 
     @pytest.mark.skip(reason="This test is not working")
     def test_data_sanity(self):
@@ -283,12 +306,24 @@ class TestWithinSessLearningCurve:
             )
 
         # E.g. if number of samples too high -> expect error
-        kwargs = dict(paradigm=FakeImageryParadigm(), datasets=[dataset], n_perms=[2, 2])
+        kwargs = dict(
+            paradigm=FakeImageryParadigm(),
+            datasets=[dataset],
+            cv_class=LearningCurveSplitter,
+        )
         should_work = ev.WithinSessionEvaluation(
-            data_size={"policy": "per_class", "value": [5, 10]}, **kwargs
+            cv_kwargs={
+                "data_size": {"policy": "per_class", "value": [5, 10]},
+                "n_perms": [2, 2],
+            },
+            **kwargs,
         )
         too_many_samples = ev.WithinSessionEvaluation(
-            data_size={"policy": "per_class", "value": [5, 100000]}, **kwargs
+            cv_kwargs={
+                "data_size": {"policy": "per_class", "value": [5, 100000]},
+                "n_perms": [2, 2],
+            },
+            **kwargs,
         )
         # This one should run
         run_evaluation(should_work, dataset, pipelines)
@@ -300,29 +335,50 @@ class TestWithinSessLearningCurve:
 
     def test_datasize_parameters(self):
         # Fail if not values are not correctly ordered
-        kwargs = dict(paradigm=FakeImageryParadigm(), datasets=[dataset])
+        # (LearningCurveSplitter is instantiated at evaluation time, not construction)
+        kwargs = dict(
+            paradigm=FakeImageryParadigm(),
+            datasets=[dataset],
+            cv_class=LearningCurveSplitter,
+            overwrite=True,
+        )
         decreasing_datasize = dict(
-            data_size={"policy": "per_class", "value": [5, 4]}, n_perms=[2, 1], **kwargs
+            cv_kwargs={
+                "data_size": {"policy": "per_class", "value": [5, 4]},
+                "n_perms": [2, 1],
+            },
+            **kwargs,
         )
         constant_datasize = dict(
-            data_size={"policy": "per_class", "value": [5, 5]}, n_perms=[2, 3], **kwargs
+            cv_kwargs={
+                "data_size": {"policy": "per_class", "value": [5, 5]},
+                "n_perms": [2, 3],
+            },
+            **kwargs,
         )
         increasing_perms = dict(
-            data_size={"policy": "per_class", "value": [3, 4]}, n_perms=[2, 3], **kwargs
+            cv_kwargs={
+                "data_size": {"policy": "per_class", "value": [3, 4]},
+                "n_perms": [2, 3],
+            },
+            **kwargs,
         )
         with pytest.raises(ValueError):
-            ev.WithinSessionEvaluation(**decreasing_datasize)
+            ev.WithinSessionEvaluation(**decreasing_datasize).process(pipelines)
         with pytest.raises(ValueError):
-            ev.WithinSessionEvaluation(**constant_datasize)
+            ev.WithinSessionEvaluation(**constant_datasize).process(pipelines)
         with pytest.raises(ValueError):
-            ev.WithinSessionEvaluation(**increasing_perms)
+            ev.WithinSessionEvaluation(**increasing_perms).process(pipelines)
 
     def test_postprocess_pipeline(self):
         learning_curve_eval = ev.WithinSessionEvaluation(
             paradigm=FakeImageryParadigm(),
             datasets=[dataset],
-            data_size={"policy": "ratio", "value": np.array([0.2, 0.5])},
-            n_perms=np.array([2, 2]),
+            cv_class=LearningCurveSplitter,
+            cv_kwargs={
+                "data_size": {"policy": "ratio", "value": np.array([0.2, 0.5])},
+                "n_perms": np.array([2, 2]),
+            },
         )
 
         cov = Covariances("oas")

--- a/moabb/tests/test_evaluations.py
+++ b/moabb/tests/test_evaluations.py
@@ -237,7 +237,6 @@ class TestWithinSessLearningCurve:
     initialization instead of during running the evaluation
     """
 
-    @pytest.mark.skip(reason="This test is not working")
     def test_correct_results_integrity(self):
         learning_curve_eval = ev.WithinSessionEvaluation(
             paradigm=FakeImageryParadigm(),
@@ -247,6 +246,7 @@ class TestWithinSessLearningCurve:
                 "data_size": {"policy": "ratio", "value": np.array([0.2, 0.5])},
                 "n_perms": np.array([2, 2]),
             },
+            overwrite=True,
         )
         process_pipeline = learning_curve_eval.paradigm.make_process_pipelines(dataset)[0]
         results = [

--- a/moabb/tests/test_splits.py
+++ b/moabb/tests/test_splits.py
@@ -511,3 +511,44 @@ def test_learning_curve_splitter_metadata():
         meta = splitter.get_metadata()
         assert meta["data_size"] is not None
         assert meta["permutation"] is not None
+
+
+@pytest.mark.parametrize(
+    "splitter",
+    [
+        WithinSessionSplitter,
+        WithinSubjectSplitter,
+        CrossSessionSplitter,
+        CrossSubjectSplitter,
+    ],
+)
+def test_learning_curve_as_cv_class(splitter, data):
+    """Test that LearningCurveSplitter can be used as cv_class for all splitters."""
+    _, y, metadata = data
+
+    data_size = {"policy": "ratio", "value": np.array([0.5, 1.0])}
+    n_perms = np.array([2, 1])
+
+    # CrossSessionSplitter requires shuffle=True when using random_state
+    extra_kwargs = {}
+    if splitter == CrossSessionSplitter:
+        extra_kwargs["shuffle"] = True
+
+    split = splitter(
+        cv_class=LearningCurveSplitter,
+        data_size=data_size,
+        n_perms=n_perms,
+        test_size=0.2,
+        random_state=42,
+        **extra_kwargs,
+    )
+
+    splits = list(split.split(y, metadata))
+    assert len(splits) > 0
+
+    for train, test in splits:
+        # Check that we get valid train/test indices
+        assert len(train) > 0
+        assert len(test) > 0
+        # Check no overlap between train and test
+        assert len(set(train) & set(test)) == 0

--- a/moabb/tests/test_splits.py
+++ b/moabb/tests/test_splits.py
@@ -552,3 +552,45 @@ def test_learning_curve_as_cv_class(splitter, data):
         assert len(test) > 0
         # Check no overlap between train and test
         assert len(set(train) & set(test)) == 0
+
+
+@pytest.mark.parametrize(
+    "splitter_cls",
+    [
+        WithinSessionSplitter,
+        WithinSubjectSplitter,
+        CrossSessionSplitter,
+        CrossSubjectSplitter,
+    ],
+)
+def test_current_splitter_is_set(splitter_cls, data):
+    """Test that _current_splitter is set after split() for all splitters."""
+    _, y, metadata = data
+
+    data_size = {"policy": "ratio", "value": np.array([0.5, 1.0])}
+    n_perms = np.array([2, 1])
+
+    extra_kwargs = {}
+    if splitter_cls == CrossSessionSplitter:
+        extra_kwargs["shuffle"] = True
+
+    split = splitter_cls(
+        cv_class=LearningCurveSplitter,
+        data_size=data_size,
+        n_perms=n_perms,
+        test_size=0.2,
+        random_state=42,
+        **extra_kwargs,
+    )
+
+    splits = list(split.split(y, metadata))
+    assert len(splits) > 0
+
+    # Verify _current_splitter is set and accessible
+    assert hasattr(split, "_current_splitter")
+    assert split._current_splitter is not None
+
+    # Verify metadata is accessible through _current_splitter
+    meta = split._current_splitter.get_metadata()
+    assert meta["data_size"] is not None
+    assert meta["permutation"] is not None

--- a/moabb/tests/test_splits.py
+++ b/moabb/tests/test_splits.py
@@ -43,7 +43,8 @@ def eval_split_within_session(shuffle, random_state, data):
     rng = check_random_state(random_state) if shuffle else None
 
     all_index = metadata.index.values
-    subjects = metadata["subject"].unique()
+    # Convert to numpy array to avoid ArrowStringArray shuffle warning
+    subjects = np.array(metadata["subject"].unique())
     if shuffle:
         rng.shuffle(subjects)
 
@@ -52,7 +53,8 @@ def eval_split_within_session(shuffle, random_state, data):
 
         subject_indices = all_index[subject_mask]
         subject_metadata = metadata[subject_mask]
-        sessions = subject_metadata["session"].unique()
+        # Convert to numpy array to avoid ArrowStringArray shuffle warning
+        sessions = np.array(subject_metadata["session"].unique())
         y_subject = y[subject_mask]
 
         if shuffle:
@@ -75,7 +77,8 @@ def eval_split_within_subject(shuffle, random_state, data):
     rng = check_random_state(random_state) if shuffle else None
 
     all_index = metadata.index.values
-    subjects = metadata["subject"].unique()
+    # Convert to numpy array to avoid ArrowStringArray shuffle warning
+    subjects = np.array(metadata["subject"].unique())
     if shuffle:
         rng.shuffle(subjects)
 

--- a/moabb/tests/test_splits.py
+++ b/moabb/tests/test_splits.py
@@ -552,6 +552,20 @@ def test_learning_curve_as_cv_class(splitter, data):
         assert len(test) > 0
         # Check no overlap between train and test
         assert len(set(train) & set(test)) == 0
+        if splitter == CrossSessionSplitter:
+            train_meta = metadata.loc[train]
+            test_meta = metadata.loc[test]
+            train_subjects = set(train_meta["subject"])
+            test_subjects = set(test_meta["subject"])
+            assert len(train_subjects) == 1
+            assert train_subjects == test_subjects
+            train_sessions = set(train_meta["session"])
+            test_sessions = set(test_meta["session"])
+            assert train_sessions.isdisjoint(test_sessions)
+        elif splitter == CrossSubjectSplitter:
+            train_subjects = set(metadata.loc[train]["subject"])
+            test_subjects = set(metadata.loc[test]["subject"])
+            assert train_subjects.isdisjoint(test_subjects)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR unifies the learning curve implementation by removing redundant code paths and consolidating all learning curve functionality into the `LearningCurveSplitter` class. This makes learning curves available across all evaluation types (WithinSession, CrossSession, CrossSubject) through a consistent API.

## Changes

### New Features
- Add `cv_class` and `cv_kwargs` parameters to all evaluation classes for custom cross-validation strategies
- Implement `LearningCurveSplitter` as a dedicated sklearn-compatible cross-validator for learning curves
- Learning curve results now automatically include "data_size" and "permutation" metadata columns

### API Changes
- **Breaking**: Remove `data_size` and `n_perms` parameters from `WithinSessionEvaluation`
- Use `cv_class=LearningCurveSplitter` with `cv_kwargs=dict(data_size=..., n_perms=...)` instead

### Code Health
- Centralize CV resolution in `BaseEvaluation` with new `_resolve_cv()` method
- Remove redundant methods from `WithinSessionEvaluation`:
  - `get_data_size_subsets()`
  - `score_explicit()`
  - `_evaluate_learning_curve()`
- Simplify `evaluate()` to always use unified `_evaluate()` path

### Other Improvements
- Add single-class safeguard for `LearningCurveSplitter` (skip splits where training set collapses to single class)
- Fix ArrowStringArray shuffle warnings by converting to numpy arrays
- Update all examples and tests to use new API

## Migration Guide

Before:
```python
evaluation = WithinSessionEvaluation(
    paradigm=paradigm,
    datasets=datasets,
    data_size={"policy": "ratio", "value": [0.2, 0.4, 0.6, 0.8, 1.0]},
    n_perms=[5, 5, 5, 5, 1],
)
```

After:
```python
from moabb.evaluations.splitters import LearningCurveSplitter

evaluation = WithinSessionEvaluation(
    paradigm=paradigm,
    datasets=datasets,
    cv_class=LearningCurveSplitter,
    cv_kwargs=dict(
        data_size={"policy": "ratio", "value": [0.2, 0.4, 0.6, 0.8, 1.0]},
        n_perms=[5, 5, 5, 5, 1],
    ),
)
```

## Test Plan
- [x] All existing tests pass
- [x] Learning curve examples work with new API
- [x] Documentation updated in whats_new.rst

Closes #962