### PR TITLE
Fix double µV conversion in BNCI2003-004 and BNCI2015-006

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -72,6 +72,7 @@ Bugs
 - Ensure optional additional scoring columns in evaluation results (:gh:`957` by `Ethan Davis`_)
 - Fix pandas ``ArrowStringArray`` shuffle warning by converting ``.unique()`` results to numpy arrays in splitters, avoiding issues with newer pandas versions (:gh:`963` by `Bruno Aristimunha`_)
 - ``LearningCurveSplitter`` now skips training splits that collapse to a single class (e.g., with very small ``data_size``) and emits a ``RuntimeWarning`` instead of producing NaN results (:gh:`963` by `Bruno Aristimunha`_)
+- Fix double µV-to-V conversion in BNCI2003-004 and BNCI2015-006: data loaded in microvolts was labeled as volts without unit conversion, causing a second scaling during EDF export via ``mne_bids`` (by `Bruno Aristimunha`_)
 
 Code health
 ~~~~~~~~~~~

--- a/moabb/datasets/bnci/base.py
+++ b/moabb/datasets/bnci/base.py
@@ -533,7 +533,7 @@ def _convert_run_bbci2003(run, ch_names, ch_types, verbose=None):
     positions = raw_positions[labels_mask]
 
     sfreq = float(run["nfo"][0, 0]["fs"][0, 0])
-    eeg_data = run["cnt"]
+    eeg_data = convert_units(run["cnt"], from_unit="uV", to_unit="V")
     raw_classes = run["mrk"]["className"]
 
     while isinstance(raw_classes, (list, np.ndarray)) and len(raw_classes) == 1:

--- a/moabb/datasets/bnci/bnci_2015.py
+++ b/moabb/datasets/bnci/bnci_2015.py
@@ -290,7 +290,7 @@ def _load_data_006_2015(
         return [filename]
     mat_data = loadmat(filename, struct_as_record=False, squeeze_me=True)
     data = mat_data["data"]
-    eeg_data = data.X
+    eeg_data = convert_units(data.X, from_unit="uV", to_unit="V")
     sfreq = float(data.fs)
     ch_names = [str(ch).strip() for ch in data.clab]
     ch_types = ["eeg"] * len(ch_names)


### PR DESCRIPTION
## Summary
- Fix missing `convert_units(from_unit="uV", to_unit="V")` calls in BNCI2003-004 (`base.py`) and BNCI2015-006 (`bnci_2015.py`)
- EEG data in these datasets was loaded in microvolts but labeled as volts (`FIFF_UNIT_V`), causing a second V→µV scaling during EDF export via `mne_bids` that exceeded EDF's 8-character header limit
- All other BNCI datasets already had the correct conversion; these two were missed

## Test plan
- [x] `python -m pytest moabb/tests/test_paradigms.py --timeout=120` — 102 passed
- [x] `pre-commit run --all-files` — all checks passed