### PR TITLE
Fix Liu2024 download failure by using correct Figshare domain

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -86,6 +86,7 @@ Bugs
 - Fix :class:`moabb.datasets.RomaniBF2025ERP` to follow MOABB nomenclature pattern by using dynamic folder name ``MNE-{code}-data`` instead of hardcoded folder name. Automatically migrates legacy folder ``BrainForm-BIDS-eeg-dataset`` to new nomenclature for backward compatibility (by `Bruno Aristimunha`_)
 - Fix ``MOABB_RESULTS`` default path to respect ``MNE_DATA`` configuration instead of hardcoding ``~/mne_data``, and fix docs CI cache to use workspace-relative ``MNE_DATA`` path and cache ``~/.mne`` config directory (by `Bruno Aristimunha`_)
 - Fix docs CI cache: set ``MNE_DATA`` env var and persist ``~/.mne`` config directory so dataset paths survive cache restore (by `Bruno Aristimunha`_)
+- Fix :class:`moabb.datasets.Liu2024` download failure by switching Figshare URLs from ``figshare.com/ndownloader`` to ``ndownloader.figshare.com`` and adding ``BadZipFile`` recovery for corrupted cached downloads (:gh:`992` by `Bruno Aristimunha`_)
 
 Code health
 ~~~~~~~~~~~

--- a/moabb/datasets/liu2024.py
+++ b/moabb/datasets/liu2024.py
@@ -6,6 +6,7 @@ import warnings
 import zipfile as z
 from pathlib import Path
 from typing import Any, Dict, Tuple
+from zipfile import BadZipFile
 
 import mne
 import numpy as np
@@ -36,11 +37,11 @@ from moabb.datasets.utils import stim_channels_with_selected_ids
 
 
 # Link to the raw data
-LIU2024_URL = "https://figshare.com/ndownloader/files/38516654"
+LIU2024_URL = "https://ndownloader.figshare.com/files/38516654"
 
 # Links to the electrodes and events information files
-LIU2024_ELECTRODES = "https://figshare.com/ndownloader/files/38516078"
-LIU2024_EVENTS = "https://figshare.com/ndownloader/files/38516084"
+LIU2024_ELECTRODES = "https://ndownloader.figshare.com/files/38516078"
+LIU2024_EVENTS = "https://ndownloader.figshare.com/files/38516084"
 
 
 class Liu2024(BaseDataset):
@@ -284,8 +285,15 @@ class Liu2024(BaseDataset):
 
         # Extract the zip file if it hasn't been extracted yet
         if not (path_folder / "edffile").is_dir():
-            zip_ref = z.ZipFile(path_zip, "r")
-            zip_ref.extractall(path_folder)
+            try:
+                with z.ZipFile(path_zip, "r") as zip_ref:
+                    zip_ref.extractall(path_folder)
+            except BadZipFile:
+                warnings.warn("Corrupted zip file detected, re-downloading...")
+                path_zip.unlink(missing_ok=True)
+                path_zip = Path(dl.data_dl(LIU2024_URL, self.code, force_update=True))
+                with z.ZipFile(path_zip, "r") as zip_ref:
+                    zip_ref.extractall(path_folder)
 
         subject_paths = []
         sub = f"sub-{subject:02d}"


### PR DESCRIPTION
## Summary
- Fix download URLs for Liu2024 dataset by switching from `figshare.com/ndownloader` to `ndownloader.figshare.com` (the old domain is blocked by AWS WAF, returning a 202 challenge HTML response instead of the zip file)
- Add `BadZipFile` exception handling to automatically re-download corrupted/invalid zip files cached from previous failed attempts

Fixes #992

## Test plan
- [x] Existing Liu2024 tests pass (7 passed, 2 skipped)
- [ ] Manually verify download works: `Liu2024().data_path(1)`