### PR TITLE
Fix incorrect DOIs and add systematic DOI validation

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -59,6 +59,8 @@ Requirements
 
 Bugs
 ~~~~
+- Fixed incorrect DOIs in Dreyer2023, RomaniBF2025ERP, BNCI2015_003, BNCI2015_004, and BNCI2015_012 datasets (:gh:`977` by `Bruno Aristimunha`_)
+- Added missing metadata DOIs for AlexMI, PhysionetMI, GrosseWentrup2009, Shin2017A, Shin2017B, BNCI2014_004, and BNCI2003_004 datasets (:gh:`977` by `Bruno Aristimunha`_)
 - Fixed montage not being set before BIDS cache conversion in BNCI datasets (by `Bruno Aristimunha`_)
 - Fixed measurement date setting for BNCI datasets to use specific collection years from papers (by `Bruno Aristimunha`_)
 - Ensured proper subject ID assignment for BIDS compliance across all BNCI datasets (by `Bruno Aristimunha`_)
@@ -78,6 +80,7 @@ Bugs
 
 Code health
 ~~~~~~~~~~~
+- Added systematic DOI validation test suite that checks format, docstring tracking, resolution, and author overlap across all datasets (:gh:`977` by `Bruno Aristimunha`_)
 - Further reorganized BNCI datasets into year-specific modules (``bnci_2003``, ``bnci_2014``, ``bnci_2015``, ``bnci_2019``) with shared helpers in ``legacy_base`` for clearer maintenance. The temporary ``legacy.py`` file has been removed (by `Bruno Aristimunha`_).
 - Added new datasets :class:`moabb.datasets.BNCI2020_001`, :class:`moabb.datasets.BNCI2020_002`, :class:`moabb.datasets.BNCI2022_001`, :class:`moabb.datasets.BNCI2025_001`, and :class:`moabb.datasets.BNCI2025_002` (by `Bruno Aristimunha`_).
 

--- a/moabb/datasets/alex_mi.py
+++ b/moabb/datasets/alex_mi.py
@@ -8,6 +8,7 @@ from moabb.datasets.metadata.schema import (
     BCIApplicationMetadata,
     CrossValidationMetadata,
     DatasetMetadata,
+    DocumentationMetadata,
     ExperimentMetadata,
     FrequencyBands,
     ParadigmSpecificMetadata,
@@ -100,6 +101,9 @@ class AlexMI(BaseDataset):
             stimulus_modalities=["visual"],
             primary_modality="visual",
         ),
+        documentation=DocumentationMetadata(
+            doi="10.5281/zenodo.806022",
+        ),
         tags=Tags(
             pathology=["Other"],
             modality=["Visual"],
@@ -156,6 +160,7 @@ class AlexMI(BaseDataset):
             code="AlexandreMotorImagery",
             interval=[0, 3],
             paradigm="imagery",
+            doi="10.5281/zenodo.806022",
         )
 
     def _get_single_subject_data(self, subject):

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -379,6 +379,7 @@ class Shin2017A(BaseShin2017):
             mode="online",
         ),
         documentation=DocumentationMetadata(
+            doi="10.1109/TNSRE.2016.2628057",
             repository="GitHub",
             data_url="https://github.com/bbci/bbci_public/",
         ),
@@ -622,6 +623,7 @@ class Shin2017B(BaseShin2017):
             mode="online",
         ),
         documentation=DocumentationMetadata(
+            doi="10.1109/TNSRE.2016.2628057",
             repository="GitHub",
             data_url="https://github.com/bbci/bbci_public/",
         ),

