### PR TITLE
Add trial introspection tools for Stieger2021 variable-length epochs

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -19,6 +19,7 @@ Version 1.5  (Source - GitHub)
 
 Enhancements
 ~~~~~~~~~~~~
+- Add :meth:`~moabb.datasets.Stieger2021.get_trial_info` and :meth:`~moabb.datasets.Stieger2021.suggest_interval` methods to help users choose an optimal epoch interval for variable-length trials, and preserve per-trial ``triallength`` metadata through BIDS conversion via annotation extras (:gh:`816`)
 - Redesign dataset API pages with a structured snapshot card, visual summary blocks, HED-tag visualization, benchmark highlights, citation/public API cards, and responsive mobile improvements (:gh:`1000` by `Bruno Aristimunha`_)
 - Add GA4 pageview metrics and popularity ranking to dataset documentation cards, with inline sparkline charts showing 90-day traffic trends (by `Bruno Aristimunha`_)
 - Polish API reference page with color-coded concept highlights, section breaks, table styling, and scoped CSS to avoid affecting other pages (by `Bruno Aristimunha`_)
@@ -80,6 +81,8 @@ Requirements
 
 Bugs
 ~~~~
+- Fix trial acceptance condition in :class:`moabb.datasets.Stieger2021` that allowed epochs
+  to extend beyond actual motor imagery duration into adjacent trials' resting periods (:gh:`816`)
 - Fix DOI escaping in "See DOI" fallback link on dataset citation cards (:gh:`1000` by `Bruno Aristimunha`_)
 - Prefer paper DOI over data DOI in dataset citation card when both are available (:gh:`1000` by `Bruno Aristimunha`_)
 - Fix timeline SVG card artifact caused by link styling on dataset pages (by `Bruno Aristimunha`_)

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Dict, Type
 
 import mne
 import mne_bids
+import pandas as pd
 from numpy import load as np_load
 from numpy import save as np_save
 
@@ -2398,6 +2399,11 @@ class BIDSInterfaceRawEDF(BIDSInterfaceBase):
                 'Encountered data in "double" format',
                 RuntimeWarning,
             )
+            # Save annotation extras before write_raw_bids (which may
+            # strip them).  We patch events.tsv afterwards.
+            ann_extras = getattr(raw.annotations, "extras", None)
+            has_extras = ann_extras is not None and any(ann_extras)
+
             mne_bids.write_raw_bids(
                 raw,
                 bids_path,
@@ -2407,6 +2413,26 @@ class BIDSInterfaceRawEDF(BIDSInterfaceBase):
                 overwrite=False,
                 verbose=self.verbose,
             )
+
+            # Append per-event metadata from annotation extras (e.g.
+            # triallength for Stieger2021) as extra columns in events.tsv.
+            if has_extras:
+                events_path = bids_path.copy().update(suffix="events", extension=".tsv")
+                events_fpath = events_path.fpath
+                if events_fpath.exists():
+                    df = pd.read_csv(str(events_fpath), sep="\t")
+                    extras_df = pd.DataFrame(ann_extras)
+                    if len(extras_df) == len(df):
+                        for col in extras_df.columns:
+                            df[col] = extras_df[col]
+                        df.to_csv(str(events_fpath), sep="\t", index=False, na_rep="n/a")
+                    else:
+                        log.warning(
+                            "Annotation extras length (%d) does not match "
+                            "events.tsv rows (%d); skipping extras.",
+                            len(extras_df),
+                            len(df),
+                        )
 
         # Post-write enrichment: update EEG sidecar with metadata fields
         if metadata is not None:

--- a/moabb/datasets/preprocessing.py
+++ b/moabb/datasets/preprocessing.py
@@ -504,6 +504,21 @@ class SetRawAnnotations(FixedTransformer):
         offset = int(self.interval[0] * raw.info["sfreq"])
         stim_channels = mne.utils._get_stim_channel(None, raw.info, raise_error=False)
         has_annotation_extras = False
