### PR TITLE
Fix MOABB_RESULTS default path and docs CI cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,9 +54,9 @@ jobs:
             echo "Removing incomplete extraction: BIDS.zip.unzip"
             rm -rf mne_data/BIDS.zip.unzip
           fi
-          if [ -d mne_data/BrainForm-BIDS-eeg-dataset ] && [ -f mne_data/BrainForm-BIDS-eeg-dataset/.cache-incomplete ]; then
+          if [ -d mne_data/MNE-RomaniBF2025ERP-data ] && [ -f mne_data/MNE-RomaniBF2025ERP-data/.cache-incomplete ]; then
             echo "Removing incomplete BrainForm dataset"
-            rm -rf mne_data/BrainForm-BIDS-eeg-dataset
+            rm -rf mne_data/MNE-RomaniBF2025ERP-data
           fi
 
       - name: Cache docs build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   build_docs:
     runs-on: ${{ matrix.os }}
+    env:
+      MNE_DATA: ${{ github.workspace }}/mne_data
     strategy:
       fail-fast: true
       matrix:
@@ -36,23 +38,25 @@ jobs:
         id: cache-mne_data
         uses: actions/cache/restore@v4
         with:
-          path: ~/mne_data
-          key: doc-${{ runner.os }}-mne-data-v2-${{ github.run_id }}
+          path: |
+            mne_data
+            ~/.mne
+          key: doc-${{ runner.os }}-mne-data-v3-${{ github.run_id }}
           restore-keys: |
-            doc-${{ runner.os }}-mne-data-v2-
+            doc-${{ runner.os }}-mne-data-v3-
 
       - name: Clean up corrupted cache
         run: |
           echo "Cache matched key: ${{ steps.cache-mne_data.outputs.cache-matched-key }}"
-          mkdir -p ~/mne_data
+          mkdir -p mne_data
           # Remove any incomplete extractions (e.g., BIDS.zip.unzip alongside final folder)
-          if [ -d ~/mne_data/BIDS.zip.unzip ]; then
+          if [ -d mne_data/BIDS.zip.unzip ]; then
             echo "Removing incomplete extraction: BIDS.zip.unzip"
-            rm -rf ~/mne_data/BIDS.zip.unzip
+            rm -rf mne_data/BIDS.zip.unzip
           fi
-          if [ -d ~/mne_data/BrainForm-BIDS-eeg-dataset ] && [ -f ~/mne_data/BrainForm-BIDS-eeg-dataset/.cache-incomplete ]; then
+          if [ -d mne_data/BrainForm-BIDS-eeg-dataset ] && [ -f mne_data/BrainForm-BIDS-eeg-dataset/.cache-incomplete ]; then
             echo "Removing incomplete BrainForm dataset"
-            rm -rf ~/mne_data/BrainForm-BIDS-eeg-dataset
+            rm -rf mne_data/BrainForm-BIDS-eeg-dataset
           fi
 
       - name: Cache docs build
@@ -66,13 +70,29 @@ jobs:
         run: |
           uv pip install -e .[docs,deeplearning,optuna,external,carbonemission]
 
+      - name: Configure MOABB download directory
+        run: |
+          python -c "
+          from moabb.utils import set_download_dir
+          from mne import set_config
+          import os
+          mne_data = os.environ['MNE_DATA']
+          set_download_dir(mne_data)
+          set_config('MOABB_RESULTS', mne_data)
+          print(f'MNE_DATA set to: {mne_data}')
+          "
+
       - name: Pre-download datasets (cold cache only)
         if: steps.cache-mne_data.outputs.cache-matched-key == ''
         run: |
           echo "Cache is cold, pre-downloading datasets with delays to avoid rate limiting..."
           python << 'EOF'
+          import os
           import sys
           import time
+
+          from moabb.utils import set_download_dir
+          set_download_dir(os.environ["MNE_DATA"])
 
           # All datasets used in examples that download from Zenodo
           # Each entry: (module_path, class_name, subjects)
@@ -168,8 +188,10 @@ jobs:
         if: success()
         uses: actions/cache/save@v4
         with:
-          path: ~/mne_data
-          key: doc-${{ runner.os }}-mne-data-v2-${{ github.run_id }}
+          path: |
+            mne_data
+            ~/.mne
+          key: doc-${{ runner.os }}-mne-data-v3-${{ github.run_id }}
 
       # Create an artifact of the html output.
       - uses: actions/upload-artifact@v4

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -75,6 +75,7 @@ Bugs
 - Fix double µV-to-V conversion in BNCI2003-004 and BNCI2015-006: data loaded in microvolts was labeled as volts without unit conversion, causing a second scaling during EDF export via ``mne_bids`` (by `Bruno Aristimunha`_)
 - Fix ``Beetl2021_A`` and ``Beetl2021_B`` 403 Forbidden errors by skipping Figshare API calls when data already exists locally, and fix double-nested zip extraction directory structure (:gh:`969` by `Bruno Aristimunha`_)
 - Fix :class:`moabb.datasets.RomaniBF2025ERP` to follow MOABB nomenclature pattern by using dynamic folder name ``MNE-{code}-data`` instead of hardcoded folder name. Automatically migrates legacy folder ``BrainForm-BIDS-eeg-dataset`` to new nomenclature for backward compatibility (by `Bruno Aristimunha`_)
+- Fix ``MOABB_RESULTS`` default path to respect ``MNE_DATA`` configuration instead of hardcoding ``~/mne_data``, and fix docs CI cache to use workspace-relative ``MNE_DATA`` path and cache ``~/.mne`` config directory (by `Bruno Aristimunha`_)
 
 Code health
 ~~~~~~~~~~~

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -92,7 +92,12 @@ class Results:
 
         if hdf5_path is None:
             if get_config("MOABB_RESULTS") is None:
-                set_config("MOABB_RESULTS", osp.join(osp.expanduser("~"), "mne_data"))
+                # Use MNE_DATA if configured (env var or config file),
+                # otherwise fall back to ~/mne_data
+                mne_data = get_config("MNE_DATA")
+                if mne_data is None:
+                    mne_data = osp.join(osp.expanduser("~"), "mne_data")
+                set_config("MOABB_RESULTS", mne_data)
             self.mod_dir = _get_path(None, "MOABB_RESULTS", "results")
             # was previously stored in the moabb source file folder:
             # self.mod_dir = osp.dirname(osp.abspath(inspect.getsourcefile(moabb)))


### PR DESCRIPTION
## Summary

- **Fix `MOABB_RESULTS` default path** in `results.py` to respect the `MNE_DATA` configuration (env var or config file) instead of hardcoding `~/mne_data`, preventing CI cache misses and inconsistent behavior when users configure a custom data directory
- **Fix docs CI cache** to use workspace-relative `MNE_DATA` path, cache `~/.mne` config directory alongside data, call `set_download_dir()` to align MOABB's download path, and bump cache key (`v2` → `v3`) to invalidate stale caches

## Test plan

- [ ] Verify docs CI workflow runs successfully with the new cache paths
- [ ] Confirm cache is restored on subsequent runs (check "Restore MNE Data Cache" step output)
- [ ] Verify `~/.mne` config directory is included in the cache
- [ ] Test that `MOABB_RESULTS` respects `MNE_DATA` when set via env var or config file