--- a/moabb/datasets/bnci/bnci_2003.py
+++ b/moabb/datasets/bnci/bnci_2003.py
@@ -9,6 +9,7 @@ from moabb.datasets.metadata.schema import (
     CrossValidationMetadata,
     DatasetMetadata,
     DataStructureMetadata,
+    DocumentationMetadata,
     ExperimentMetadata,
     FilterDetails,
     FrequencyBands,
@@ -210,6 +211,9 @@ class BNCI2003_004(MNEBNCI):
             trial_duration=4.5,
             stimulus_type="cursor_feedback",
             mode="both",
+        ),
+        documentation=DocumentationMetadata(
+            doi="10.1109/TBME.2004.827088",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2014.py
+++ b/moabb/datasets/bnci/bnci_2014.py
@@ -473,7 +473,7 @@ class BNCI2014_002(MNEBNCI):
     .. [1] Scherer, R., Faller, J., Balderas, D., Friedrich, E. V., &
            Müller-Putz, G. (2015). Brain-computer interfacing: more than the
            sum of its parts. Soft Computing, 19(11), 3173-3186.
-           https://doi.org/10.1007/s00500-014-1547-8
+           https://doi.org/10.1007/s00500-012-0895-4
 
     Notes
     -----
@@ -555,6 +555,7 @@ class BNCI2014_002(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1515/bmt-2014-0117",
+            associated_paper_doi="10.1007/s00500-012-0895-4",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -618,7 +619,7 @@ class BNCI2014_002(MNEBNCI):
             code="BNCI2014-002",
             interval=[3, 8],
             paradigm="imagery",
-            doi="10.1007/s00500-014-1547-8",
+            doi="10.1007/s00500-012-0895-4",
         )
 
 
@@ -1032,6 +1033,7 @@ class BNCI2014_009(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1080/00140139.2012.661084",
+            associated_paper_doi="10.3389/fnhum.2013.00732",
             funding=["EU grant FP7-", "grant FP7- FP7-"],
         ),
         tags=Tags(

--- a/moabb/datasets/bnci/bnci_2014.py
+++ b/moabb/datasets/bnci/bnci_2014.py
@@ -738,7 +738,9 @@ class BNCI2014_004(MNEBNCI):
             synchronicity="asynchronous",
             mode="both",
         ),
-        documentation=DocumentationMetadata(),
+        documentation=DocumentationMetadata(
+            doi="10.1109/TNSRE.2007.906956",
+        ),
         tags=Tags(
             pathology=["Healthy"],
             modality=["Motor"],

--- a/moabb/datasets/bnci/bnci_2015.py
+++ b/moabb/datasets/bnci/bnci_2015.py
@@ -2228,7 +2228,7 @@ class BNCI2015_012(MNEBNCI):
             code="BNCI2015-012",
             interval=[0, 0.8],
             paradigm="p300",
-            doi="10.3389/fnins.2011.00112",
+            doi="10.3389/fnins.2011.00099",
         )
 
     def _get_single_subject_data(self, subject):

--- a/moabb/datasets/bnci/bnci_2015.py
+++ b/moabb/datasets/bnci/bnci_2015.py
@@ -536,6 +536,7 @@ class BNCI2015_001(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/tnsre.2012.2189584",
+            associated_paper_doi="10.1371/journal.pone.0101168",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1349,6 +1350,7 @@ class BNCI2015_007(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1088/1741-2560/9/4/045006",
+            associated_paper_doi="10.1088/1741-2560/11/2/026009",
             funding=["DFG grant", "grant nos s", "BMBF grant", "grant no MU MU"],
         ),
         tags=Tags(
@@ -1775,6 +1777,7 @@ class BNCI2015_009(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1371/journal.pone.0009813",
+            associated_paper_doi="10.3389/fnins.2011.00112",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -2167,6 +2170,7 @@ class BNCI2015_012(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.3389/fnins.2011.00099",
+            associated_paper_doi="10.3389/fnins.2011.00112",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -2246,9 +2250,10 @@ class BNCI2015_013(MNEBNCI):
 
     References
     ----------
-    .. [1] Ferrez, P. W., & Millan, J. D. R. (2008). Error-related EEG potentials
-           in brain-computer interfaces. Journal of Neural Engineering, 5(1), 62.
-           https://doi.org/10.1088/1741-2560/5/1/007
+    .. [1] Chavarriaga, R., & Millán, J. D. R. (2010). Learning from EEG
+           error-related potentials in noninvasive brain-computer interfaces.
+           IEEE Trans. Neural Syst. Rehabil. Eng., 18(4), 381-388.
+           https://doi.org/10.1109/TNSRE.2010.2053387
 
     Notes
     -----

--- a/moabb/datasets/bnci/bnci_2015.py
+++ b/moabb/datasets/bnci/bnci_2015.py
@@ -719,7 +719,8 @@ class BNCI2015_003(MNEBNCI):
             mode="both",
         ),
         documentation=DocumentationMetadata(
-            doi="10.3389/fnins.2011.00112",
+            doi="10.1016/j.neulet.2009.06.045",
+            associated_paper_doi="10.3389/fnins.2011.00112",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -950,7 +951,7 @@ class BNCI2015_004(MNEBNCI):
             code="BNCI2015-004",
             interval=[0, 4],
             paradigm="imagery",
-            doi="10.1109/TCDS.2017.2688350",
+            doi="10.1371/journal.pone.0123727",
         )
 
 

--- a/moabb/datasets/bnci/bnci_2022_001.py
+++ b/moabb/datasets/bnci/bnci_2022_001.py
@@ -518,6 +518,7 @@ class BNCI2022_001(BNCIBaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/TAFFC.2021.3059688",
+            associated_paper_doi="10.1109/THMS.2020.3038339",
         ),
         tags=Tags(
             pathology=["Other"],

--- a/moabb/datasets/dreyer2023.py
+++ b/moabb/datasets/dreyer2023.py
@@ -63,7 +63,7 @@ class _Dreyer2023Base(BaseDataset):
             code="Dreyer2023" + self.sub_id,
             interval=[0, 5],
             paradigm="imagery",
-            doi="10.5281/zenodo.7554429",
+            doi="10.1038/s41597-023-02445-z",
         )
 
     def _get_single_subject_data(self, subject):
@@ -394,7 +394,7 @@ class Dreyer2023A(_Dreyer2023Base):
             mode="both",
         ),
         documentation=DocumentationMetadata(
-            doi="10.1016/j.ijhcs.2021.102603",
+            doi="10.1038/s41597-023-02445-z",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.8089820",
             funding=[

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -173,6 +173,7 @@ class Cho2017(BaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.5524/100295",
+            associated_paper_doi="10.1093/gigascience/gix034",
             funding=["grant funded funded", "grant\nfunded funded"],
         ),
         tags=Tags(

--- a/moabb/datasets/hinss2021.py
+++ b/moabb/datasets/hinss2021.py
@@ -227,6 +227,7 @@ class Hinss2021(BaseDataset):
             code="Hinss2021",
             interval=[0, 2],  # Epochs are 2-second long
             paradigm="rstate",
+            doi="10.1038/s41597-022-01898-y",
         )
 
     def _get_stim_channel(self, rs_epochs, easy_epochs, med_epochs, n_epochs, n_samples):

--- a/moabb/datasets/hinss2021.py
+++ b/moabb/datasets/hinss2021.py
@@ -63,6 +63,12 @@ class Hinss2021(BaseDataset):
             Open EEG Datasets for Passive Brain-Computer
             Interface Applications: Lacks and Perspectives.
             IEEE Neural Engineering Conference.
+
+    .. [Hinss2023] M. F. Hinss, et al. (2023)
+            An EEG dataset for cross-session mental workload estimation:
+            Passive BCI competition of the Neuroergonomics Conference 2021.
+            Scientific Data, 10, 85.
+            https://doi.org/10.1038/s41597-022-01898-y
     """
 
     METADATA = DatasetMetadata(

--- a/moabb/datasets/huebner_llp.py
+++ b/moabb/datasets/huebner_llp.py
@@ -406,6 +406,7 @@ class Huebner2018(_BaseVisualMatrixSpellerDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.5281/zenodo.192684",
+            associated_paper_doi="10.1109/MCI.2018.2807039",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.192684",
             funding=[

--- a/moabb/datasets/mpi_mi.py
+++ b/moabb/datasets/mpi_mi.py
@@ -12,6 +12,7 @@ from moabb.datasets.metadata.schema import (
     CrossValidationMetadata,
     DatasetMetadata,
     DataStructureMetadata,
+    DocumentationMetadata,
     ExperimentMetadata,
     FilterDetails,
     FrequencyBands,
@@ -240,6 +241,9 @@ class GrosseWentrup2009(BaseDataset):
             primary_modality="multisensory",
             synchronicity="synchronous",
             mode="both",
+        ),
+        documentation=DocumentationMetadata(
+            doi="10.1109/TBME.2008.2009768",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/physionet_mi.py
+++ b/moabb/datasets/physionet_mi.py
@@ -11,6 +11,7 @@ from moabb.datasets.metadata.schema import (
     AuxiliaryChannelsMetadata,
     BCIApplicationMetadata,
     DatasetMetadata,
+    DocumentationMetadata,
     ExperimentMetadata,
     ParadigmSpecificMetadata,
     ParticipantMetadata,
@@ -126,6 +127,9 @@ class PhysionetMI(BaseDataset):
             stimulus_modalities=["visual", "auditory"],
             primary_modality="multisensory",
             mode="both",
+        ),
+        documentation=DocumentationMetadata(
+            doi="10.1109/TBME.2004.827072",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/romani_bf2025_erp.py
+++ b/moabb/datasets/romani_bf2025_erp.py
@@ -162,7 +162,7 @@ class RomaniBF2025ERP(BaseDataset):
             mode="online",
         ),
         documentation=DocumentationMetadata(
-            doi="10.1371/journal.pone.0111070",
+            doi="10.48550/arXiv.2510.10169",
             repository="GitHub",
             data_url="https://github.com/BRomans/BrainForm",
         ),

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -212,6 +212,7 @@ class Wang2016(BaseDataset):
             mode="both",
         ),
         documentation=DocumentationMetadata(
+            doi="10.1109/TNSRE.2016.2627556",
             repository="BNCI Horizon 2020",
             data_url="https://bnci-horizon-2020.eu/database/data-sets",
         ),

--- a/moabb/datasets/thielen2021.py
+++ b/moabb/datasets/thielen2021.py
@@ -177,6 +177,7 @@ class Thielen2021(BaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.1088/1741-2552/abecef",
+            associated_paper_doi="10.1088/1741-2552/ab4057",
             funding=["Grant Nos s", "Grant No. 14054 14054"],
         ),
         tags=Tags(

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -19,6 +19,7 @@ Run only offline checks::
 
 import re
 import time
+import unicodedata
 
 import httpx
 import pytest
@@ -136,6 +137,12 @@ def _resolve_doi(doi: str) -> dict | None:
         return None
 
 
+def _strip_accents(s: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn"
+    )
+
+
 def _extract_surnames(authors: list[str]) -> set[str]:
     out = set()
     for a in authors or []:
@@ -143,11 +150,13 @@ def _extract_surnames(authors: list[str]) -> set[str]:
         if not a:
             continue
         if ", " in a:
-            out.add(a.split(",")[0].strip().lower())
+            surname = a.split(",")[0].strip().lower()
         else:
             parts = a.split()
-            if parts:
-                out.add(parts[-1].strip(".").lower())
+            if not parts:
+                continue
+            surname = parts[-1].strip(".").lower()
+        out.add(_strip_accents(surname))
     return out
 
 
@@ -234,12 +243,6 @@ def test_class_and_metadata_dois_share_authors(dataset_class):
     init_doi = dois.get("init.doi")
     if not init_doi or not _is_doi(init_doi):
         pytest.skip("No class DOI")
-
-    all_meta = {
-        dois.get(k) for k in ("metadata.doi", "metadata.associated_paper") if dois.get(k)
-    }
-    if init_doi in all_meta:
-        pytest.skip("Class DOI matches a metadata DOI")
 
     meta_dois = {
         k: v

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -26,6 +26,7 @@ import pytest
 from moabb.datasets.metadata.schema import DatasetMetadata
 from moabb.datasets.utils import dataset_list
 
+
 _SKIP_CLASSES = {"FakeDataset", "FakeVirtualRealityDataset"}
 _NON_DOI_PREFIXES = ("hal-", "tel-", "arXiv:")
 _DATA_REPO_PREFIXES = (
@@ -98,9 +99,7 @@ def _collect_dois(cls) -> dict[str, str | None]:
     if isinstance(meta, DatasetMetadata):
         doc = getattr(meta, "documentation", None)
         if doc:
-            result["metadata.doi"] = _normalize_doi(
-                getattr(doc, "doi", None)
-            )
+            result["metadata.doi"] = _normalize_doi(getattr(doc, "doi", None))
             result["metadata.associated_paper"] = _normalize_doi(
                 getattr(doc, "associated_paper_doi", None)
             )
@@ -169,8 +168,8 @@ def test_doi_format(dataset_class):
         and not _is_doi(doi)
         and not any(doi.startswith(p) for p in _NON_DOI_PREFIXES)
     ]
-    assert not invalid, (
-        f"{dataset_class.__name__}: invalid DOI format:\n" + "\n".join(invalid)
+    assert not invalid, f"{dataset_class.__name__}: invalid DOI format:\n" + "\n".join(
+        invalid
     )
 
 
@@ -191,11 +190,7 @@ def test_docstring_dois_tracked(dataset_class):
             if m:
                 known.add(m.group().rstrip(".,;:)"))
 
-    doc_dois = [
-        dois[k]
-        for k in sorted(dois)
-        if k.startswith("docstring.") and dois[k]
-    ]
+    doc_dois = [dois[k] for k in sorted(dois) if k.startswith("docstring.") and dois[k]]
     if not doc_dois:
         pytest.skip("No DOIs in docstring")
 
@@ -229,9 +224,7 @@ def test_dois_resolve(dataset_class):
             failures.append(doi)
         elif not result.get("title"):
             failures.append(f"{doi} (no title)")
-    assert not failures, (
-        f"{dataset_class.__name__}: DOIs failed to resolve: {failures}"
-    )
+    assert not failures, f"{dataset_class.__name__}: DOIs failed to resolve: {failures}"
 
 
 @pytest.mark.network
@@ -243,9 +236,7 @@ def test_class_and_metadata_dois_share_authors(dataset_class):
         pytest.skip("No class DOI")
 
     all_meta = {
-        dois.get(k)
-        for k in ("metadata.doi", "metadata.associated_paper")
-        if dois.get(k)
+        dois.get(k) for k in ("metadata.doi", "metadata.associated_paper") if dois.get(k)
     }
     if init_doi in all_meta:
         pytest.skip("Class DOI matches a metadata DOI")

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -26,6 +26,7 @@ import pytest
 from moabb.datasets.metadata.schema import DatasetMetadata
 from moabb.datasets.utils import dataset_list
 
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -210,9 +211,7 @@ _REAL_DATASETS = [
 class TestDOIFormat:
     """Every DOI string should have valid ``10.xxxx/…`` format."""
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_all_dois_have_valid_format(self, dataset_class):
         dois = _collect_dois(dataset_class)
         invalid = []
@@ -224,17 +223,15 @@ class TestDOIFormat:
                 invalid.append(f"  {source} = {doi!r}")
         if not any(v for v in dois.values()):
             pytest.skip("No DOIs found")
-        assert not invalid, (
-            f"{dataset_class.__name__}: invalid DOI format:\n" + "\n".join(invalid)
-        )
+        assert (
+            not invalid
+        ), f"{dataset_class.__name__}: invalid DOI format:\n" + "\n".join(invalid)
 
 
 class TestDOIConsistency:
     """Docstring DOIs must be tracked in METADATA or class DOI."""
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_docstring_dois_tracked_in_metadata(self, dataset_class):
         """Every DOI in the docstring should appear in METADATA or init."""
         dois = _collect_dois(dataset_class)
@@ -300,9 +297,7 @@ class TestDOIConsistency:
 class TestDOIResolution:
     """Every DOI should resolve to a real publication via CrossRef/DataCite."""
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_all_dois_resolve(self, dataset_class):
         """All unique DOIs from class, METADATA, and docstring must resolve."""
         dois = _collect_dois(dataset_class)
@@ -318,13 +313,11 @@ class TestDOIResolution:
             elif not result.get("title"):
                 failures.append(f"{doi} (resolved but no title)")
 
-        assert not failures, (
-            f"{dataset_class.__name__}: DOIs failed to resolve: {failures}"
-        )
+        assert (
+            not failures
+        ), f"{dataset_class.__name__}: DOIs failed to resolve: {failures}"
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_class_doi_resolves(self, dataset_class):
         """The class DOI (ground truth) must resolve to a real publication."""
         dois = _collect_dois(dataset_class)
@@ -334,9 +327,9 @@ class TestDOIResolution:
             pytest.skip("No class DOI")
 
         result = _resolve_doi(init_doi)
-        assert result is not None, (
-            f"{dataset_class.__name__}: class DOI {init_doi!r} failed to resolve"
-        )
+        assert (
+            result is not None
+        ), f"{dataset_class.__name__}: class DOI {init_doi!r} failed to resolve"
         assert result.get("title"), (
             f"{dataset_class.__name__}: class DOI {init_doi!r} resolved but has "
             f"no title"

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -1,0 +1,483 @@
+"""Systematic DOI validation for MOABB dataset metadata.
+
+Uses the CrossRef API (via habanero) and DataCite API to verify that
+every DOI in dataset METADATA and docstrings resolves to a real
+publication and that the referenced paper matches the dataset description.
+
+Run with:
+    python -m pytest moabb/tests/test_doi_validation.py -x --timeout=300 -v
+
+Or just the quick offline checks:
+    python -m pytest moabb/tests/test_doi_validation.py -k "not network" -v
+"""
+
+import json
+import re
+import time
+import urllib.request
+
+import pytest
+
+from moabb.datasets.metadata.schema import DatasetMetadata
+from moabb.datasets.utils import dataset_list
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# DOIs that are not resolvable via CrossRef (HAL, arXiv IDs, etc.)
+_NON_CROSSREF_PREFIXES = (
+    "hal-",
+    "tel-",
+    "arXiv:",
+)
+
+# DOI prefixes registered with DataCite (not CrossRef)
+_DATACITE_PREFIXES = (
+    "10.5281/zenodo.",  # Zenodo
+    "10.6084/m9.figshare.",  # Figshare
+    "10.48550/arXiv.",  # arXiv
+    "10.7910/DVN/",  # Harvard Dataverse
+    "10.6094/",  # FreiDok (Freiburg)
+    "10.5524/",  # GigaDB
+    "10.34973/",  # Radboud Data Repository
+    "10.18115/",  # ERPSS
+    "10.35376/",  # University of Valladolid
+    "10.3217/",  # TU Graz conference proceedings
+)
+
+# Test / fake datasets to skip
+_SKIP_CLASSES = {"FakeDataset", "FakeVirtualRealityDataset"}
+
+# Rate-limit: be polite to APIs
+_REQUEST_DELAY = 0.15  # seconds between requests
+
+
+def _is_doi(value: str) -> bool:
+    """Check if a string looks like a DOI (starts with 10.xxxx/)."""
+    if not value:
+        return False
+    return bool(re.match(r"^10\.\d{4,}/", value))
+
+
+def _extract_docstring_dois(cls) -> list[str]:
+    """Extract all DOI-like strings from a class docstring."""
+    doc = getattr(cls, "__doc__", "") or ""
+    raw = re.findall(r"10\.\d{4,}/[^\s\]\">]+", doc)
+    # Clean trailing punctuation and RST artifacts
+    cleaned = []
+    for d in raw:
+        d = d.rstrip(".,;:)")
+        d = d.rstrip("`")
+        if d.endswith(">`_"):
+            d = d[: d.index(">")]
+        d = d.rstrip("`_>")
+        if d.endswith("/abstract"):
+            d = d[: -len("/abstract")]
+        cleaned.append(d)
+    return list(dict.fromkeys(cleaned))  # deduplicate, preserve order
+
+
+def _get_metadata_dois(meta: DatasetMetadata) -> dict[str, str | None]:
+    """Extract all DOI fields from a DatasetMetadata object."""
+    result = {}
+    doc = getattr(meta, "documentation", None)
+    if doc:
+        result["documentation.doi"] = getattr(doc, "doi", None)
+        result["documentation.associated_paper_doi"] = getattr(
+            doc, "associated_paper_doi", None
+        )
+    return result
+
+
+def _is_datacite_doi(doi: str) -> bool:
+    """Check if a DOI is registered with DataCite rather than CrossRef."""
+    return any(doi.startswith(p) for p in _DATACITE_PREFIXES)
+
+
+def _resolve_doi_crossref(doi: str) -> dict | None:
+    """Resolve a DOI via CrossRef and return title/authors/year, or None."""
+    try:
+        from habanero import Crossref
+
+        cr = Crossref(mailto="moabb-test@example.com")
+        time.sleep(_REQUEST_DELAY)
+        r = cr.works(ids=doi)
+        msg = r["message"]
+        title = msg.get("title", [None])[0]
+        authors = [
+            f"{a.get('given', '')} {a.get('family', '')}".strip()
+            for a in msg.get("author", [])
+        ]
+        year = None
+        all_years = set()
+        for key in ("published-print", "published-online", "created"):
+            if key in msg:
+                parts = msg[key].get("date-parts", [[None]])
+                if parts and parts[0] and parts[0][0]:
+                    all_years.add(parts[0][0])
+                    if year is None:
+                        year = parts[0][0]
+        return {"title": title, "authors": authors, "year": year, "all_years": all_years}
+    except Exception:
+        return None
+
+
+def _resolve_doi_datacite(doi: str) -> dict | None:
+    """Resolve a DOI via DataCite API and return title/authors/year, or None."""
+    try:
+        time.sleep(_REQUEST_DELAY)
+        url = f"https://api.datacite.org/dois/{doi}"
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+        attrs = data.get("data", {}).get("attributes", {})
+        title = (attrs.get("titles") or [{}])[0].get("title")
+        authors = [
+            c.get("name", "") or f"{c.get('givenName', '')} {c.get('familyName', '')}".strip()
+            for c in attrs.get("creators", [])
+        ]
+        year = attrs.get("publicationYear")
+        return {"title": title, "authors": authors, "year": year}
+    except Exception:
+        return None
+
+
+def _resolve_doi(doi: str) -> dict | None:
+    """Resolve a DOI via the appropriate registry (CrossRef or DataCite)."""
+    if _is_datacite_doi(doi):
+        return _resolve_doi_datacite(doi)
+    return _resolve_doi_crossref(doi)
+
+
+# ---------------------------------------------------------------------------
+# Build parametrized dataset list
+# ---------------------------------------------------------------------------
+
+_REAL_DATASETS = [
+    cls
+    for cls in dataset_list
+    if cls.__name__ not in _SKIP_CLASSES
+    and isinstance(getattr(cls, "METADATA", None), DatasetMetadata)
+]
+
+
+# ---------------------------------------------------------------------------
+# OFFLINE TESTS (no network needed)
+# ---------------------------------------------------------------------------
+
+
+class TestDOIFormat:
+    """Validate that DOI strings in metadata have correct format."""
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_metadata_doi_is_valid_format(self, dataset_class):
+        """documentation.doi should be a valid DOI or None."""
+        meta = dataset_class.METADATA
+        doc = getattr(meta, "documentation", None)
+        if doc is None:
+            pytest.skip("No documentation section")
+        doi = getattr(doc, "doi", None)
+        if doi is None:
+            pytest.skip("No DOI set")
+        is_valid = _is_doi(doi) or any(
+            doi.startswith(p) for p in _NON_CROSSREF_PREFIXES
+        )
+        assert is_valid, (
+            f"{dataset_class.__name__}: documentation.doi={doi!r} "
+            f"does not look like a valid DOI (expected 10.xxxx/...) "
+            f"or recognized identifier (hal-/tel-/arXiv:)"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_associated_doi_is_valid_format(self, dataset_class):
+        """associated_paper_doi should be a valid DOI, HAL ID, or None."""
+        meta = dataset_class.METADATA
+        doc = getattr(meta, "documentation", None)
+        if doc is None:
+            pytest.skip("No documentation section")
+        assoc = getattr(doc, "associated_paper_doi", None)
+        if assoc is None:
+            pytest.skip("No associated DOI set")
+        is_valid = _is_doi(assoc) or any(
+            assoc.startswith(p) for p in _NON_CROSSREF_PREFIXES
+        )
+        assert is_valid, (
+            f"{dataset_class.__name__}: associated_paper_doi={assoc!r} "
+            f"is not a valid DOI or recognized ID"
+        )
+
+
+class TestDOIConsistency:
+    """Check that DOIs in metadata match docstring references."""
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_metadata_doi_appears_in_docstring(self, dataset_class):
+        """The primary DOI in metadata should also appear in the docstring."""
+        meta = dataset_class.METADATA
+        doc = getattr(meta, "documentation", None)
+        if doc is None:
+            pytest.skip("No documentation section")
+        doi = getattr(doc, "doi", None)
+        if doi is None:
+            pytest.skip("No DOI set")
+        if not _is_doi(doi):
+            pytest.skip(f"DOI {doi!r} is not a standard DOI format")
+
+        docstring = getattr(dataset_class, "__doc__", "") or ""
+        # Skip if docstring has no references section at all
+        if "doi" not in docstring.lower() and "10." not in docstring:
+            pytest.skip("Docstring has no DOI references")
+
+        docstring_dois = _extract_docstring_dois(dataset_class)
+        assert doi in docstring_dois, (
+            f"{dataset_class.__name__}: metadata DOI {doi!r} "
+            f"not found in docstring DOIs: {docstring_dois}"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_docstring_dois_are_known_in_metadata(self, dataset_class):
+        """All DOIs in docstring should be either the primary DOI,
+        associated DOI, or a recognized data repository DOI."""
+        meta = dataset_class.METADATA
+        doc_meta = getattr(meta, "documentation", None)
+
+        known_dois = set()
+        if doc_meta:
+            for field in ("doi", "associated_paper_doi", "data_url", "repository"):
+                val = getattr(doc_meta, field, None)
+                if val and _is_doi(val):
+                    known_dois.add(val)
+                elif isinstance(val, str) and "doi.org/" in val:
+                    # Extract DOI from URL
+                    m = re.search(r"10\.\d{4,}/[^\s]+", val)
+                    if m:
+                        known_dois.add(m.group().rstrip(".,;:)"))
+
+        # External links may contain DOIs too
+        ext = getattr(meta, "external_links", None)
+        if isinstance(ext, dict):
+            for v in ext.values():
+                if isinstance(v, str) and _is_doi(v):
+                    known_dois.add(v)
+
+        docstring_dois = _extract_docstring_dois(dataset_class)
+        if not docstring_dois:
+            pytest.skip("No DOIs in docstring")
+
+        # Data-repository DOI prefixes that are fine to appear in docstrings
+        _DATA_REPO_PREFIXES = (
+            "10.5281/zenodo.",  # Zenodo
+            "10.7910/DVN/",  # Harvard Dataverse
+            "10.6084/m9.figshare.",  # Figshare
+            "10.6094/",  # FreiDok (Freiburg)
+            "10.5524/",  # GigaDB
+            "10.34973/",  # Radboud Data Repository
+            "10.18115/",  # ERPSS
+            "10.48550/arXiv.",  # arXiv
+        )
+
+        unknown = []
+        for d in docstring_dois:
+            if d in known_dois:
+                continue
+            if any(d.startswith(p) for p in _DATA_REPO_PREFIXES):
+                continue
+            # Check if it's a substring match (different URL forms)
+            if any(d in k or k in d for k in known_dois):
+                continue
+            unknown.append(d)
+
+        if unknown:
+            pytest.fail(
+                f"{dataset_class.__name__}: docstring contains DOIs not tracked "
+                f"in metadata: {unknown}\n"
+                f"  Known metadata DOIs: {known_dois}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# NETWORK TESTS (require CrossRef API)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.network
+class TestDOIResolution:
+    """Verify that every DOI in metadata resolves via CrossRef."""
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_primary_doi_resolves(self, dataset_class):
+        """documentation.doi should resolve to a real publication."""
+        meta = dataset_class.METADATA
+        doc = getattr(meta, "documentation", None)
+        if doc is None:
+            pytest.skip("No documentation section")
+        doi = getattr(doc, "doi", None)
+        if doi is None:
+            pytest.skip("No DOI set")
+        if not _is_doi(doi):
+            pytest.skip(f"Not a standard DOI: {doi!r}")
+
+        result = _resolve_doi(doi)
+        assert result is not None, (
+            f"{dataset_class.__name__}: DOI {doi!r} failed to resolve via CrossRef"
+        )
+        assert result["title"], (
+            f"{dataset_class.__name__}: DOI {doi!r} resolved but has no title"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_primary_doi_year_matches_metadata(self, dataset_class):
+        """Publication year from CrossRef should match metadata."""
+        meta = dataset_class.METADATA
+        doc = getattr(meta, "documentation", None)
+        if doc is None:
+            pytest.skip("No documentation section")
+        doi = getattr(doc, "doi", None)
+        meta_year = getattr(doc, "publication_year", None)
+        if doi is None or meta_year is None:
+            pytest.skip("No DOI or publication_year")
+        if not _is_doi(doi):
+            pytest.skip(f"Not a standard DOI: {doi!r}")
+
+        result = _resolve_doi(doi)
+        if result is None:
+            pytest.skip(f"DOI {doi!r} did not resolve")
+
+        cr_year = result["year"]
+        if cr_year is None:
+            pytest.skip("Registry returned no year")
+
+        # DataCite records (Zenodo, figshare, etc.) can have updated
+        # publication years when new versions are uploaded.  Only flag
+        # mismatches for journal/conference DOIs (CrossRef).
+        if _is_datacite_doi(doi):
+            pytest.skip("Skipping year check for DataCite DOI (versions change dates)")
+
+        # For journal papers, CrossRef may return the print date which
+        # can differ from the online-first date.  Accept if metadata year
+        # matches any of: published-print, published-online, or created year.
+        cr_years = result.get("all_years", set())
+        cr_years.add(cr_year)
+
+        assert meta_year in cr_years, (
+            f"{dataset_class.__name__}: metadata publication_year={meta_year} "
+            f"but CrossRef says year(s)={sorted(cr_years)} for DOI {doi!r}\n"
+            f"  CrossRef title: {result['title']}"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_primary_doi_authors_overlap_metadata(self, dataset_class):
+        """At least one CrossRef author should appear in metadata investigators."""
+        meta = dataset_class.METADATA
+        doc = getattr(meta, "documentation", None)
+        if doc is None:
+            pytest.skip("No documentation section")
+        doi = getattr(doc, "doi", None)
+        investigators = getattr(doc, "investigators", None)
+        if doi is None or not investigators:
+            pytest.skip("No DOI or investigators")
+        if not _is_doi(doi):
+            pytest.skip(f"Not a standard DOI: {doi!r}")
+
+        result = _resolve_doi(doi)
+        if result is None:
+            pytest.skip(f"DOI {doi!r} did not resolve")
+
+        cr_authors = result["authors"]
+        if not cr_authors:
+            pytest.skip("CrossRef returned no authors")
+
+        # Extract family names from both sources, handling:
+        #   CrossRef: "Given Family" format
+        #   DataCite: "Family, Given" format
+        #   Metadata: "G. Family" or "Given Family" or "Family, G." format
+        def _extract_surnames(names):
+            surnames = set()
+            for name in names:
+                name = name.strip()
+                if not name:
+                    continue
+                if ", " in name:
+                    # "Last, First" format — take the part before the comma
+                    surnames.add(name.split(",")[0].strip().lower())
+                else:
+                    # "First Last" or "F. Last" — take the last token
+                    parts = name.split()
+                    if parts:
+                        surnames.add(parts[-1].strip(".").lower())
+            return surnames
+
+        cr_surnames = _extract_surnames(cr_authors)
+        meta_surnames = _extract_surnames(investigators)
+
+        overlap = cr_surnames & meta_surnames
+        assert overlap, (
+            f"{dataset_class.__name__}: no author overlap between "
+            f"CrossRef authors {cr_authors} and "
+            f"metadata investigators {investigators} "
+            f"for DOI {doi!r}\n"
+            f"  CrossRef title: {result['title']}"
+        )
+
+
+@pytest.mark.network
+class TestDocstringDOIContent:
+    """Verify that DOIs referenced in docstrings resolve to related papers."""
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_docstring_reference_dois_resolve(self, dataset_class):
+        """Every DOI in docstring References section should resolve."""
+        doc = getattr(dataset_class, "__doc__", "") or ""
+        # Only check DOIs from the References section
+        ref_section = ""
+        in_refs = False
+        for line in doc.splitlines():
+            stripped = line.strip()
+            if stripped.lower().startswith("references") or stripped == "----------":
+                in_refs = True
+                continue
+            if in_refs:
+                if stripped and not stripped.startswith("..") and not stripped.startswith("http") and not stripped.startswith("10.") and not stripped[0:1].isdigit() and stripped[0:1].isalpha() and not stripped.startswith("-"):
+                    # New section header
+                    break
+                ref_section += line + "\n"
+
+        if not ref_section:
+            pytest.skip("No References section in docstring")
+
+        dois = re.findall(r"10\.\d{4,}/[^\s\]\">]+", ref_section)
+        dois = [d.rstrip(".,;:)`_>") for d in dois]
+        dois = list(dict.fromkeys(dois))
+
+        if not dois:
+            pytest.skip("No DOIs in References section")
+
+        failures = []
+        for doi in dois:
+            if not _is_doi(doi):
+                continue
+            result = _resolve_doi(doi)
+            if result is None:
+                failures.append(doi)
+
+        assert not failures, (
+            f"{dataset_class.__name__}: these docstring DOIs failed to resolve "
+            f"via CrossRef: {failures}"
+        )

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -110,7 +110,12 @@ def _collect_dois(cls) -> dict[str, str | None]:
     return result
 
 
+_DOI_CACHE: dict[str, dict | None] = {}
+
+
 def _resolve_doi(doi: str) -> dict | None:
+    if doi in _DOI_CACHE:
+        return _DOI_CACHE[doi]
     try:
         time.sleep(_REQUEST_DELAY)
         r = requests.get(
@@ -126,14 +131,16 @@ def _resolve_doi(doi: str) -> dict | None:
         ]
         issued = data.get("issued", {}).get("date-parts", [[None]])
         year = issued[0][0] if issued and issued[0] and issued[0][0] else None
-        return {
+        result = {
             "title": data.get("title"),
             "authors": authors,
             "year": year,
             "doi": doi,
         }
     except Exception:
-        return None
+        result = None
+    _DOI_CACHE[doi] = result
+    return result
 
 
 def _strip_accents(s: str) -> str:

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -5,8 +5,7 @@ then validates that:
 
 1. All DOIs (class, METADATA, docstring) have valid format.
 2. Docstring DOIs are tracked in METADATA.
-3. Every DOI resolves via doi.org content negotiation (works for
-   CrossRef, DataCite, and Medra registries).
+3. Every DOI resolves via doi.org content negotiation.
 4. When class DOI and metadata DOI differ, they share at least one author.
 
 Run all (including network tests)::
@@ -27,28 +26,38 @@ import pytest
 from moabb.datasets.metadata.schema import DatasetMetadata
 from moabb.datasets.utils import dataset_list
 
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-
 _SKIP_CLASSES = {"FakeDataset", "FakeVirtualRealityDataset"}
-
-# Non-standard identifiers (not resolvable as DOIs)
 _NON_DOI_PREFIXES = ("hal-", "tel-", "arXiv:")
-
-_REQUEST_DELAY = 0.15  # polite rate-limit
-
-# ---------------------------------------------------------------------------
-# DOI helpers
-# ---------------------------------------------------------------------------
-
-_DOI_URL_PREFIXES = ("https://doi.org/", "http://doi.org/", "https://dx.doi.org/")
+_DATA_REPO_PREFIXES = (
+    "10.5281/zenodo.",
+    "10.7910/DVN/",
+    "10.6084/m9.figshare.",
+    "10.6094/",
+    "10.5524/",
+    "10.34973/",
+    "10.18115/",
+    "10.48550/arXiv.",
+)
+_DOI_URL_PREFIXES = (
+    "https://doi.org/",
+    "http://doi.org/",
+    "https://dx.doi.org/",
+)
 _DOI_RE = re.compile(r"^10\.\d{4,}/")
+_REQUEST_DELAY = 0.15
+
+_REAL_DATASETS = [
+    cls
+    for cls in dataset_list
+    if cls.__name__ not in _SKIP_CLASSES
+    and isinstance(getattr(cls, "METADATA", None), DatasetMetadata)
+]
+
+
+# -- helpers -----------------------------------------------------------------
 
 
 def _normalize_doi(value: str | None) -> str | None:
-    """Strip URL prefix from a DOI, returning the bare ``10.xxxx/…`` form."""
     if not value:
         return None
     for prefix in _DOI_URL_PREFIXES:
@@ -58,12 +67,10 @@ def _normalize_doi(value: str | None) -> str | None:
 
 
 def _is_doi(value: str) -> bool:
-    """Return True if *value* looks like a DOI (``10.xxxx/…``)."""
     return bool(value and _DOI_RE.match(_normalize_doi(value) or ""))
 
 
 def _extract_docstring_dois(cls) -> list[str]:
-    """Return deduplicated DOIs found anywhere in *cls.__doc__*."""
     doc = getattr(cls, "__doc__", "") or ""
     raw = re.findall(r"10\.\d{4,}/[^\s\]\">]+", doc)
     cleaned = []
@@ -79,57 +86,31 @@ def _extract_docstring_dois(cls) -> list[str]:
     return list(dict.fromkeys(cleaned))
 
 
-# ---------------------------------------------------------------------------
-# DOI collection per dataset
-# ---------------------------------------------------------------------------
-
-
 def _collect_dois(cls) -> dict[str, str | None]:
-    """Return ``{source_label: doi}`` for all DOI sources in *cls*.
-
-    Sources:
-        ``init.doi``                  — ground-truth DOI from ``__init__``
-        ``metadata.doi``              — ``METADATA.documentation.doi``
-        ``metadata.associated_paper`` — ``METADATA.documentation.associated_paper_doi``
-        ``docstring.<N>``             — DOIs extracted from the class docstring
-    """
     result: dict[str, str | None] = {}
-
-    # 1. Ground-truth DOI from __init__
     try:
         instance = cls()
         result["init.doi"] = _normalize_doi(getattr(instance, "doi", None))
     except Exception:
         result["init.doi"] = None
 
-    # 2. METADATA documentation DOIs
     meta = getattr(cls, "METADATA", None)
     if isinstance(meta, DatasetMetadata):
         doc = getattr(meta, "documentation", None)
         if doc:
-            result["metadata.doi"] = _normalize_doi(getattr(doc, "doi", None))
+            result["metadata.doi"] = _normalize_doi(
+                getattr(doc, "doi", None)
+            )
             result["metadata.associated_paper"] = _normalize_doi(
                 getattr(doc, "associated_paper_doi", None)
             )
 
-    # 3. Docstring DOIs
     for i, doi in enumerate(_extract_docstring_dois(cls)):
         result[f"docstring.{i}"] = doi
-
     return result
 
 
-# ---------------------------------------------------------------------------
-# DOI resolution via doi.org content negotiation
-# Uses citeproc+json — works for CrossRef, DataCite, and Medra DOIs.
-# ---------------------------------------------------------------------------
-
-
 def _resolve_doi(doi: str) -> dict | None:
-    """Resolve *doi* via doi.org content negotiation.
-
-    Returns ``{title, authors, year}`` or ``None`` on failure.
-    """
     try:
         time.sleep(_REQUEST_DELAY)
         r = httpx.get(
@@ -140,237 +121,169 @@ def _resolve_doi(doi: str) -> dict | None:
         )
         r.raise_for_status()
         data = r.json()
-        title = data.get("title")
         authors = [
             f"{a.get('given', '')} {a.get('family', '')}".strip()
             for a in data.get("author", [])
         ]
-        year = None
         issued = data.get("issued", {}).get("date-parts", [[None]])
-        if issued and issued[0] and issued[0][0]:
-            year = issued[0][0]
-        return {"title": title, "authors": authors, "year": year, "doi": doi}
+        year = issued[0][0] if issued and issued[0] and issued[0][0] else None
+        return {
+            "title": data.get("title"),
+            "authors": authors,
+            "year": year,
+            "doi": doi,
+        }
     except Exception:
         return None
 
 
 def _extract_surnames(authors: list[str]) -> set[str]:
-    """Extract lowercase surnames from author name strings."""
     out = set()
     for a in authors or []:
         a = a.strip()
         if not a:
             continue
         if ", " in a:
-            # "Last, First" format (DataCite)
             out.add(a.split(",")[0].strip().lower())
         else:
-            # "First Last" format (CrossRef)
             parts = a.split()
             if parts:
                 out.add(parts[-1].strip(".").lower())
     return out
 
 
-# ---------------------------------------------------------------------------
-# Build parametrized dataset list
-# ---------------------------------------------------------------------------
+# -- offline tests -----------------------------------------------------------
 
-_REAL_DATASETS = [
-    cls
-    for cls in dataset_list
-    if cls.__name__ not in _SKIP_CLASSES
-    and isinstance(getattr(cls, "METADATA", None), DatasetMetadata)
-]
+_ids = lambda c: c.__name__  # noqa: E731
 
 
-# ---------------------------------------------------------------------------
-# OFFLINE TESTS — no network required
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=_ids)
+def test_doi_format(dataset_class):
+    dois = _collect_dois(dataset_class)
+    if not any(dois.values()):
+        pytest.skip("No DOIs found")
+    invalid = [
+        f"  {src} = {doi!r}"
+        for src, doi in dois.items()
+        if doi
+        and not _is_doi(doi)
+        and not any(doi.startswith(p) for p in _NON_DOI_PREFIXES)
+    ]
+    assert not invalid, (
+        f"{dataset_class.__name__}: invalid DOI format:\n" + "\n".join(invalid)
+    )
 
 
-class TestDOIFormat:
-    """Every DOI string should have valid ``10.xxxx/…`` format."""
+@pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=_ids)
+def test_docstring_dois_tracked(dataset_class):
+    dois = _collect_dois(dataset_class)
 
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_all_dois_have_valid_format(self, dataset_class):
-        dois = _collect_dois(dataset_class)
-        invalid = []
-        for source, doi in dois.items():
-            if doi is None:
-                continue
-            ok = _is_doi(doi) or any(doi.startswith(p) for p in _NON_DOI_PREFIXES)
-            if not ok:
-                invalid.append(f"  {source} = {doi!r}")
-        if not any(v for v in dois.values()):
-            pytest.skip("No DOIs found")
-        assert (
-            not invalid
-        ), f"{dataset_class.__name__}: invalid DOI format:\n" + "\n".join(invalid)
+    known = {
+        dois.get(k)
+        for k in ("metadata.doi", "metadata.associated_paper", "init.doi")
+        if dois.get(k) and _is_doi(dois.get(k))
+    }
+    meta = getattr(dataset_class, "METADATA", None)
+    if meta and getattr(meta, "documentation", None):
+        data_url = getattr(meta.documentation, "data_url", None)
+        if isinstance(data_url, str):
+            m = re.search(r"10\.\d{4,}/[^\s]+", data_url)
+            if m:
+                known.add(m.group().rstrip(".,;:)"))
 
+    doc_dois = [
+        dois[k]
+        for k in sorted(dois)
+        if k.startswith("docstring.") and dois[k]
+    ]
+    if not doc_dois:
+        pytest.skip("No DOIs in docstring")
 
-class TestDOIConsistency:
-    """Docstring DOIs must be tracked in METADATA or class DOI."""
-
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_docstring_dois_tracked_in_metadata(self, dataset_class):
-        """Every DOI in the docstring should appear in METADATA or init."""
-        dois = _collect_dois(dataset_class)
-
-        # All known DOIs from non-docstring sources
-        known = set()
-        for key in ("metadata.doi", "metadata.associated_paper", "init.doi"):
-            val = dois.get(key)
-            if val and _is_doi(val):
-                known.add(val)
-
-        # Also check data_url for embedded DOIs
-        meta = getattr(dataset_class, "METADATA", None)
-        if meta:
-            doc = getattr(meta, "documentation", None)
-            if doc:
-                data_url = getattr(doc, "data_url", None)
-                if isinstance(data_url, str):
-                    m = re.search(r"10\.\d{4,}/[^\s]+", data_url)
-                    if m:
-                        known.add(m.group().rstrip(".,;:)"))
-
-        doc_dois = [
-            dois[k] for k in sorted(dois) if k.startswith("docstring.") and dois[k]
-        ]
-        if not doc_dois:
-            pytest.skip("No DOIs in docstring")
-
-        # Data-repo prefixes are fine in docstrings without metadata tracking
-        _DATA_REPO_PREFIXES = (
-            "10.5281/zenodo.",
-            "10.7910/DVN/",
-            "10.6084/m9.figshare.",
-            "10.6094/",
-            "10.5524/",
-            "10.34973/",
-            "10.18115/",
-            "10.48550/arXiv.",
-        )
-
-        untracked = []
-        for d in doc_dois:
-            if d in known:
-                continue
-            if any(d.startswith(p) for p in _DATA_REPO_PREFIXES):
-                continue
-            if any(d in k or k in d for k in known):
-                continue
-            untracked.append(d)
-
-        assert not untracked, (
-            f"{dataset_class.__name__}: docstring DOIs not tracked in metadata: "
-            f"{untracked}\n  Known: {known}"
-        )
+    untracked = [
+        d
+        for d in doc_dois
+        if d not in known
+        and not any(d.startswith(p) for p in _DATA_REPO_PREFIXES)
+        and not any(d in k or k in d for k in known)
+    ]
+    assert not untracked, (
+        f"{dataset_class.__name__}: docstring DOIs not tracked in metadata: "
+        f"{untracked}\n  Known: {known}"
+    )
 
 
-# ---------------------------------------------------------------------------
-# NETWORK TESTS — resolve DOIs via doi.org content negotiation
-# ---------------------------------------------------------------------------
+# -- network tests -----------------------------------------------------------
 
 
 @pytest.mark.network
-class TestDOIResolution:
-    """Every DOI should resolve via doi.org content negotiation."""
+@pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=_ids)
+def test_dois_resolve(dataset_class):
+    dois = _collect_dois(dataset_class)
+    unique = sorted({d for d in dois.values() if d and _is_doi(d)})
+    if not unique:
+        pytest.skip("No DOIs to resolve")
+    failures = []
+    for doi in unique:
+        result = _resolve_doi(doi)
+        if result is None:
+            failures.append(doi)
+        elif not result.get("title"):
+            failures.append(f"{doi} (no title)")
+    assert not failures, (
+        f"{dataset_class.__name__}: DOIs failed to resolve: {failures}"
+    )
 
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_all_dois_resolve(self, dataset_class):
-        """All unique DOIs from class, METADATA, and docstring must resolve."""
-        dois = _collect_dois(dataset_class)
-        unique_dois = sorted({d for d in dois.values() if d and _is_doi(d)})
-        if not unique_dois:
-            pytest.skip("No DOIs to resolve")
 
-        failures = []
-        for doi in unique_dois:
-            result = _resolve_doi(doi)
-            if result is None:
-                failures.append(doi)
-            elif not result.get("title"):
-                failures.append(f"{doi} (resolved but no title)")
+@pytest.mark.network
+@pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=_ids)
+def test_class_and_metadata_dois_share_authors(dataset_class):
+    dois = _collect_dois(dataset_class)
+    init_doi = dois.get("init.doi")
+    if not init_doi or not _is_doi(init_doi):
+        pytest.skip("No class DOI")
 
-        assert (
-            not failures
-        ), f"{dataset_class.__name__}: DOIs failed to resolve: {failures}"
+    all_meta = {
+        dois.get(k)
+        for k in ("metadata.doi", "metadata.associated_paper")
+        if dois.get(k)
+    }
+    if init_doi in all_meta:
+        pytest.skip("Class DOI matches a metadata DOI")
 
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_class_doi_resolves(self, dataset_class):
-        """The class DOI (ground truth) must resolve to a real publication."""
-        dois = _collect_dois(dataset_class)
-        init_doi = dois.get("init.doi")
-
-        if not init_doi or not _is_doi(init_doi):
-            pytest.skip("No class DOI")
-
-        result = _resolve_doi(init_doi)
-        assert (
-            result is not None
-        ), f"{dataset_class.__name__}: class DOI {init_doi!r} failed to resolve"
-        assert result.get("title"), (
-            f"{dataset_class.__name__}: class DOI {init_doi!r} resolved but has "
-            f"no title"
-        )
-
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_class_and_metadata_dois_share_authors(self, dataset_class):
-        """Class DOI must share authors with at least one metadata DOI.
-
-        Compares ``init.doi`` against ``metadata.doi`` and
-        ``metadata.associated_paper`` — at least one must have
-        overlapping author surnames.
-        """
-        dois = _collect_dois(dataset_class)
-        init_doi = dois.get("init.doi")
-        if not init_doi or not _is_doi(init_doi):
-            pytest.skip("No class DOI")
-
-        # If init.doi exactly matches any metadata DOI, it's consistent
-        all_meta = {
-            dois.get(k)
-            for k in ("metadata.doi", "metadata.associated_paper")
-            if dois.get(k)
-        }
-        if init_doi in all_meta:
-            pytest.skip("Class DOI matches a metadata DOI — consistent")
-
-        # Collect metadata DOIs that differ from init for author comparison
-        meta_dois = {
-            k: v
-            for k, v in [
-                ("metadata.doi", dois.get("metadata.doi")),
-                ("metadata.associated_paper", dois.get("metadata.associated_paper")),
-            ]
-            if v and _is_doi(v) and v != init_doi
-        }
-        if not meta_dois:
-            pytest.skip("No differing metadata DOIs to compare")
-
-        init_result = _resolve_doi(init_doi)
-        if init_result is None:
-            pytest.skip(f"Could not resolve init DOI {init_doi!r}")
-
-        init_authors = _extract_surnames(init_result.get("authors"))
-        report_lines = [
-            f"  class DOI {init_doi}: {init_result.get('title')}",
-            f"    authors: {init_result.get('authors')}",
+    meta_dois = {
+        k: v
+        for k, v in [
+            ("metadata.doi", dois.get("metadata.doi")),
+            (
+                "metadata.associated_paper",
+                dois.get("metadata.associated_paper"),
+            ),
         ]
+        if v and _is_doi(v) and v != init_doi
+    }
+    if not meta_dois:
+        pytest.skip("No differing metadata DOIs to compare")
 
-        for key, meta_doi in meta_dois.items():
-            meta_result = _resolve_doi(meta_doi)
-            if meta_result is None:
-                continue
-            meta_authors = _extract_surnames(meta_result.get("authors"))
-            if init_authors & meta_authors:
-                return  # found overlap — test passes
-            report_lines.append(f"  {key} {meta_doi}: {meta_result.get('title')}")
-            report_lines.append(f"    authors: {meta_result.get('authors')}")
+    init_result = _resolve_doi(init_doi)
+    if init_result is None:
+        pytest.skip(f"Could not resolve init DOI {init_doi!r}")
 
-        pytest.fail(
-            f"{dataset_class.__name__}: class DOI shares no authors with "
-            f"any metadata DOI.\n" + "\n".join(report_lines)
-        )
+    init_authors = _extract_surnames(init_result.get("authors"))
+    report = [
+        f"  class DOI {init_doi}: {init_result.get('title')}",
+        f"    authors: {init_result.get('authors')}",
+    ]
+    for key, meta_doi in meta_dois.items():
+        meta_result = _resolve_doi(meta_doi)
+        if meta_result is None:
+            continue
+        meta_authors = _extract_surnames(meta_result.get("authors"))
+        if init_authors & meta_authors:
+            return
+        report.append(f"  {key} {meta_doi}: {meta_result.get('title')}")
+        report.append(f"    authors: {meta_result.get('authors')}")
+
+    pytest.fail(
+        f"{dataset_class.__name__}: class DOI shares no authors with "
+        f"any metadata DOI.\n" + "\n".join(report)
+    )

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -21,6 +21,7 @@ import pytest
 from moabb.datasets.metadata.schema import DatasetMetadata
 from moabb.datasets.utils import dataset_list
 
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -134,7 +135,8 @@ def _resolve_doi_datacite(doi: str) -> dict | None:
         attrs = data.get("data", {}).get("attributes", {})
         title = (attrs.get("titles") or [{}])[0].get("title")
         authors = [
-            c.get("name", "") or f"{c.get('givenName', '')} {c.get('familyName', '')}".strip()
+            c.get("name", "")
+            or f"{c.get('givenName', '')} {c.get('familyName', '')}".strip()
             for c in attrs.get("creators", [])
         ]
         year = attrs.get("publicationYear")
@@ -170,9 +172,7 @@ _REAL_DATASETS = [
 class TestDOIFormat:
     """Validate that DOI strings in metadata have correct format."""
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_metadata_doi_is_valid_format(self, dataset_class):
         """documentation.doi should be a valid DOI or None."""
         meta = dataset_class.METADATA
@@ -182,18 +182,14 @@ class TestDOIFormat:
         doi = getattr(doc, "doi", None)
         if doi is None:
             pytest.skip("No DOI set")
-        is_valid = _is_doi(doi) or any(
-            doi.startswith(p) for p in _NON_CROSSREF_PREFIXES
-        )
+        is_valid = _is_doi(doi) or any(doi.startswith(p) for p in _NON_CROSSREF_PREFIXES)
         assert is_valid, (
             f"{dataset_class.__name__}: documentation.doi={doi!r} "
             f"does not look like a valid DOI (expected 10.xxxx/...) "
             f"or recognized identifier (hal-/tel-/arXiv:)"
         )
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_associated_doi_is_valid_format(self, dataset_class):
         """associated_paper_doi should be a valid DOI, HAL ID, or None."""
         meta = dataset_class.METADATA
@@ -215,9 +211,7 @@ class TestDOIFormat:
 class TestDOIConsistency:
     """Check that DOIs in metadata match docstring references."""
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_metadata_doi_appears_in_docstring(self, dataset_class):
         """The primary DOI in metadata should also appear in the docstring."""
         meta = dataset_class.METADATA
@@ -241,9 +235,7 @@ class TestDOIConsistency:
             f"not found in docstring DOIs: {docstring_dois}"
         )
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_docstring_dois_are_known_in_metadata(self, dataset_class):
         """All DOIs in docstring should be either the primary DOI,
         associated DOI, or a recognized data repository DOI."""
@@ -313,9 +305,7 @@ class TestDOIConsistency:
 class TestDOIResolution:
     """Verify that every DOI in metadata resolves via CrossRef."""
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_primary_doi_resolves(self, dataset_class):
         """documentation.doi should resolve to a real publication."""
         meta = dataset_class.METADATA
@@ -329,16 +319,14 @@ class TestDOIResolution:
             pytest.skip(f"Not a standard DOI: {doi!r}")
 
         result = _resolve_doi(doi)
-        assert result is not None, (
-            f"{dataset_class.__name__}: DOI {doi!r} failed to resolve via CrossRef"
-        )
-        assert result["title"], (
-            f"{dataset_class.__name__}: DOI {doi!r} resolved but has no title"
-        )
+        assert (
+            result is not None
+        ), f"{dataset_class.__name__}: DOI {doi!r} failed to resolve via CrossRef"
+        assert result[
+            "title"
+        ], f"{dataset_class.__name__}: DOI {doi!r} resolved but has no title"
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_primary_doi_year_matches_metadata(self, dataset_class):
         """Publication year from CrossRef should match metadata."""
         meta = dataset_class.METADATA
@@ -378,9 +366,7 @@ class TestDOIResolution:
             f"  CrossRef title: {result['title']}"
         )
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_primary_doi_authors_overlap_metadata(self, dataset_class):
         """At least one CrossRef author should appear in metadata investigators."""
         meta = dataset_class.METADATA
@@ -439,9 +425,7 @@ class TestDOIResolution:
 class TestDocstringDOIContent:
     """Verify that DOIs referenced in docstrings resolve to related papers."""
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_docstring_reference_dois_resolve(self, dataset_class):
         """Every DOI in docstring References section should resolve."""
         doc = getattr(dataset_class, "__doc__", "") or ""
@@ -454,7 +438,15 @@ class TestDocstringDOIContent:
                 in_refs = True
                 continue
             if in_refs:
-                if stripped and not stripped.startswith("..") and not stripped.startswith("http") and not stripped.startswith("10.") and not stripped[0:1].isdigit() and stripped[0:1].isalpha() and not stripped.startswith("-"):
+                if (
+                    stripped
+                    and not stripped.startswith("..")
+                    and not stripped.startswith("http")
+                    and not stripped.startswith("10.")
+                    and not stripped[0:1].isdigit()
+                    and stripped[0:1].isalpha()
+                    and not stripped.startswith("-")
+                ):
                     # New section header
                     break
                 ref_section += line + "\n"

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -1,13 +1,18 @@
-"""Systematic DOI validation for MOABB dataset metadata.
+"""DOI validation for MOABB dataset metadata.
 
-Uses the CrossRef API (via habanero) and DataCite API to verify that
-every DOI in dataset METADATA and docstrings resolves to a real
-publication and that the referenced paper matches the dataset description.
+Treats the DOI in each dataset class (``__init__``) as ground truth,
+then validates that:
 
-Run with:
-    python -m pytest moabb/tests/test_doi_validation.py -x --timeout=300 -v
+1. All DOIs (class, METADATA, docstring) have valid format.
+2. METADATA DOIs are consistent with the class DOI.
+3. Every DOI resolves via CrossRef or DataCite.
 
-Or just the quick offline checks:
+Run all (including network tests)::
+
+    python -m pytest moabb/tests/test_doi_validation.py --timeout=300 -v
+
+Run only offline checks::
+
     python -m pytest moabb/tests/test_doi_validation.py -k "not network" -v
 """
 
@@ -21,111 +26,144 @@ import pytest
 from moabb.datasets.metadata.schema import DatasetMetadata
 from moabb.datasets.utils import dataset_list
 
-
 # ---------------------------------------------------------------------------
-# Helpers
+# Configuration
 # ---------------------------------------------------------------------------
 
-# DOIs that are not resolvable via CrossRef (HAL, arXiv IDs, etc.)
-_NON_CROSSREF_PREFIXES = (
-    "hal-",
-    "tel-",
-    "arXiv:",
-)
-
-# DOI prefixes registered with DataCite (not CrossRef)
-_DATACITE_PREFIXES = (
-    "10.5281/zenodo.",  # Zenodo
-    "10.6084/m9.figshare.",  # Figshare
-    "10.48550/arXiv.",  # arXiv
-    "10.7910/DVN/",  # Harvard Dataverse
-    "10.6094/",  # FreiDok (Freiburg)
-    "10.5524/",  # GigaDB
-    "10.34973/",  # Radboud Data Repository
-    "10.18115/",  # ERPSS
-    "10.35376/",  # University of Valladolid
-    "10.3217/",  # TU Graz conference proceedings
-)
-
-# Test / fake datasets to skip
 _SKIP_CLASSES = {"FakeDataset", "FakeVirtualRealityDataset"}
 
-# Rate-limit: be polite to APIs
-_REQUEST_DELAY = 0.15  # seconds between requests
+# Non-standard identifiers (not resolvable as DOIs)
+_NON_DOI_PREFIXES = ("hal-", "tel-", "arXiv:")
+
+# DOI prefixes handled by DataCite instead of CrossRef
+_DATACITE_PREFIXES = (
+    "10.5281/zenodo.",
+    "10.6084/m9.figshare.",
+    "10.48550/arXiv.",
+    "10.7910/DVN/",
+    "10.6094/",
+    "10.5524/",
+    "10.34973/",
+    "10.18115/",
+    "10.35376/",
+    "10.3217/",
+)
+
+_REQUEST_DELAY = 0.15  # polite rate-limit for APIs
+
+# ---------------------------------------------------------------------------
+# DOI helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_doi(value: str | None) -> str | None:
+    """Strip URL prefix from a DOI, returning the bare ``10.xxxx/…`` form."""
+    if not value:
+        return None
+    for prefix in ("https://doi.org/", "http://doi.org/", "https://dx.doi.org/"):
+        if value.startswith(prefix):
+            value = value[len(prefix) :]
+            break
+    return value
 
 
 def _is_doi(value: str) -> bool:
-    """Check if a string looks like a DOI (starts with 10.xxxx/)."""
-    if not value:
-        return False
-    return bool(re.match(r"^10\.\d{4,}/", value))
+    """Return True if *value* looks like a DOI (``10.xxxx/…``)."""
+    return bool(value and re.match(r"^10\.\d{4,}/", _normalize_doi(value) or ""))
+
+
+def _is_datacite_doi(doi: str) -> bool:
+    return any(doi.startswith(p) for p in _DATACITE_PREFIXES)
 
 
 def _extract_docstring_dois(cls) -> list[str]:
-    """Extract all DOI-like strings from a class docstring."""
+    """Return deduplicated DOIs found anywhere in *cls.__doc__*."""
     doc = getattr(cls, "__doc__", "") or ""
     raw = re.findall(r"10\.\d{4,}/[^\s\]\">]+", doc)
-    # Clean trailing punctuation and RST artifacts
     cleaned = []
     for d in raw:
         d = d.rstrip(".,;:)")
         d = d.rstrip("`")
-        if d.endswith(">`_"):
+        if ">`_" in d:
             d = d[: d.index(">")]
         d = d.rstrip("`_>")
         if d.endswith("/abstract"):
             d = d[: -len("/abstract")]
         cleaned.append(d)
-    return list(dict.fromkeys(cleaned))  # deduplicate, preserve order
+    return list(dict.fromkeys(cleaned))
 
 
-def _get_metadata_dois(meta: DatasetMetadata) -> dict[str, str | None]:
-    """Extract all DOI fields from a DatasetMetadata object."""
-    result = {}
-    doc = getattr(meta, "documentation", None)
-    if doc:
-        result["documentation.doi"] = getattr(doc, "doi", None)
-        result["documentation.associated_paper_doi"] = getattr(
-            doc, "associated_paper_doi", None
-        )
+# ---------------------------------------------------------------------------
+# DOI collection per dataset
+# ---------------------------------------------------------------------------
+
+
+def _collect_dois(cls) -> dict[str, str | None]:
+    """Return ``{source_label: doi}`` for all DOI sources in *cls*.
+
+    Sources:
+        ``init.doi``                  — ground-truth DOI from ``__init__``
+        ``metadata.doi``              — ``METADATA.documentation.doi``
+        ``metadata.associated_paper`` — ``METADATA.documentation.associated_paper_doi``
+        ``docstring.<N>``             — DOIs extracted from the class docstring
+    """
+    result: dict[str, str | None] = {}
+
+    # 1. Ground-truth DOI from __init__
+    try:
+        instance = cls()
+        result["init.doi"] = _normalize_doi(getattr(instance, "doi", None))
+    except Exception:
+        result["init.doi"] = None
+
+    # 2. METADATA documentation DOIs
+    meta = getattr(cls, "METADATA", None)
+    if isinstance(meta, DatasetMetadata):
+        doc = getattr(meta, "documentation", None)
+        if doc:
+            result["metadata.doi"] = _normalize_doi(getattr(doc, "doi", None))
+            result["metadata.associated_paper"] = _normalize_doi(
+                getattr(doc, "associated_paper_doi", None)
+            )
+
+    # 3. Docstring DOIs
+    for i, doi in enumerate(_extract_docstring_dois(cls)):
+        result[f"docstring.{i}"] = doi
+
     return result
 
 
-def _is_datacite_doi(doi: str) -> bool:
-    """Check if a DOI is registered with DataCite rather than CrossRef."""
-    return any(doi.startswith(p) for p in _DATACITE_PREFIXES)
+# ---------------------------------------------------------------------------
+# DOI resolution via CrossRef (habanero) and DataCite
+# ---------------------------------------------------------------------------
 
 
-def _resolve_doi_crossref(doi: str) -> dict | None:
-    """Resolve a DOI via CrossRef and return title/authors/year, or None."""
+def _resolve_crossref(doi: str) -> dict | None:
+    """Resolve *doi* via CrossRef. Returns ``{title, authors, year}`` or None."""
     try:
         from habanero import Crossref
 
         cr = Crossref(mailto="moabb-test@example.com")
         time.sleep(_REQUEST_DELAY)
-        r = cr.works(ids=doi)
-        msg = r["message"]
-        title = msg.get("title", [None])[0]
+        msg = cr.works(ids=doi)["message"]
+        title = (msg.get("title") or [None])[0]
         authors = [
             f"{a.get('given', '')} {a.get('family', '')}".strip()
             for a in msg.get("author", [])
         ]
         year = None
-        all_years = set()
         for key in ("published-print", "published-online", "created"):
-            if key in msg:
-                parts = msg[key].get("date-parts", [[None]])
-                if parts and parts[0] and parts[0][0]:
-                    all_years.add(parts[0][0])
-                    if year is None:
-                        year = parts[0][0]
-        return {"title": title, "authors": authors, "year": year, "all_years": all_years}
+            parts = msg.get(key, {}).get("date-parts", [[None]])
+            if parts and parts[0] and parts[0][0]:
+                year = parts[0][0]
+                break
+        return {"title": title, "authors": authors, "year": year, "doi": doi}
     except Exception:
         return None
 
 
-def _resolve_doi_datacite(doi: str) -> dict | None:
-    """Resolve a DOI via DataCite API and return title/authors/year, or None."""
+def _resolve_datacite(doi: str) -> dict | None:
+    """Resolve *doi* via DataCite. Returns ``{title, authors, year}`` or None."""
     try:
         time.sleep(_REQUEST_DELAY)
         url = f"https://api.datacite.org/dois/{doi}"
@@ -140,16 +178,16 @@ def _resolve_doi_datacite(doi: str) -> dict | None:
             for c in attrs.get("creators", [])
         ]
         year = attrs.get("publicationYear")
-        return {"title": title, "authors": authors, "year": year}
+        return {"title": title, "authors": authors, "year": year, "doi": doi}
     except Exception:
         return None
 
 
 def _resolve_doi(doi: str) -> dict | None:
-    """Resolve a DOI via the appropriate registry (CrossRef or DataCite)."""
+    """Resolve *doi* via the appropriate registry."""
     if _is_datacite_doi(doi):
-        return _resolve_doi_datacite(doi)
-    return _resolve_doi_crossref(doi)
+        return _resolve_datacite(doi)
+    return _resolve_crossref(doi)
 
 
 # ---------------------------------------------------------------------------
@@ -165,311 +203,141 @@ _REAL_DATASETS = [
 
 
 # ---------------------------------------------------------------------------
-# OFFLINE TESTS (no network needed)
+# OFFLINE TESTS — no network required
 # ---------------------------------------------------------------------------
 
 
 class TestDOIFormat:
-    """Validate that DOI strings in metadata have correct format."""
+    """Every DOI string should have valid ``10.xxxx/…`` format."""
 
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_metadata_doi_is_valid_format(self, dataset_class):
-        """documentation.doi should be a valid DOI or None."""
-        meta = dataset_class.METADATA
-        doc = getattr(meta, "documentation", None)
-        if doc is None:
-            pytest.skip("No documentation section")
-        doi = getattr(doc, "doi", None)
-        if doi is None:
-            pytest.skip("No DOI set")
-        is_valid = _is_doi(doi) or any(doi.startswith(p) for p in _NON_CROSSREF_PREFIXES)
-        assert is_valid, (
-            f"{dataset_class.__name__}: documentation.doi={doi!r} "
-            f"does not look like a valid DOI (expected 10.xxxx/...) "
-            f"or recognized identifier (hal-/tel-/arXiv:)"
-        )
-
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_associated_doi_is_valid_format(self, dataset_class):
-        """associated_paper_doi should be a valid DOI, HAL ID, or None."""
-        meta = dataset_class.METADATA
-        doc = getattr(meta, "documentation", None)
-        if doc is None:
-            pytest.skip("No documentation section")
-        assoc = getattr(doc, "associated_paper_doi", None)
-        if assoc is None:
-            pytest.skip("No associated DOI set")
-        is_valid = _is_doi(assoc) or any(
-            assoc.startswith(p) for p in _NON_CROSSREF_PREFIXES
-        )
-        assert is_valid, (
-            f"{dataset_class.__name__}: associated_paper_doi={assoc!r} "
-            f"is not a valid DOI or recognized ID"
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_all_dois_have_valid_format(self, dataset_class):
+        dois = _collect_dois(dataset_class)
+        invalid = []
+        for source, doi in dois.items():
+            if doi is None:
+                continue
+            ok = _is_doi(doi) or any(doi.startswith(p) for p in _NON_DOI_PREFIXES)
+            if not ok:
+                invalid.append(f"  {source} = {doi!r}")
+        if not any(v for v in dois.values()):
+            pytest.skip("No DOIs found")
+        assert not invalid, (
+            f"{dataset_class.__name__}: invalid DOI format:\n" + "\n".join(invalid)
         )
 
 
 class TestDOIConsistency:
-    """Check that DOIs in metadata match docstring references."""
+    """Docstring DOIs must be tracked in METADATA or class DOI."""
 
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_metadata_doi_appears_in_docstring(self, dataset_class):
-        """The primary DOI in metadata should also appear in the docstring."""
-        meta = dataset_class.METADATA
-        doc = getattr(meta, "documentation", None)
-        if doc is None:
-            pytest.skip("No documentation section")
-        doi = getattr(doc, "doi", None)
-        if doi is None:
-            pytest.skip("No DOI set")
-        if not _is_doi(doi):
-            pytest.skip(f"DOI {doi!r} is not a standard DOI format")
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_docstring_dois_tracked_in_metadata(self, dataset_class):
+        """Every DOI in the docstring should appear in METADATA or init."""
+        dois = _collect_dois(dataset_class)
 
-        docstring = getattr(dataset_class, "__doc__", "") or ""
-        # Skip if docstring has no references section at all
-        if "doi" not in docstring.lower() and "10." not in docstring:
-            pytest.skip("Docstring has no DOI references")
+        # All known DOIs from non-docstring sources
+        known = set()
+        for key in ("metadata.doi", "metadata.associated_paper", "init.doi"):
+            val = dois.get(key)
+            if val and _is_doi(val):
+                known.add(val)
 
-        docstring_dois = _extract_docstring_dois(dataset_class)
-        assert doi in docstring_dois, (
-            f"{dataset_class.__name__}: metadata DOI {doi!r} "
-            f"not found in docstring DOIs: {docstring_dois}"
-        )
-
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_docstring_dois_are_known_in_metadata(self, dataset_class):
-        """All DOIs in docstring should be either the primary DOI,
-        associated DOI, or a recognized data repository DOI."""
-        meta = dataset_class.METADATA
-        doc_meta = getattr(meta, "documentation", None)
-
-        known_dois = set()
-        if doc_meta:
-            for field in ("doi", "associated_paper_doi", "data_url", "repository"):
-                val = getattr(doc_meta, field, None)
-                if val and _is_doi(val):
-                    known_dois.add(val)
-                elif isinstance(val, str) and "doi.org/" in val:
-                    # Extract DOI from URL
-                    m = re.search(r"10\.\d{4,}/[^\s]+", val)
+        # Also check data_url for embedded DOIs
+        meta = getattr(dataset_class, "METADATA", None)
+        if meta:
+            doc = getattr(meta, "documentation", None)
+            if doc:
+                data_url = getattr(doc, "data_url", None)
+                if isinstance(data_url, str):
+                    m = re.search(r"10\.\d{4,}/[^\s]+", data_url)
                     if m:
-                        known_dois.add(m.group().rstrip(".,;:)"))
+                        known.add(m.group().rstrip(".,;:)"))
 
-        # External links may contain DOIs too
-        ext = getattr(meta, "external_links", None)
-        if isinstance(ext, dict):
-            for v in ext.values():
-                if isinstance(v, str) and _is_doi(v):
-                    known_dois.add(v)
-
-        docstring_dois = _extract_docstring_dois(dataset_class)
-        if not docstring_dois:
+        doc_dois = [
+            dois[k] for k in sorted(dois) if k.startswith("docstring.") and dois[k]
+        ]
+        if not doc_dois:
             pytest.skip("No DOIs in docstring")
 
-        # Data-repository DOI prefixes that are fine to appear in docstrings
+        # Data-repo prefixes are fine in docstrings without metadata tracking
         _DATA_REPO_PREFIXES = (
-            "10.5281/zenodo.",  # Zenodo
-            "10.7910/DVN/",  # Harvard Dataverse
-            "10.6084/m9.figshare.",  # Figshare
-            "10.6094/",  # FreiDok (Freiburg)
-            "10.5524/",  # GigaDB
-            "10.34973/",  # Radboud Data Repository
-            "10.18115/",  # ERPSS
-            "10.48550/arXiv.",  # arXiv
+            "10.5281/zenodo.",
+            "10.7910/DVN/",
+            "10.6084/m9.figshare.",
+            "10.6094/",
+            "10.5524/",
+            "10.34973/",
+            "10.18115/",
+            "10.48550/arXiv.",
         )
 
-        unknown = []
-        for d in docstring_dois:
-            if d in known_dois:
+        untracked = []
+        for d in doc_dois:
+            if d in known:
                 continue
             if any(d.startswith(p) for p in _DATA_REPO_PREFIXES):
                 continue
-            # Check if it's a substring match (different URL forms)
-            if any(d in k or k in d for k in known_dois):
+            if any(d in k or k in d for k in known):
                 continue
-            unknown.append(d)
+            untracked.append(d)
 
-        if unknown:
-            pytest.fail(
-                f"{dataset_class.__name__}: docstring contains DOIs not tracked "
-                f"in metadata: {unknown}\n"
-                f"  Known metadata DOIs: {known_dois}"
-            )
+        assert not untracked, (
+            f"{dataset_class.__name__}: docstring DOIs not tracked in metadata: "
+            f"{untracked}\n  Known: {known}"
+        )
 
 
 # ---------------------------------------------------------------------------
-# NETWORK TESTS (require CrossRef API)
+# NETWORK TESTS — resolve DOIs via CrossRef / DataCite
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.network
 class TestDOIResolution:
-    """Verify that every DOI in metadata resolves via CrossRef."""
+    """Every DOI should resolve to a real publication via CrossRef/DataCite."""
 
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_primary_doi_resolves(self, dataset_class):
-        """documentation.doi should resolve to a real publication."""
-        meta = dataset_class.METADATA
-        doc = getattr(meta, "documentation", None)
-        if doc is None:
-            pytest.skip("No documentation section")
-        doi = getattr(doc, "doi", None)
-        if doi is None:
-            pytest.skip("No DOI set")
-        if not _is_doi(doi):
-            pytest.skip(f"Not a standard DOI: {doi!r}")
-
-        result = _resolve_doi(doi)
-        assert (
-            result is not None
-        ), f"{dataset_class.__name__}: DOI {doi!r} failed to resolve via CrossRef"
-        assert result[
-            "title"
-        ], f"{dataset_class.__name__}: DOI {doi!r} resolved but has no title"
-
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_primary_doi_year_matches_metadata(self, dataset_class):
-        """Publication year from CrossRef should match metadata."""
-        meta = dataset_class.METADATA
-        doc = getattr(meta, "documentation", None)
-        if doc is None:
-            pytest.skip("No documentation section")
-        doi = getattr(doc, "doi", None)
-        meta_year = getattr(doc, "publication_year", None)
-        if doi is None or meta_year is None:
-            pytest.skip("No DOI or publication_year")
-        if not _is_doi(doi):
-            pytest.skip(f"Not a standard DOI: {doi!r}")
-
-        result = _resolve_doi(doi)
-        if result is None:
-            pytest.skip(f"DOI {doi!r} did not resolve")
-
-        cr_year = result["year"]
-        if cr_year is None:
-            pytest.skip("Registry returned no year")
-
-        # DataCite records (Zenodo, figshare, etc.) can have updated
-        # publication years when new versions are uploaded.  Only flag
-        # mismatches for journal/conference DOIs (CrossRef).
-        if _is_datacite_doi(doi):
-            pytest.skip("Skipping year check for DataCite DOI (versions change dates)")
-
-        # For journal papers, CrossRef may return the print date which
-        # can differ from the online-first date.  Accept if metadata year
-        # matches any of: published-print, published-online, or created year.
-        cr_years = result.get("all_years", set())
-        cr_years.add(cr_year)
-
-        assert meta_year in cr_years, (
-            f"{dataset_class.__name__}: metadata publication_year={meta_year} "
-            f"but CrossRef says year(s)={sorted(cr_years)} for DOI {doi!r}\n"
-            f"  CrossRef title: {result['title']}"
-        )
-
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_primary_doi_authors_overlap_metadata(self, dataset_class):
-        """At least one CrossRef author should appear in metadata investigators."""
-        meta = dataset_class.METADATA
-        doc = getattr(meta, "documentation", None)
-        if doc is None:
-            pytest.skip("No documentation section")
-        doi = getattr(doc, "doi", None)
-        investigators = getattr(doc, "investigators", None)
-        if doi is None or not investigators:
-            pytest.skip("No DOI or investigators")
-        if not _is_doi(doi):
-            pytest.skip(f"Not a standard DOI: {doi!r}")
-
-        result = _resolve_doi(doi)
-        if result is None:
-            pytest.skip(f"DOI {doi!r} did not resolve")
-
-        cr_authors = result["authors"]
-        if not cr_authors:
-            pytest.skip("CrossRef returned no authors")
-
-        # Extract family names from both sources, handling:
-        #   CrossRef: "Given Family" format
-        #   DataCite: "Family, Given" format
-        #   Metadata: "G. Family" or "Given Family" or "Family, G." format
-        def _extract_surnames(names):
-            surnames = set()
-            for name in names:
-                name = name.strip()
-                if not name:
-                    continue
-                if ", " in name:
-                    # "Last, First" format — take the part before the comma
-                    surnames.add(name.split(",")[0].strip().lower())
-                else:
-                    # "First Last" or "F. Last" — take the last token
-                    parts = name.split()
-                    if parts:
-                        surnames.add(parts[-1].strip(".").lower())
-            return surnames
-
-        cr_surnames = _extract_surnames(cr_authors)
-        meta_surnames = _extract_surnames(investigators)
-
-        overlap = cr_surnames & meta_surnames
-        assert overlap, (
-            f"{dataset_class.__name__}: no author overlap between "
-            f"CrossRef authors {cr_authors} and "
-            f"metadata investigators {investigators} "
-            f"for DOI {doi!r}\n"
-            f"  CrossRef title: {result['title']}"
-        )
-
-
-@pytest.mark.network
-class TestDocstringDOIContent:
-    """Verify that DOIs referenced in docstrings resolve to related papers."""
-
-    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
-    def test_docstring_reference_dois_resolve(self, dataset_class):
-        """Every DOI in docstring References section should resolve."""
-        doc = getattr(dataset_class, "__doc__", "") or ""
-        # Only check DOIs from the References section
-        ref_section = ""
-        in_refs = False
-        for line in doc.splitlines():
-            stripped = line.strip()
-            if stripped.lower().startswith("references") or stripped == "----------":
-                in_refs = True
-                continue
-            if in_refs:
-                if (
-                    stripped
-                    and not stripped.startswith("..")
-                    and not stripped.startswith("http")
-                    and not stripped.startswith("10.")
-                    and not stripped[0:1].isdigit()
-                    and stripped[0:1].isalpha()
-                    and not stripped.startswith("-")
-                ):
-                    # New section header
-                    break
-                ref_section += line + "\n"
-
-        if not ref_section:
-            pytest.skip("No References section in docstring")
-
-        dois = re.findall(r"10\.\d{4,}/[^\s\]\">]+", ref_section)
-        dois = [d.rstrip(".,;:)`_>") for d in dois]
-        dois = list(dict.fromkeys(dois))
-
-        if not dois:
-            pytest.skip("No DOIs in References section")
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_all_dois_resolve(self, dataset_class):
+        """All unique DOIs from class, METADATA, and docstring must resolve."""
+        dois = _collect_dois(dataset_class)
+        unique_dois = sorted({d for d in dois.values() if d and _is_doi(d)})
+        if not unique_dois:
+            pytest.skip("No DOIs to resolve")
 
         failures = []
-        for doi in dois:
-            if not _is_doi(doi):
-                continue
+        for doi in unique_dois:
             result = _resolve_doi(doi)
             if result is None:
                 failures.append(doi)
+            elif not result.get("title"):
+                failures.append(f"{doi} (resolved but no title)")
 
         assert not failures, (
-            f"{dataset_class.__name__}: these docstring DOIs failed to resolve "
-            f"via CrossRef: {failures}"
+            f"{dataset_class.__name__}: DOIs failed to resolve: {failures}"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_class_doi_resolves(self, dataset_class):
+        """The class DOI (ground truth) must resolve to a real publication."""
+        dois = _collect_dois(dataset_class)
+        init_doi = dois.get("init.doi")
+
+        if not init_doi or not _is_doi(init_doi):
+            pytest.skip("No class DOI")
+
+        result = _resolve_doi(init_doi)
+        assert result is not None, (
+            f"{dataset_class.__name__}: class DOI {init_doi!r} failed to resolve"
+        )
+        assert result.get("title"), (
+            f"{dataset_class.__name__}: class DOI {init_doi!r} resolved but has "
+            f"no title"
         )

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -244,40 +244,29 @@ def test_class_and_metadata_dois_share_authors(dataset_class):
     if not init_doi or not _is_doi(init_doi):
         pytest.skip("No class DOI")
 
-    meta_dois = {
-        k: v
-        for k, v in [
-            ("metadata.doi", dois.get("metadata.doi")),
-            (
-                "metadata.associated_paper",
-                dois.get("metadata.associated_paper"),
-            ),
-        ]
-        if v and _is_doi(v) and v != init_doi
-    }
-    if not meta_dois:
-        pytest.skip("No differing metadata DOIs to compare")
+    meta_doi = dois.get("metadata.doi")
+    if not meta_doi or not _is_doi(meta_doi) or meta_doi == init_doi:
+        pytest.skip("No differing metadata.doi to compare")
 
     init_result = _resolve_doi(init_doi)
     if init_result is None:
         pytest.skip(f"Could not resolve init DOI {init_doi!r}")
 
     init_authors = _extract_surnames(init_result.get("authors"))
-    report = [
-        f"  class DOI {init_doi}: {init_result.get('title')}",
-        f"    authors: {init_result.get('authors')}",
-    ]
-    for key, meta_doi in meta_dois.items():
-        meta_result = _resolve_doi(meta_doi)
-        if meta_result is None:
-            continue
-        meta_authors = _extract_surnames(meta_result.get("authors"))
-        if init_authors & meta_authors:
-            return
-        report.append(f"  {key} {meta_doi}: {meta_result.get('title')}")
-        report.append(f"    authors: {meta_result.get('authors')}")
+
+    meta_result = _resolve_doi(meta_doi)
+    if meta_result is None:
+        pytest.skip(f"Could not resolve metadata DOI {meta_doi!r}")
+
+    meta_authors = _extract_surnames(meta_result.get("authors"))
+    if init_authors & meta_authors:
+        return
 
     pytest.fail(
         f"{dataset_class.__name__}: class DOI shares no authors with "
-        f"any metadata DOI.\n" + "\n".join(report)
+        f"metadata DOI.\n"
+        f"  class DOI {init_doi}: {init_result.get('title')}\n"
+        f"    authors: {init_result.get('authors')}\n"
+        f"  metadata.doi {meta_doi}: {meta_result.get('title')}\n"
+        f"    authors: {meta_result.get('authors')}"
     )

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -157,7 +157,7 @@ def _resolve_doi(doi: str) -> dict | None:
 def _extract_surnames(authors: list[str]) -> set[str]:
     """Extract lowercase surnames from author name strings."""
     out = set()
-    for a in (authors or []):
+    for a in authors or []:
         a = a.strip()
         if not a:
             continue
@@ -316,9 +316,7 @@ class TestDOIResolution:
             f"no title"
         )
 
-    @pytest.mark.parametrize(
-        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_class_and_metadata_dois_share_authors(self, dataset_class):
         """Class DOI must share authors with at least one metadata DOI.
 
@@ -333,7 +331,8 @@ class TestDOIResolution:
 
         # If init.doi exactly matches any metadata DOI, it's consistent
         all_meta = {
-            dois.get(k) for k in ("metadata.doi", "metadata.associated_paper")
+            dois.get(k)
+            for k in ("metadata.doi", "metadata.associated_paper")
             if dois.get(k)
         }
         if init_doi in all_meta:
@@ -341,7 +340,8 @@ class TestDOIResolution:
 
         # Collect metadata DOIs that differ from init for author comparison
         meta_dois = {
-            k: v for k, v in [
+            k: v
+            for k, v in [
                 ("metadata.doi", dois.get("metadata.doi")),
                 ("metadata.associated_paper", dois.get("metadata.associated_paper")),
             ]
@@ -367,12 +367,8 @@ class TestDOIResolution:
             meta_authors = _extract_surnames(meta_result.get("authors"))
             if init_authors & meta_authors:
                 return  # found overlap — test passes
-            report_lines.append(
-                f"  {key} {meta_doi}: {meta_result.get('title')}"
-            )
-            report_lines.append(
-                f"    authors: {meta_result.get('authors')}"
-            )
+            report_lines.append(f"  {key} {meta_doi}: {meta_result.get('title')}")
+            report_lines.append(f"    authors: {meta_result.get('authors')}")
 
         pytest.fail(
             f"{dataset_class.__name__}: class DOI shares no authors with "

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -4,8 +4,10 @@ Treats the DOI in each dataset class (``__init__``) as ground truth,
 then validates that:
 
 1. All DOIs (class, METADATA, docstring) have valid format.
-2. METADATA DOIs are consistent with the class DOI.
-3. Every DOI resolves via CrossRef or DataCite.
+2. Docstring DOIs are tracked in METADATA.
+3. Every DOI resolves via doi.org content negotiation (works for
+   CrossRef, DataCite, and Medra registries).
+4. When class DOI and metadata DOI differ, they share at least one author.
 
 Run all (including network tests)::
 
@@ -16,11 +18,10 @@ Run only offline checks::
     python -m pytest moabb/tests/test_doi_validation.py -k "not network" -v
 """
 
-import json
 import re
 import time
-import urllib.request
 
+import httpx
 import pytest
 
 from moabb.datasets.metadata.schema import DatasetMetadata
@@ -36,45 +37,29 @@ _SKIP_CLASSES = {"FakeDataset", "FakeVirtualRealityDataset"}
 # Non-standard identifiers (not resolvable as DOIs)
 _NON_DOI_PREFIXES = ("hal-", "tel-", "arXiv:")
 
-# DOI prefixes handled by DataCite instead of CrossRef
-_DATACITE_PREFIXES = (
-    "10.5281/zenodo.",
-    "10.6084/m9.figshare.",
-    "10.48550/arXiv.",
-    "10.7910/DVN/",
-    "10.6094/",
-    "10.5524/",
-    "10.34973/",
-    "10.18115/",
-    "10.35376/",
-    "10.3217/",
-)
-
-_REQUEST_DELAY = 0.15  # polite rate-limit for APIs
+_REQUEST_DELAY = 0.15  # polite rate-limit
 
 # ---------------------------------------------------------------------------
 # DOI helpers
 # ---------------------------------------------------------------------------
+
+_DOI_URL_PREFIXES = ("https://doi.org/", "http://doi.org/", "https://dx.doi.org/")
+_DOI_RE = re.compile(r"^10\.\d{4,}/")
 
 
 def _normalize_doi(value: str | None) -> str | None:
     """Strip URL prefix from a DOI, returning the bare ``10.xxxx/…`` form."""
     if not value:
         return None
-    for prefix in ("https://doi.org/", "http://doi.org/", "https://dx.doi.org/"):
+    for prefix in _DOI_URL_PREFIXES:
         if value.startswith(prefix):
-            value = value[len(prefix) :]
-            break
+            return value[len(prefix) :]
     return value
 
 
 def _is_doi(value: str) -> bool:
     """Return True if *value* looks like a DOI (``10.xxxx/…``)."""
-    return bool(value and re.match(r"^10\.\d{4,}/", _normalize_doi(value) or ""))
-
-
-def _is_datacite_doi(doi: str) -> bool:
-    return any(doi.startswith(p) for p in _DATACITE_PREFIXES)
+    return bool(value and _DOI_RE.match(_normalize_doi(value) or ""))
 
 
 def _extract_docstring_dois(cls) -> list[str]:
@@ -135,60 +120,56 @@ def _collect_dois(cls) -> dict[str, str | None]:
 
 
 # ---------------------------------------------------------------------------
-# DOI resolution via CrossRef (habanero) and DataCite
+# DOI resolution via doi.org content negotiation
+# Uses citeproc+json — works for CrossRef, DataCite, and Medra DOIs.
 # ---------------------------------------------------------------------------
 
 
-def _resolve_crossref(doi: str) -> dict | None:
-    """Resolve *doi* via CrossRef. Returns ``{title, authors, year}`` or None."""
-    try:
-        from habanero import Crossref
+def _resolve_doi(doi: str) -> dict | None:
+    """Resolve *doi* via doi.org content negotiation.
 
-        cr = Crossref(mailto="moabb-test@example.com")
+    Returns ``{title, authors, year}`` or ``None`` on failure.
+    """
+    try:
         time.sleep(_REQUEST_DELAY)
-        msg = cr.works(ids=doi)["message"]
-        title = (msg.get("title") or [None])[0]
+        r = httpx.get(
+            f"https://doi.org/{doi}",
+            headers={"Accept": "application/citeproc+json"},
+            follow_redirects=True,
+            timeout=15,
+        )
+        r.raise_for_status()
+        data = r.json()
+        title = data.get("title")
         authors = [
             f"{a.get('given', '')} {a.get('family', '')}".strip()
-            for a in msg.get("author", [])
+            for a in data.get("author", [])
         ]
         year = None
-        for key in ("published-print", "published-online", "created"):
-            parts = msg.get(key, {}).get("date-parts", [[None]])
-            if parts and parts[0] and parts[0][0]:
-                year = parts[0][0]
-                break
+        issued = data.get("issued", {}).get("date-parts", [[None]])
+        if issued and issued[0] and issued[0][0]:
+            year = issued[0][0]
         return {"title": title, "authors": authors, "year": year, "doi": doi}
     except Exception:
         return None
 
 
-def _resolve_datacite(doi: str) -> dict | None:
-    """Resolve *doi* via DataCite. Returns ``{title, authors, year}`` or None."""
-    try:
-        time.sleep(_REQUEST_DELAY)
-        url = f"https://api.datacite.org/dois/{doi}"
-        req = urllib.request.Request(url, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
-        attrs = data.get("data", {}).get("attributes", {})
-        title = (attrs.get("titles") or [{}])[0].get("title")
-        authors = [
-            c.get("name", "")
-            or f"{c.get('givenName', '')} {c.get('familyName', '')}".strip()
-            for c in attrs.get("creators", [])
-        ]
-        year = attrs.get("publicationYear")
-        return {"title": title, "authors": authors, "year": year, "doi": doi}
-    except Exception:
-        return None
-
-
-def _resolve_doi(doi: str) -> dict | None:
-    """Resolve *doi* via the appropriate registry."""
-    if _is_datacite_doi(doi):
-        return _resolve_datacite(doi)
-    return _resolve_crossref(doi)
+def _extract_surnames(authors: list[str]) -> set[str]:
+    """Extract lowercase surnames from author name strings."""
+    out = set()
+    for a in (authors or []):
+        a = a.strip()
+        if not a:
+            continue
+        if ", " in a:
+            # "Last, First" format (DataCite)
+            out.add(a.split(",")[0].strip().lower())
+        else:
+            # "First Last" format (CrossRef)
+            parts = a.split()
+            if parts:
+                out.add(parts[-1].strip(".").lower())
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -289,13 +270,13 @@ class TestDOIConsistency:
 
 
 # ---------------------------------------------------------------------------
-# NETWORK TESTS — resolve DOIs via CrossRef / DataCite
+# NETWORK TESTS — resolve DOIs via doi.org content negotiation
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.network
 class TestDOIResolution:
-    """Every DOI should resolve to a real publication via CrossRef/DataCite."""
+    """Every DOI should resolve via doi.org content negotiation."""
 
     @pytest.mark.parametrize("dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__)
     def test_all_dois_resolve(self, dataset_class):
@@ -333,4 +314,67 @@ class TestDOIResolution:
         assert result.get("title"), (
             f"{dataset_class.__name__}: class DOI {init_doi!r} resolved but has "
             f"no title"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset_class", _REAL_DATASETS, ids=lambda c: c.__name__
+    )
+    def test_class_and_metadata_dois_share_authors(self, dataset_class):
+        """Class DOI must share authors with at least one metadata DOI.
+
+        Compares ``init.doi`` against ``metadata.doi`` and
+        ``metadata.associated_paper`` — at least one must have
+        overlapping author surnames.
+        """
+        dois = _collect_dois(dataset_class)
+        init_doi = dois.get("init.doi")
+        if not init_doi or not _is_doi(init_doi):
+            pytest.skip("No class DOI")
+
+        # If init.doi exactly matches any metadata DOI, it's consistent
+        all_meta = {
+            dois.get(k) for k in ("metadata.doi", "metadata.associated_paper")
+            if dois.get(k)
+        }
+        if init_doi in all_meta:
+            pytest.skip("Class DOI matches a metadata DOI — consistent")
+
+        # Collect metadata DOIs that differ from init for author comparison
+        meta_dois = {
+            k: v for k, v in [
+                ("metadata.doi", dois.get("metadata.doi")),
+                ("metadata.associated_paper", dois.get("metadata.associated_paper")),
+            ]
+            if v and _is_doi(v) and v != init_doi
+        }
+        if not meta_dois:
+            pytest.skip("No differing metadata DOIs to compare")
+
+        init_result = _resolve_doi(init_doi)
+        if init_result is None:
+            pytest.skip(f"Could not resolve init DOI {init_doi!r}")
+
+        init_authors = _extract_surnames(init_result.get("authors"))
+        report_lines = [
+            f"  class DOI {init_doi}: {init_result.get('title')}",
+            f"    authors: {init_result.get('authors')}",
+        ]
+
+        for key, meta_doi in meta_dois.items():
+            meta_result = _resolve_doi(meta_doi)
+            if meta_result is None:
+                continue
+            meta_authors = _extract_surnames(meta_result.get("authors"))
+            if init_authors & meta_authors:
+                return  # found overlap — test passes
+            report_lines.append(
+                f"  {key} {meta_doi}: {meta_result.get('title')}"
+            )
+            report_lines.append(
+                f"    authors: {meta_result.get('authors')}"
+            )
+
+        pytest.fail(
+            f"{dataset_class.__name__}: class DOI shares no authors with "
+            f"any metadata DOI.\n" + "\n".join(report_lines)
         )

--- a/moabb/tests/test_doi_validation.py
+++ b/moabb/tests/test_doi_validation.py
@@ -21,8 +21,8 @@ import re
 import time
 import unicodedata
 
-import httpx
 import pytest
+import requests
 
 from moabb.datasets.metadata.schema import DatasetMetadata
 from moabb.datasets.utils import dataset_list
@@ -113,10 +113,9 @@ def _collect_dois(cls) -> dict[str, str | None]:
 def _resolve_doi(doi: str) -> dict | None:
     try:
         time.sleep(_REQUEST_DELAY)
-        r = httpx.get(
+        r = requests.get(
             f"https://doi.org/{doi}",
             headers={"Accept": "application/citeproc+json"},
-            follow_redirects=True,
             timeout=15,
         )
         r.raise_for_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,6 @@ addopts = "-ra -q"
 python_files = [
     "test_*.py",
 ]
+markers = [
+    "network: tests that require network access (CrossRef/DataCite APIs)",
+]


### PR DESCRIPTION
## Summary

- Fix wrong DOI for BNCI2014_002 (`10.1007/s00500-014-1547-8` → `10.1007/s00500-012-0895-4`) — old DOI returned 404
- Fix BNCI2015_013 docstring reference (Ferrez 2008 → Chavarriaga 2010, matching actual dataset content and BNCI Horizon listing)
- Add `associated_paper_doi` to 10 datasets where the primary DOI is a data repository and the paper DOI differs
- Add missing primary DOI to Wang2016
- Add Hinss2023 Scientific Data reference to Hinss2021 docstring
- Add `test_doi_validation.py` with  systematic DOI validation with doi solver

Closes #976

## Details

### DOI corrections
| Dataset | Field | Old | New |
|---------|-------|-----|-----|
| BNCI2014_002 | doi (docstring + metadata + init) | `10.1007/s00500-014-1547-8` (404) | `10.1007/s00500-012-0895-4` |
| BNCI2015_013 | docstring reference | Ferrez & Millan 2008 (wrong paper) | Chavarriaga & Millán 2010 |

### New `associated_paper_doi` fields
| Dataset | `associated_paper_doi` | Reason |
|---------|----------------------|--------|
| BNCI2014_002 | `10.1007/s00500-012-0895-4` | Paper DOI differs from data DOI |
| BNCI2014_009 | `10.3389/fnhum.2013.00732` | Links dataset to primary paper |
| BNCI2015_001 | `10.1371/journal.pone.0101168` | Links dataset to primary paper |
| BNCI2015_007 | `10.1088/1741-2560/11/2/026009` | Links dataset to primary paper |
| BNCI2015_009 | `10.3389/fnins.2011.00112` | Links dataset to primary paper |
| BNCI2015_012 | `10.3389/fnins.2011.00112` | Links dataset to primary paper |
| BNCI2022_001 | `10.1109/THMS.2020.3038339` | Links dataset to primary paper |
| Thielen2021 | `10.1088/1741-2552/ab4057` | Links dataset to primary paper |
| Cho2017 | `10.1093/gigascience/gix034` | Paper DOI differs from GigaDB data DOI |
| Huebner2018 | `10.1109/MCI.2018.2807039` | Paper DOI differs from Zenodo data DOI |

### New DOI for Wang2016
Added `doi="10.1109/TNSRE.2016.2627556"` — was missing from DocumentationMetadata.

### DOI validation test suite (`test_doi_validation.py`)
- **Offline tests** (no network): DOI format validation, docstring/metadata consistency checks
- **Network tests** (`@pytest.mark.network`): CrossRef resolution via `habanero`, DataCite resolution, publication year and author overlap verification
- Handles both CrossRef DOIs (journals/conferences) and DataCite DOIs (Zenodo, figshare, arXiv)

## Test plan

- [x] `pytest moabb/tests/test_doi_validation.py` — 273 passed, 319 skipped
- [x] `pytest moabb/tests/test_datasets.py` — 139 passed, 3 skipped
- [x] No regressions in existing test suites