+
+        # Check for annotation extras before events extraction potentially
+        # destroys the original annotations.  This works regardless of
+        # whether a stim channel is present.
+        orig_extras = (
+            getattr(raw.annotations, "extras", None) if raw.annotations else None
+        )
+        if orig_extras is not None and any(orig_extras):
+            has_annotation_extras = True
+            sfreq = raw.info["sfreq"]
+            extras_by_sample = {}
+            for ann, extra in zip(raw.annotations, orig_extras):
+                sample = int(round(ann["onset"] * sfreq)) + raw.first_samp
+                extras_by_sample[sample] = extra
+
         if len(stim_channels) == 0:
             if raw.annotations is None:
                 log.warning(
@@ -514,16 +529,6 @@ class SetRawAnnotations(FixedTransformer):
                 raise ValueError(
                     "When no stim channel is present, event_id values must be integers (not lists)."
                 )
-            # Build lookup of extras by sample position before events extraction
-            # destroys the original annotations
-            orig_extras = getattr(raw.annotations, "extras", None)
-            if orig_extras is not None and any(orig_extras):
-                has_annotation_extras = True
-                sfreq = raw.info["sfreq"]
-                extras_by_sample = {}
-                for ann, extra in zip(raw.annotations, orig_extras):
-                    sample = int(round(ann["onset"] * sfreq)) + raw.first_samp
-                    extras_by_sample[sample] = extra
 
             events, _ = mne.events_from_annotations(
                 raw, event_id=self.event_id, verbose=False

--- a/moabb/datasets/stieger2021.py
+++ b/moabb/datasets/stieger2021.py
@@ -667,18 +667,17 @@ class Stieger2021(BaseDataset):
 
         info = self.get_trial_info(subjects=subjects)
 
-        all_lengths = np.concatenate(
-            [
-                sess_info["triallengths"]
-                for subj_info in info.values()
-                for sess_info in subj_info.values()
-                if len(sess_info["triallengths"]) > 0
-            ]
-        )
+        lengths_list = [
+            sess_info["triallengths"]
+            for subj_info in info.values()
+            for sess_info in subj_info.values()
+            if len(sess_info["triallengths"]) > 0
+        ]
 
-        if len(all_lengths) == 0:
+        if len(lengths_list) == 0:
             raise ValueError("No artifact-free trials found for the requested subjects.")
 
+        all_lengths = np.concatenate(lengths_list)
         # The quantile at (1 - keep_ratio) gives the tmax that keeps
         # at least keep_ratio fraction of trials.
         tmax = float(np.quantile(all_lengths, 1 - keep_ratio))

--- a/moabb/datasets/stieger2021.py
+++ b/moabb/datasets/stieger2021.py
@@ -325,8 +325,32 @@ class Stieger2021(BaseDataset):
     )
 
     def __init__(
-        self, interval=[0, 3], sessions=None, fix_bads=True, subjects=None, **kwargs
+        self,
+        interval=[0, 3],
+        sessions=None,
+        fix_bads=True,
+        subjects=None,
+        **kwargs,  # noqa: B006
     ):
+        """Initialize Stieger2021 dataset.
+
+        Parameters
+        ----------
+        interval : list of float, default=[0, 3]
+            Epoch interval ``[tmin, tmax]`` in seconds relative to stimulus
+            onset.  Because trials in this dataset have variable lengths
+            (roughly 0.04 s to 6 s), epochs whose trial is shorter than
+            ``tmax`` are automatically rejected.  Use
+            :meth:`get_trial_info` to inspect per-subject trial-length
+            distributions and :meth:`suggest_interval` to pick an interval
+            that retains a desired fraction of trials.
+        sessions : list of int or None
+            Sessions to load.
+        fix_bads : bool
+            If True, bad channels are interpolated.
+        subjects : list of int or None
+            Subjects to load.
+        """
         deprecated_renames = {
             "Interval": "interval",
             "Sessions": "sessions",
@@ -401,6 +425,21 @@ class Stieger2021(BaseDataset):
                 spath.append(fpath)
         return spath
 
+    @staticmethod
+    def _parse_session(filepath):
+        """Extract the integer session number from a Stieger2021 filename."""
+        return int(os.path.basename(filepath).split("_")[2].split(".")[0])
+
+    @staticmethod
+    def _load_container(filepath):
+        """Load the BCI container from a Stieger2021 .mat file."""
+        return loadmat(
+            file_name=filepath,
+            squeeze_me=True,
+            struct_as_record=False,
+            verify_compressed_data_integrity=False,
+        )["BCI"]
+
     def _get_single_subject_data(self, subject):
         file_path = self.data_path(subject)
 
@@ -408,18 +447,13 @@ class Stieger2021(BaseDataset):
 
         for file in file_path:
 
-            session = int(os.path.basename(file).split("_")[2].split(".")[0])
+            session = self._parse_session(file)
 
             if self.sessions is not None:
                 if session not in set(self.sessions):
                     continue
 
-            container = loadmat(
-                file_name=file,
-                squeeze_me=True,
-                struct_as_record=False,
-                verify_compressed_data_integrity=False,
-            )["BCI"]
+            container = self._load_container(file)
 
             srate = container.SRATE
 
@@ -438,35 +472,49 @@ class Stieger2021(BaseDataset):
 
             X_flat = []
             stim_flat = []
+            accepted_triallengths = []
+            rejected_lengths = []
             for i in range(container.data.shape[0]):
                 x = container.data[i][channel_mask, :]
-                y = container.TrialData[i].targetnumber
+                td = container.TrialData[i]
                 stim = np.zeros_like(container.time[i])
-                if (  # check if the trial is artifact-free and long enough
-                    container.TrialData[i].artifact == 0
-                    and (container.TrialData[i].triallength + 2) > self.interval[1]
-                ):
-                    # this should be the cue time-point
-                    assert (
-                        container.time[i][2 * srate] == 0
-                    ), "This should be the cue time-point"
-                    stim[2 * srate] = y
+                if td.artifact == 0:
+                    if td.triallength >= self.interval[1]:
+                        # this should be the cue time-point
+                        assert (
+                            container.time[i][2 * srate] == 0
+                        ), "This should be the cue time-point"
+                        stim[2 * srate] = td.targetnumber
+                        accepted_triallengths.append(float(td.triallength))
+                    else:
+                        rejected_lengths.append(td.triallength)
                 X_flat.append(x)
                 stim_flat.append(stim[None, :])
 
             X_flat = np.concatenate(X_flat, axis=1)
             stim_flat = np.concatenate(stim_flat, axis=1)
 
-            p_keep = np.flatnonzero(stim_flat).shape[0] / container.data.shape[0]
+            n_total = container.data.shape[0]
+            n_accepted = len(accepted_triallengths)
+            p_keep = n_accepted / n_total
 
             message = (
-                "The trial length of this dataset is dynamic."
+                "The trial length of this dataset is dynamic. "
                 f"For the specified interval [{self.interval[0]}, {self.interval[1]}], "
                 f"{(1 - p_keep) * 100:.0f}% of the epochs of record {subject}/"
                 f"{session} (subject/session) were rejected (artifact or"
-                " too short) ."
+                " too short)."
             )
+            if rejected_lengths:
+                message += (
+                    f" Rejected-for-length trials had durations in "
+                    f"[{min(rejected_lengths):.2f}, {max(rejected_lengths):.2f}] s."
+                )
             if p_keep < 0.5:
+                message += (
+                    " Consider using suggest_interval() to find an interval"
+                    " that retains more trials."
+                )
                 LOGGER.warning(message)
             else:
                 LOGGER.info(message)
@@ -476,6 +524,25 @@ class Stieger2021(BaseDataset):
             info = mne.create_info(ch_names=ch_names, ch_types=ch_types, sfreq=srate)
             raw = mne.io.RawArray(data=eeg_data, info=info, verbose=False)
             raw.set_montage(montage)
+
+            # Attach triallength as annotation extras so it flows through
+            # to BIDS events.tsv during conversion.
+            events_arr = mne.find_events(raw, shortest_event=0, verbose=False)
+            if len(events_arr) > 0:
+                event_desc = {v: k for k, v in self.event_id.items()}
+                annotations = mne.annotations_from_events(
+                    events_arr,
+                    raw.info["sfreq"],
+                    event_desc,
+                    first_samp=raw.first_samp,
+                    verbose=False,
+                )
+                assert len(annotations) == len(accepted_triallengths), (
+                    f"Mismatch: {len(annotations)} annotations but "
+                    f"{len(accepted_triallengths)} trial lengths."
+                )
+                annotations.extras = [{"triallength": tl} for tl in accepted_triallengths]
+                raw.set_annotations(annotations)
             if isinstance(container.chaninfo.noisechan, int):
                 badchanidxs = [container.chaninfo.noisechan]
             elif isinstance(container.chaninfo.noisechan, np.ndarray):
@@ -509,3 +576,119 @@ class Stieger2021(BaseDataset):
 
             subject_data[str(session)] = {"0": raw}
         return subject_data
+
+    def get_trial_info(self, subjects=None):
+        """Return trial-length metadata for the requested subjects.
+
+        Loads only the ``TrialData`` metadata from the ``.mat`` files
+        (without building full MNE Raw objects) and summarises trial
+        durations for artifact-free trials.
+
+        Parameters
+        ----------
+        subjects : list of int or None
+            Subjects to query.  Defaults to all selected subjects
+            (``self.subject_list``).
+
+        Returns
+        -------
+        info : dict
+            Nested dict ``{subject_id: {session_id: {...}}}`` where each
+            innermost dict contains:
+
+            - ``triallengths`` : np.ndarray – lengths of artifact-free trials
+            - ``n_total`` : int – total number of trials
+            - ``n_artifact_free`` : int – trials without artifacts
+            - ``min`` : float – shortest artifact-free trial
+            - ``max`` : float – longest artifact-free trial
+            - ``median`` : float – median artifact-free trial length
+        """
+        if subjects is None:
+            subjects = self.subject_list
+
+        info = {}
+        for subject in subjects:
+            file_paths = self.data_path(subject)
+            subject_info = {}
+            for file in file_paths:
+                session = self._parse_session(file)
+                if self.sessions is not None and session not in set(self.sessions):
+                    continue
+
+                container = self._load_container(file)
+
+                n_total = container.data.shape[0]
+                lengths = []
+                for i in range(n_total):
+                    td = container.TrialData[i]
+                    if td.artifact == 0:
+                        lengths.append(float(td.triallength))
+
+                lengths = np.array(lengths)
+                subject_info[session] = {
+                    "triallengths": lengths,
+                    "n_total": n_total,
+                    "n_artifact_free": len(lengths),
+                    "min": float(lengths.min()) if len(lengths) > 0 else np.nan,
+                    "max": float(lengths.max()) if len(lengths) > 0 else np.nan,
+                    "median": float(np.median(lengths)) if len(lengths) > 0 else np.nan,
+                }
+            info[subject] = subject_info
+        return info
+
+    def suggest_interval(self, subjects=None, keep_ratio=1.0):
+        """Suggest an epoch interval that retains a given fraction of trials.
+
+        Parameters
+        ----------
+        subjects : list of int or None
+            Subjects to consider.  Defaults to all selected subjects.
+        keep_ratio : float
+            Fraction of artifact-free trials to retain (between 0 and 1).
+            For example, ``keep_ratio=0.95`` returns an interval whose
+            ``tmax`` equals the 5th percentile of trial lengths, so that
+            at least 95 % of artifact-free trials are long enough.
+
+        Returns
+        -------
+        interval : list of float
+            ``[tmin, tmax]`` where ``tmin`` is the current
+            ``self.interval[0]`` and ``tmax`` is chosen to satisfy
+            ``keep_ratio``.
+
+        Examples
+        --------
+        >>> ds = Stieger2021(subjects=[1, 2, 3])
+        >>> ds.suggest_interval(keep_ratio=0.95)  # doctest: +SKIP
+        [0, 2.1]
+        """
+        if not 0 < keep_ratio <= 1.0:
+            raise ValueError("keep_ratio must be in (0, 1].")
+
+        info = self.get_trial_info(subjects=subjects)
+
+        all_lengths = np.concatenate(
+            [
+                sess_info["triallengths"]
+                for subj_info in info.values()
+                for sess_info in subj_info.values()
+                if len(sess_info["triallengths"]) > 0
+            ]
+        )
+
+        if len(all_lengths) == 0:
+            raise ValueError("No artifact-free trials found for the requested subjects.")
+
+        # The quantile at (1 - keep_ratio) gives the tmax that keeps
+        # at least keep_ratio fraction of trials.
+        tmax = float(np.quantile(all_lengths, 1 - keep_ratio))
+
+        tmin = self.interval[0]
+        if tmax <= tmin:
+            raise ValueError(
+                f"Cannot satisfy keep_ratio={keep_ratio}: the resulting tmax "
+                f"({tmax:.3f} s) is not greater than tmin ({tmin} s). "
+                "Try a smaller keep_ratio."
+            )
+
+        return [tmin, tmax]


### PR DESCRIPTION
## Summary

- Add `get_trial_info()` and `suggest_interval(keep_ratio)` methods to `Stieger2021` so users can inspect variable-length trial distributions and choose an interval that maximizes trial retention
- Preserve per-trial `triallength` metadata through BIDS conversion via annotation extras, preventing data loss when converting to BIDS format
- Fix `SetRawAnnotations` to preserve annotation extras regardless of whether a stim channel is present
- Enhance rejection logging with min/max of rejected trial durations and a hint to use `suggest_interval()`

Closes #816

## Motivation

Stieger2021 has variable-length MI trials (0.04 s – 6 s). After fixing the trial acceptance condition (#816), trials shorter than `interval[1]` are correctly rejected — but this can silently discard a large portion of data. Users had no way to know what interval maximizes trial retention, and per-trial duration metadata was lost during BIDS conversion.

## Usage

```python
ds = Stieger2021(subjects=[1, 2, 3])

# Inspect trial-length distributions
info = ds.get_trial_info()

# Find an interval that keeps 95% of artifact-free trials
interval = ds.suggest_interval(keep_ratio=0.95)
# e.g. returns [0, 0.578]

# Use the suggested interval
ds_tuned = Stieger2021(interval=interval, subjects=[1, 2, 3])
```

## Test plan

- [x] `python -c "from moabb.datasets import Stieger2021; print('import ok')"` — no syntax errors
- [x] `get_trial_info()` and `suggest_interval()` tested on downloaded subject 1
- [x] Annotation extras verified to survive `SetRawAnnotations` pipeline
- [x] `triallength` column confirmed in BIDS `events.tsv` after write and read-back
- [x] `pytest moabb/tests/ -k "stieger or preprocessing" -x` — all tests pass
- [x] Pre-commit hooks (black, isort, ruff, codespell) all pass