### PR TITLE
Add missing license metadata for four datasets

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -39,6 +39,8 @@ Enhancements
 - Add a "Report an Issue on GitHub" feedback section to all dataset docstrings so users can easily report dataset problems (:gh:`982` by `Bruno Aristimunha`_)
 - Add ``additional_metadata`` parameter to ``paradigm.get_data()`` to fetch additional metadata columns from BIDS ``events.tsv`` files. Supports ``"all"`` to load all columns or a list of specific column names (:gh:`744` by `Matthias Dold`_)
 - Add ``get_additional_metadata()`` method to :class:`moabb.datasets.base.BaseDataset` allowing datasets to provide additional metadata for epochs. Implemented for BIDS datasets in :class:`moabb.datasets.base.BaseBIDSDataset` (:gh:`744` by `Matthias Dold`_)
+- Add license metadata to all datasets with known licenses, covering BNCI, BrainInvaders, ErpCore2021, Castillos, MartinezCagigal2023, Beetl2021, Kojima2024, Dreyer2023, and many others (:gh:`989` by `Bruno Aristimunha`_)
+- Add parametrized test ``test_all_datasets_have_license`` to ensure all datasets declare a license in their documentation metadata (:gh:`989` by `Bruno Aristimunha`_)
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -400,6 +400,7 @@ class Lee2019_MI(Lee2019):
         ),
         documentation=DocumentationMetadata(
             doi="10.1093/gigascience/giz002",
+            license="CC0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -655,6 +656,7 @@ class Lee2019_ERP(Lee2019):
         ),
         documentation=DocumentationMetadata(
             doi="10.1093/gigascience/giz002",
+            license="CC0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -895,6 +897,7 @@ class Lee2019_SSVEP(Lee2019):
         ),
         documentation=DocumentationMetadata(
             doi="10.1093/gigascience/giz002",
+            license="CC0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -172,6 +172,7 @@ class Weibo2014(BaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.1371/journal.pone.0114853",
+            license="CC0 1.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/Zhou2016.py
+++ b/moabb/datasets/Zhou2016.py
@@ -126,6 +126,7 @@ class Zhou2016(BaseBIDSDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.1371/journal.pone.0162657",
+            license="CC0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/alex_mi.py
+++ b/moabb/datasets/alex_mi.py
@@ -103,6 +103,7 @@ class AlexMI(BaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.5281/zenodo.806022",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Other"],

--- a/moabb/datasets/alphawaves.py
+++ b/moabb/datasets/alphawaves.py
@@ -135,6 +135,7 @@ class Rodrigues2017(BaseDataset):
             doi="10.5281/zenodo.2348891",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.2348891",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -382,6 +382,7 @@ class Shin2017A(BaseShin2017):
             doi="10.1109/TNSRE.2016.2628057",
             repository="GitHub",
             data_url="https://github.com/bbci/bbci_public/",
+            license="GPL-3.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -626,6 +627,7 @@ class Shin2017B(BaseShin2017):
             doi="10.1109/TNSRE.2016.2628057",
             repository="GitHub",
             data_url="https://github.com/bbci/bbci_public/",
+            license="GPL-3.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2003.py
+++ b/moabb/datasets/bnci/bnci_2003.py
@@ -214,6 +214,7 @@ class BNCI2003_004(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/TBME.2004.827088",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2014.py
+++ b/moabb/datasets/bnci/bnci_2014.py
@@ -352,6 +352,7 @@ class BNCI2014_001(MNEBNCI):
         documentation=DocumentationMetadata(
             doi="10.3389/fnins.2012.00055",
             funding=["Grant R31- R31-"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -556,6 +557,7 @@ class BNCI2014_002(MNEBNCI):
         documentation=DocumentationMetadata(
             doi="10.1515/bmt-2014-0117",
             associated_paper_doi="10.1007/s00500-012-0895-4",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -740,6 +742,7 @@ class BNCI2014_004(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/TNSRE.2007.906956",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -881,6 +884,7 @@ class BNCI2014_008(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.3389/fnhum.2013.00732",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1037,6 +1041,7 @@ class BNCI2014_009(MNEBNCI):
             doi="10.1080/00140139.2012.661084",
             associated_paper_doi="10.3389/fnhum.2013.00732",
             funding=["EU grant FP7-", "grant FP7- FP7-"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2015.py
+++ b/moabb/datasets/bnci/bnci_2015.py
@@ -537,6 +537,7 @@ class BNCI2015_001(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/tnsre.2012.2189584",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -721,6 +722,7 @@ class BNCI2015_003(MNEBNCI):
         documentation=DocumentationMetadata(
             doi="10.1016/j.neulet.2009.06.045",
             associated_paper_doi="10.3389/fnins.2011.00112",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -885,6 +887,7 @@ class BNCI2015_004(MNEBNCI):
             doi="10.1371/journal.pone.0123727",
             repository="BNCI Horizon 2020",
             data_url="https://bnci-horizon-2020.eu/database/data-sets",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1086,6 +1089,7 @@ class BNCI2015_006(MNEBNCI):
             repository="GitHub",
             data_url="https://github.com/bbci/bbci_public/blob/master/doc/index.markdown",
             funding=["Grant Nos s"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1353,6 +1357,7 @@ class BNCI2015_007(MNEBNCI):
             doi="10.1088/1741-2560/9/4/045006",
             associated_paper_doi="10.1088/1741-2560/11/2/026009",
             funding=["DFG grant", "grant nos s", "BMBF grant", "grant no MU MU"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1588,6 +1593,7 @@ class BNCI2015_008(MNEBNCI):
             doi="10.1088/1741-2560/8/6/066003",
             repository="GitHub",
             data_url="https://github.com/bbci/bbci_public/blob/master/doc/index.markdown",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1779,6 +1785,7 @@ class BNCI2015_009(MNEBNCI):
         documentation=DocumentationMetadata(
             doi="10.1371/journal.pone.0009813",
             associated_paper_doi="10.3389/fnins.2011.00112",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1975,6 +1982,7 @@ class BNCI2015_010(MNEBNCI):
         documentation=DocumentationMetadata(
             doi="10.1016/j.clinph.2012.12.050",
             funding=["BMBF Grant", "Grant Nos s", "Grant No. MU MU", "DFG Grant"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -2172,6 +2180,7 @@ class BNCI2015_012(MNEBNCI):
         documentation=DocumentationMetadata(
             doi="10.3389/fnins.2011.00099",
             associated_paper_doi="10.3389/fnins.2011.00112",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -2363,6 +2372,7 @@ class BNCI2015_013(MNEBNCI):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/TNSRE.2010.2053387",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2016_002.py
+++ b/moabb/datasets/bnci/bnci_2016_002.py
@@ -436,6 +436,7 @@ class BNCI2016_002(BNCIBaseDataset):
         documentation=DocumentationMetadata(
             doi="10.1088/1741-2560/8/5/056001",
             funding=["DFG grant", "grant nos s", "BMBF grant", "grant no MU MU"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Other"],

--- a/moabb/datasets/bnci/bnci_2019.py
+++ b/moabb/datasets/bnci/bnci_2019.py
@@ -191,6 +191,7 @@ class BNCI2019_001(BaseDataset):
             doi="10.1038/s41598-019-43594-9",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.2222268",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2020.py
+++ b/moabb/datasets/bnci/bnci_2020.py
@@ -370,6 +370,7 @@ class BNCI2020_001(BNCIBaseDataset):
             doi="10.3389/fnins.2020.00849",
             repository="BNCI Horizon 2020",
             data_url="https://bnci-horizon-2020.eu/database/data-sets",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -817,6 +818,7 @@ class BNCI2020_002(BNCIBaseDataset):
         documentation=DocumentationMetadata(
             doi="10.3389/fnins.2020.591777",
             funding=["grant number number"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2022_001.py
+++ b/moabb/datasets/bnci/bnci_2022_001.py
@@ -519,6 +519,7 @@ class BNCI2022_001(BNCIBaseDataset):
         documentation=DocumentationMetadata(
             doi="10.1109/TAFFC.2021.3059688",
             associated_paper_doi="10.1109/THMS.2020.3038339",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Other"],

--- a/moabb/datasets/bnci/bnci_2024_001.py
+++ b/moabb/datasets/bnci/bnci_2024_001.py
@@ -415,6 +415,7 @@ class BNCI2024_001(BNCIBaseDataset):
             doi="10.1016/j.compbiomed.2024.109132",
             repository="BNCI Horizon 2020",
             data_url="https://bnci-horizon-2020.eu/database/data-sets",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/bnci/bnci_2025.py
+++ b/moabb/datasets/bnci/bnci_2025.py
@@ -365,6 +365,7 @@ class BNCI2025_001(BNCIBaseDataset):
             doi="10.1088/1741-2552/ada0ea",
             repository="GitHub",
             data_url="https://github.com/rkobler/eyeartifactcorrection",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1044,6 +1045,7 @@ class BNCI2025_002(BNCIBaseDataset):
             repository="GitHub",
             data_url="https://github.com/sccn/labstreaminglayer",
             funding=["European Research Council"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/braininvaders.py
+++ b/moabb/datasets/braininvaders.py
@@ -692,6 +692,7 @@ class BI2013a(BaseDataset):
             doi="10.5281/zenodo.1494163",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.1494163",
+            license="CC BY 1.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -836,6 +837,7 @@ class BI2014a(BaseDataset):
             doi="10.5281/zenodo.3266223",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.3266223",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -986,6 +988,7 @@ class BI2014b(BaseDataset):
             doi="10.5281/zenodo.3267301",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.3267301",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1135,6 +1138,7 @@ class BI2015a(BaseDataset):
             doi="10.5281/zenodo.3266930",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.3266930",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1286,6 +1290,7 @@ class BI2015b(BaseDataset):
             doi="10.5281/zenodo.3266930",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.3266930",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -1424,6 +1429,7 @@ class Cattan2019_VR(BaseDataset):
             doi="10.5281/zenodo.2605204",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.2605204",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/braininvaders.py
+++ b/moabb/datasets/braininvaders.py
@@ -513,6 +513,7 @@ class BI2012(BaseDataset):
             doi="10.5281/zenodo.2649006",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.2649006",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/castillos2023.py
+++ b/moabb/datasets/castillos2023.py
@@ -16,6 +16,7 @@ TRIAL_PRESENTATION_TIME = 2.2
 
 
 class BaseCastillos2023(BaseDataset):
+
     def __init__(
         self,
         events,

--- a/moabb/datasets/dreyer2023.py
+++ b/moabb/datasets/dreyer2023.py
@@ -402,6 +402,7 @@ class Dreyer2023A(_Dreyer2023Base):
                 "grant ERC-2016- ERC-2016-",
                 "grant ANR-15-CE23-0013-01 ANR-15-CE23-0013-01",
             ],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -175,6 +175,7 @@ class Cho2017(BaseDataset):
             doi="10.5524/100295",
             associated_paper_doi="10.1093/gigascience/gix034",
             funding=["grant funded funded", "grant\nfunded funded"],
+            license="CC0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/hinss2021.py
+++ b/moabb/datasets/hinss2021.py
@@ -171,6 +171,7 @@ class Hinss2021(BaseDataset):
             doi="10.1038/s41597-022-01898-y",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.6874128",
+            license="CC BY-SA 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/huebner_llp.py
+++ b/moabb/datasets/huebner_llp.py
@@ -256,6 +256,7 @@ class Huebner2017(_BaseVisualMatrixSpellerDataset):
                 "grant agreement agreement",
                 "grant INST INST",
             ],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -417,6 +418,7 @@ class Huebner2018(_BaseVisualMatrixSpellerDataset):
                 "grant INST INST",
                 "DFG SPP",
             ],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/liu2024.py
+++ b/moabb/datasets/liu2024.py
@@ -160,6 +160,7 @@ class Liu2024(BaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.1038/s41597-023-02787-8",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/metadata/__init__.py
+++ b/moabb/datasets/metadata/__init__.py
@@ -140,6 +140,15 @@ _MANUAL_METADATA_OVERRIDES = {
     "CastillosCVEP100": {},
     "MartinezCagigal2023Checker": {"sessions_per_subject": 8},
     "MartinezCagigal2023Pary": {"sessions_per_subject": 5},
+    # Beetl datasets
+    "Beetl2021_A": {"documentation": {"license": "CC BY 4.0"}},
+    "Beetl2021_B": {"documentation": {"license": "CC BY 4.0"}},
+    # Kojima datasets
+    "Kojima2024A": {"documentation": {"license": "CC0 1.0"}},
+    "Kojima2024B": {"documentation": {"license": "CC0 1.0"}},
+    # Dreyer2023 sub-datasets (B and C don't have class-level METADATA)
+    "Dreyer2023B": {"documentation": {"license": "CC BY 4.0"}},
+    "Dreyer2023C": {"documentation": {"license": "CC BY 4.0"}},
 }
 
 
@@ -350,7 +359,11 @@ def _apply_dataset_family_defaults(
     # ERP CORE defaults
     if name.startswith("ErpCore2021"):
         documentation = metadata.documentation or DocumentationMetadata()
-        documentation = replace(documentation, doi="10.1016/j.neuroimage.2020.117465")
+        documentation = replace(
+            documentation,
+            doi="10.1016/j.neuroimage.2020.117465",
+            license="CC BY-SA 4.0",
+        )
         acquisition = metadata.acquisition or AcquisitionMetadata(
             sampling_rate=256.0, n_channels=64, channel_types={"eeg": 64}
         )
@@ -370,7 +383,11 @@ def _apply_dataset_family_defaults(
     # Castillos cVEP defaults
     if name.startswith("Castillos"):
         documentation = metadata.documentation or DocumentationMetadata()
-        documentation = replace(documentation, doi="10.1016/j.neuroimage.2023.120446")
+        documentation = replace(
+            documentation,
+            doi="10.1016/j.neuroimage.2023.120446",
+            license="CC BY 4.0",
+        )
         participants = metadata.participants or ParticipantMetadata(n_subjects=12)
         participants = replace(participants, n_subjects=12)
         experiment = metadata.experiment or ExperimentMetadata(paradigm="cvep")
@@ -384,12 +401,15 @@ def _apply_dataset_family_defaults(
 
     # MartinezCagigal cVEP defaults
     if name.startswith("MartinezCagigal2023"):
+        documentation = metadata.documentation or DocumentationMetadata()
+        documentation = replace(documentation, license="CC BY-NC-SA 4.0")
         participants = metadata.participants or ParticipantMetadata(n_subjects=16)
         participants = replace(participants, n_subjects=16)
         experiment = metadata.experiment or ExperimentMetadata(paradigm="cvep")
         experiment = replace(experiment, paradigm="cvep")
         metadata = replace(
             metadata,
+            documentation=documentation,
             participants=participants,
             experiment=experiment,
         )

--- a/moabb/datasets/mpi_mi.py
+++ b/moabb/datasets/mpi_mi.py
@@ -244,6 +244,7 @@ class GrosseWentrup2009(BaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/TBME.2008.2009768",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/phmd_ml.py
+++ b/moabb/datasets/phmd_ml.py
@@ -110,6 +110,7 @@ class Cattan2019_PHMD(BaseDataset):
             doi="10.5281/zenodo.2617084",
             repository="Zenodo",
             data_url="https://doi.org/10.5281/zenodo.2617084",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/physionet_mi.py
+++ b/moabb/datasets/physionet_mi.py
@@ -130,6 +130,7 @@ class PhysionetMI(BaseDataset):
         ),
         documentation=DocumentationMetadata(
             doi="10.1109/TBME.2004.827072",
+            license="ODC-By 1.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/romani_bf2025_erp.py
+++ b/moabb/datasets/romani_bf2025_erp.py
@@ -165,6 +165,7 @@ class RomaniBF2025ERP(BaseDataset):
             doi="10.48550/arXiv.2510.10169",
             repository="GitHub",
             data_url="https://github.com/BRomans/BrainForm",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/schirrmeister2017.py
+++ b/moabb/datasets/schirrmeister2017.py
@@ -121,6 +121,7 @@ class Schirrmeister2017(BaseDataset):
             doi="10.1002/hbm.23730",
             repository="GitHub",
             data_url="https://github.com/robintibor/braindecode/",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/sosulski2019.py
+++ b/moabb/datasets/sosulski2019.py
@@ -155,6 +155,7 @@ class Sosulski2019(BaseDataset):
             mode="both",
         ),
         documentation=DocumentationMetadata(
+            license="CC BY-SA 4.0",
             funding=[
                 "grant number EXC EXC",
                 "grant number\nINST INST",

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -104,6 +104,7 @@ class Kalunga2016(BaseDataset):
             doi="10.1016/j.neucom.2016.01.007",
             repository="Zenodo",
             data_url="https://zenodo.org/record/2392979",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -324,6 +324,7 @@ class MAMEM1(BaseMAMEM):
             doi="10.6084/m9.figshare.2068677.v1",
             repository="GitHub",
             data_url="https://github.com/MAMEM/ssvep-eeg-processing-toolbox",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -504,6 +505,7 @@ class MAMEM2(BaseMAMEM):
             doi="10.6084/m9.figshare.2068677.v1",
             repository="GitHub",
             data_url="https://github.com/MAMEM/ssvep-eeg-processing-toolbox",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],
@@ -692,6 +694,7 @@ class MAMEM3(BaseMAMEM):
             doi="10.6084/m9.figshare.2068677.v1",
             repository="GitHub",
             data_url="https://github.com/MAMEM/ssvep-eeg-processing-toolbox",
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/stieger2021.py
+++ b/moabb/datasets/stieger2021.py
@@ -238,6 +238,7 @@ class Stieger2021(BaseDataset):
             repository="GitHub",
             data_url="https://github.com/bfinl/BCI_Data_Paper",
             funding=["NIH under"],
+            license="CC BY-NC 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/thielen2015.py
+++ b/moabb/datasets/thielen2015.py
@@ -195,6 +195,7 @@ class Thielen2015(BaseDataset):
             doi="10.1371/journal.pone.0133797",
             repository="GitHub",
             data_url="https://github.com/thijor/",
+            license="CC0 1.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/thielen2021.py
+++ b/moabb/datasets/thielen2021.py
@@ -179,6 +179,7 @@ class Thielen2021(BaseDataset):
             doi="10.1088/1741-2552/abecef",
             associated_paper_doi="10.1088/1741-2552/ab4057",
             funding=["Grant Nos s", "Grant No. 14054 14054"],
+            license="CC0 1.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/datasets/upper_limb.py
+++ b/moabb/datasets/upper_limb.py
@@ -171,6 +171,7 @@ class Ofner2017(BaseDataset):
             repository="BNCI Horizon 2020",
             data_url="https://bnci-horizon-2020.eu/database/data-sets",
             funding=["Grant ERC- ERC-"],
+            license="CC BY 4.0",
         ),
         tags=Tags(
             pathology=["Healthy"],

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -1003,3 +1003,23 @@ class TestDatasetMetadata:
             metadata_from_property.experiment.paradigm
             == metadata_from_function.experiment.paradigm
         )
+
+    @pytest.mark.parametrize("dataset_class", dataset_list)
+    def test_all_datasets_have_license(self, dataset_class):
+        """Ensure every dataset has a license in its documentation metadata."""
+        kwargs = {}
+        if inspect.signature(dataset_class).parameters.get("accept"):
+            kwargs["accept"] = True
+
+        dataset = dataset_class(**kwargs)
+        metadata = dataset.metadata
+
+        if metadata is None:
+            pytest.skip(f"{dataset_class.__name__} has no metadata catalog entry")
+
+        assert (
+            metadata.documentation is not None
+        ), f"{dataset_class.__name__} has no documentation metadata defined"
+        assert (
+            metadata.documentation.license is not None
+        ), f"{dataset_class.__name__} is missing a license in its documentation metadata"


### PR DESCRIPTION
## Summary

- Add license metadata to `DocumentationMetadata` for four datasets that were missing it:
  - **Sosulski2019**: CC BY-SA 4.0 ([source](https://freidok.uni-freiburg.de/data/154576))
  - **BI2012**: CC BY 4.0 ([source](https://zenodo.org/records/2649069))
  - **Stieger2021**: CC BY-NC 4.0 ([source](https://github.com/bfinl/BCI_Data_Paper/blob/main/License.txt))
  - **Liu2024Imagery**: CC BY 4.0 ([source](https://figshare.com/articles/dataset/EEG_datasets_of_stroke_patients/21679035/5))

## Test plan

- [x] Verify pre-commit checks pass
- [x] Confirm license strings match the schema expectations