### PR TITLE
Remove redundant autoattribute METADATA from MartinezCagigal docstrings

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -112,6 +112,7 @@ Bugs
 - Fix docs CI cache: set ``MNE_DATA`` env var and persist ``~/.mne`` config directory so dataset paths survive cache restore (by `Bruno Aristimunha`_)
 - Fix CI dataset cache reuse across commits/PR updates by using stable cache keys and default-branch cache saves for docs/tests workflows, avoiding repeated dataset downloads (by `Bruno Aristimunha`_)
 - Fix :class:`moabb.datasets.Liu2024` download failure by switching Figshare URLs from ``figshare.com/ndownloader`` to ``ndownloader.figshare.com`` and adding ``BadZipFile`` recovery for corrupted cached downloads (:gh:`992` by `Bruno Aristimunha`_)
+- Remove redundant ``autoattribute METADATA`` from MartinezCagigal2023 Checker and Pary docstrings (:gh:`1022` by `Bruno Aristimunha`_)
 - Fix TRCA Riemannian mean convergence failure by regularizing ill-conditioned cross-covariance matrices in :class:`moabb.pipelines.classification.SSVEP_TRCA`. Eigenvalue clamping bounds the condition number, eliminating ``Convergence not reached`` and ``invalid value encountered in log`` warnings (by `Bruno Aristimunha`_)
 - Fix SSVEP CCA-family estimator consistency and eCCA formulation:
   :class:`moabb.pipelines.classification.SSVEP_CCA`,

--- a/moabb/datasets/martinezcagigal2023_checker_cvep.py
+++ b/moabb/datasets/martinezcagigal2023_checker_cvep.py
@@ -55,8 +55,6 @@ class MartinezCagigal2023Checker(BaseDataset):
     """Checkerboard m-sequence-based c-VEP dataset from
     Martínez-Cagigal et al. (2025) and Fernández-Rodríguez et al. (2023).
 
-    .. autoattribute:: METADATA
-
     **Dataset Description**
 
     This dataset, accessible at [1]_, was originally recorded for study [2]_,

--- a/moabb/datasets/martinezcagigal2023_pary_cvep.py
+++ b/moabb/datasets/martinezcagigal2023_pary_cvep.py
@@ -76,8 +76,6 @@ log = logging.getLogger(__name__)
 class MartinezCagigal2023Pary(BaseDataset):
     """P-ary m-sequence-based c-VEP dataset from Martínez-Cagigal et al. (2023)
 
-    .. autoattribute:: METADATA
-
     **Dataset Description**
 
     This dataset was originally recorded for study [1]_, which evaluated


### PR DESCRIPTION
## Summary
- Removed `.. autoattribute:: METADATA` directive from `MartinezCagigal2023Checker` and `MartinezCagigal2023Pary` docstrings
- This directive caused Sphinx to dump the raw `DatasetMetadata` dataclass representation into the Overview tab, producing messy documentation output
- The metadata is already correctly rendered by `dataset_timeline_ext.py` via `_get_dataset_info()` in the header card and visual summary grid — no other dataset uses this directive

## Test plan
- [x] Verified no other files contain `.. autoattribute:: METADATA`
- [x] Built docs locally with `make html-noplot` — build succeeds
- [ ] Confirm the Overview tab for both datasets shows clean description text without raw metadata dump
- [ ] Confirm header card and visual grid still display metadata correctly