### PR TITLE
Fix HED annotation semantics for Motor Imagery per expert review

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -138,6 +138,7 @@ Bugs
 - Fix ``set_montage`` crash in :class:`moabb.datasets.Thielen2015` when ``return_all_modalities=True`` by retyping ANA/EXG channels to ``misc`` (:gh:`1030` by `Bruno Aristimunha`_)
 - Fix duplicate stim channels and dead CPz reference channel in :class:`moabb.datasets.Liu2024` when ``return_all_modalities=True`` (:gh:`1030` by `Bruno Aristimunha`_)
 - Fix :class:`moabb.datasets.preprocessing.RawToEpochs` silently stripping all non-EEG channels regardless of ``return_all_modalities`` setting (:gh:`1030` by `Bruno Aristimunha`_)
+- Fix HED annotation semantics for Motor Imagery events per expert review: decompose each MI event into separate ``(Sensory-event, Experimental-stimulus, Visual-presentation)`` and ``(Agent-action, ...)`` top-level groups per HED Rules 2b/2e/2f, remove conflated ``Cue`` + ``Experimental-stimulus`` roles, fix SSVEP ``rest`` tag to ``Experiment-structure``, and extract shared ``_MI_SENSORY`` constant to reduce tag duplication (:gh:`1035` by `Bruno Aristimunha`_)
 
 Code health
 ~~~~~~~~~~~

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -351,112 +351,239 @@ _PARADIGM_COG_ATLAS = {
 # Maps (paradigm, event_name) → HED tag string using HED schema 8.4.0.
 _PARADIGM_HED_TAGS = {
     # ── Motor Imagery ──
+    # Each MI stimulus event decomposes into two top-level groups per HED
+    # annotation semantics (Rules 2b/2e/2f):
+    #   1. (Sensory-event, Experimental-stimulus, Visual-presentation) — what
+    #      the participant sees on screen.
+    #   2. (Agent-action, (Imagine, ...)) — what the participant does.
     "imagery": {
         # Common MI events
-        "left_hand": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Move, (Left, Hand)))",
-        "right_hand": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Move, (Right, Hand)))",
-        "feet": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Move, Foot))",
-        "tongue": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Move, Tongue))",
-        "both_hand": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Move, Hand))",
-        "hands": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Move, Hand))",
-        "rest": "Sensory-event, Experimental-stimulus, Cue, Rest",
-        "right_hand_right_foot": (
-            "Sensory-event, Experimental-stimulus, Cue, "
-            "(Imagine, (Move, (Right, Hand)), (Move, (Right, Foot)))"
+        "left_hand": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, (Left, Hand))))"
         ),
-        "palmar_grasp": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Grasp, Hand))",
-        "lateral_grasp": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Grasp, Hand, (Label/lateral)))",
+        "right_hand": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, (Right, Hand))))"
+        ),
+        "feet": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, Foot)))"
+        ),
+        "tongue": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, Tongue)))"
+        ),
+        "both_hand": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, Hand)))"
+        ),
+        "hands": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, Hand)))"
+        ),
+        "rest": ("(Sensory-event, Experimental-stimulus, Visual-presentation), " "Rest"),
+        "right_hand_right_foot": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, (Right, Hand)), (Move, (Right, Foot))))"
+        ),
+        "palmar_grasp": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Grasp, Hand)))"
+        ),
+        "lateral_grasp": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Grasp, Hand, (Label/lateral))))"
+        ),
         # Weibo2014 — compound limb motor imagery
         "left_hand_right_foot": (
-            "Sensory-event, Experimental-stimulus, Cue, "
-            "(Imagine, (Move, (Left, Hand)), (Move, (Right, Foot)))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, (Left, Hand)), (Move, (Right, Foot))))"
         ),
         "right_hand_left_foot": (
-            "Sensory-event, Experimental-stimulus, Cue, "
-            "(Imagine, (Move, (Right, Hand)), (Move, (Left, Foot)))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Move, (Right, Hand)), (Move, (Left, Foot))))"
         ),
         # Ofner2017 — upper limb motor imagery
-        "right_elbow_flexion": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Flex, (Right, Elbow)))",
-        "right_elbow_extension": (
-            "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Stretch, (Right, Elbow)))"
+        "right_elbow_flexion": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Flex, (Right, Elbow))))"
         ),
-        "right_supination": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Turn, (Right, Forearm), (Label/supination)))",
-        "right_pronation": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Turn, (Right, Forearm), (Label/pronation)))",
-        "right_hand_close": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Close, (Right, Hand)))",
-        "right_hand_open": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Open, (Right, Hand)))",
+        "right_elbow_extension": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Stretch, (Right, Elbow))))"
+        ),
+        "right_supination": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Turn, (Right, Forearm), (Label/supination))))"
+        ),
+        "right_pronation": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Turn, (Right, Forearm), (Label/pronation))))"
+        ),
+        "right_hand_close": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Close, (Right, Hand))))"
+        ),
+        "right_hand_open": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Open, (Right, Hand))))"
+        ),
         # BNCI2019_001 — motor imagery without laterality prefix
-        "hand_open": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Open, Hand))",
-        "pronation": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Turn, Forearm, (Label/pronation)))",
-        "supination": "Sensory-event, Experimental-stimulus, Cue, (Imagine, (Turn, Forearm, (Label/supination)))",
+        "hand_open": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Open, Hand)))"
+        ),
+        "pronation": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Turn, Forearm, (Label/pronation))))"
+        ),
+        "supination": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, (Turn, Forearm, (Label/supination))))"
+        ),
         # BNCI2015_004 — mental/cognitive tasks
-        "math": "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/math))",
-        "letter": "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/letter))",
-        "rotation": "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/rotation))",
-        "count": "Sensory-event, Experimental-stimulus, Cue, (Imagine, Count)",
-        "baseline": "Sensory-event, Experimental-stimulus, Cue, Rest",
+        "math": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/math)))"
+        ),
+        "letter": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/letter)))"
+        ),
+        "rotation": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/rotation)))"
+        ),
+        "count": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Count))"
+        ),
+        "baseline": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), " "Rest"
+        ),
         # Shin2017B — mental arithmetic
-        "subtraction": "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/subtraction))",
+        "subtraction": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/subtraction)))"
+        ),
         # BNCI2024_001 — handwritten character writing
-        "letter_a": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/a))",
-        "letter_d": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/d))",
-        "letter_e": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/e))",
-        "letter_f": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/f))",
-        "letter_j": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/j))",
-        "letter_n": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/n))",
-        "letter_o": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/o))",
-        "letter_s": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/s))",
-        "letter_t": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/t))",
-        "letter_v": "Sensory-event, Experimental-stimulus, Cue, (Write, Hand, (Label/v))",
+        "letter_a": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/a)))"
+        ),
+        "letter_d": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/d)))"
+        ),
+        "letter_e": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/e)))"
+        ),
+        "letter_f": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/f)))"
+        ),
+        "letter_j": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/j)))"
+        ),
+        "letter_n": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/n)))"
+        ),
+        "letter_o": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/o)))"
+        ),
+        "letter_s": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/s)))"
+        ),
+        "letter_t": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/t)))"
+        ),
+        "letter_v": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Write, Hand, (Label/v)))"
+        ),
         # BNCI2022_001 — drone piloting / waypoint events
         "trajectory_start": "Experiment-structure, (Label/trajectory_start)",
         "waypoint_hit": "Experiment-structure, (Label/waypoint_hit)",
         "waypoint_miss": "Experiment-structure, (Label/waypoint_miss)",
         "trajectory_end": "Experiment-structure, (Label/trajectory_end)",
         # BNCI2025_001 — discrete reaching (direction × speed × distance)
-        "up_slow_near": "Sensory-event, Experimental-stimulus, Cue, (Reach, Upward, (Label/slow), (Label/near))",
-        "up_slow_far": "Sensory-event, Experimental-stimulus, Cue, (Reach, Upward, (Label/slow), (Label/far))",
-        "up_fast_near": "Sensory-event, Experimental-stimulus, Cue, (Reach, Upward, (Label/fast), (Label/near))",
-        "up_fast_far": "Sensory-event, Experimental-stimulus, Cue, (Reach, Upward, (Label/fast), (Label/far))",
+        "up_slow_near": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Upward, (Label/slow), (Label/near)))"
+        ),
+        "up_slow_far": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Upward, (Label/slow), (Label/far)))"
+        ),
+        "up_fast_near": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Upward, (Label/fast), (Label/near)))"
+        ),
+        "up_fast_far": (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Upward, (Label/fast), (Label/far)))"
+        ),
         "down_slow_near": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Downward, (Label/slow), (Label/near))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Downward, (Label/slow), (Label/near)))"
         ),
         "down_slow_far": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Downward, (Label/slow), (Label/far))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Downward, (Label/slow), (Label/far)))"
         ),
         "down_fast_near": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Downward, (Label/fast), (Label/near))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Downward, (Label/fast), (Label/near)))"
         ),
         "down_fast_far": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Downward, (Label/fast), (Label/far))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Downward, (Label/fast), (Label/far)))"
         ),
         "left_slow_near": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Left, (Label/slow), (Label/near))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Left, (Label/slow), (Label/near)))"
         ),
         "left_slow_far": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Left, (Label/slow), (Label/far))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Left, (Label/slow), (Label/far)))"
         ),
         "left_fast_near": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Left, (Label/fast), (Label/near))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Left, (Label/fast), (Label/near)))"
         ),
         "left_fast_far": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Left, (Label/fast), (Label/far))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Left, (Label/fast), (Label/far)))"
         ),
         "right_slow_near": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Right, (Label/slow), (Label/near))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Right, (Label/slow), (Label/near)))"
         ),
         "right_slow_far": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Right, (Label/slow), (Label/far))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Right, (Label/slow), (Label/far)))"
         ),
         "right_fast_near": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Right, (Label/fast), (Label/near))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Right, (Label/fast), (Label/near)))"
         ),
         "right_fast_far": (
-            "Sensory-event, Experimental-stimulus, Cue, (Reach, Right, (Label/fast), (Label/far))"
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Reach, Right, (Label/fast), (Label/far)))"
         ),
         # BNCI2025_002 — continuous 2D trajectory tracking
         "snakerun": "Experiment-structure, (Label/snakerun)",
         "freerun": "Experiment-structure, (Label/freerun)",
         "eyerun": "Experiment-structure, (Label/eyerun)",
+        # Cue event for datasets that expose it separately
+        "cue": "Sensory-event, Cue, (Auditory-presentation, Tone), (Visual-presentation, Cross)",
     },
     # ── P300 / Oddball ──
     "p300": {
@@ -1110,7 +1237,7 @@ def _build_hed_sidecar_annotations(dataset):
         for name in event_names:
             if name not in hed:
                 if name == "rest":
-                    hed[name] = "Sensory-event, Cue, Rest"
+                    hed[name] = "Experiment-structure, Rest"
                 else:
                     safe_freq = name.replace(".", "_")
                     hed[name] = (

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -349,234 +349,135 @@ _PARADIGM_COG_ATLAS = {
 
 # Paradigm-level HED tag mappings for events.json sidecar enrichment.
 # Maps (paradigm, event_name) → HED tag string using HED schema 8.4.0.
+
+# Shared sensory prefix for MI events — the visual cue the participant sees.
+_MI_SENSORY = "(Sensory-event, Experimental-stimulus, Visual-presentation)"
+
 _PARADIGM_HED_TAGS = {
     # ── Motor Imagery ──
     # Each MI stimulus event decomposes into two top-level groups per HED
     # annotation semantics (Rules 2b/2e/2f):
-    #   1. (Sensory-event, Experimental-stimulus, Visual-presentation) — what
-    #      the participant sees on screen.
+    #   1. _MI_SENSORY — what the participant sees on screen.
     #   2. (Agent-action, (Imagine, ...)) — what the participant does.
     "imagery": {
         # Common MI events
-        "left_hand": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Move, (Left, Hand))))"
-        ),
-        "right_hand": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Move, (Right, Hand))))"
-        ),
-        "feet": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Move, Foot)))"
-        ),
-        "tongue": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Move, Tongue)))"
-        ),
-        "both_hand": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Move, Hand)))"
-        ),
-        "hands": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Move, Hand)))"
-        ),
-        "rest": ("(Sensory-event, Experimental-stimulus, Visual-presentation), " "Rest"),
+        "left_hand": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Move, (Left, Hand))))",
+        "right_hand": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Move, (Right, Hand))))",
+        "feet": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Move, Foot)))",
+        "tongue": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Move, Tongue)))",
+        "both_hand": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Move, Hand)))",
+        "hands": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Move, Hand)))",
+        "rest": f"{_MI_SENSORY}, Rest",
         "right_hand_right_foot": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            f"{_MI_SENSORY}, "
             "(Agent-action, (Imagine, (Move, (Right, Hand)), (Move, (Right, Foot))))"
         ),
-        "palmar_grasp": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Grasp, Hand)))"
-        ),
+        "palmar_grasp": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Grasp, Hand)))",
         "lateral_grasp": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Grasp, Hand, (Label/lateral))))"
+            f"{_MI_SENSORY}, (Agent-action, (Imagine, (Grasp, Hand, (Label/lateral))))"
         ),
         # Weibo2014 — compound limb motor imagery
         "left_hand_right_foot": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            f"{_MI_SENSORY}, "
             "(Agent-action, (Imagine, (Move, (Left, Hand)), (Move, (Right, Foot))))"
         ),
         "right_hand_left_foot": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            f"{_MI_SENSORY}, "
             "(Agent-action, (Imagine, (Move, (Right, Hand)), (Move, (Left, Foot))))"
         ),
         # Ofner2017 — upper limb motor imagery
-        "right_elbow_flexion": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Flex, (Right, Elbow))))"
-        ),
+        "right_elbow_flexion": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Flex, (Right, Elbow))))",
         "right_elbow_extension": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Stretch, (Right, Elbow))))"
+            f"{_MI_SENSORY}, (Agent-action, (Imagine, (Stretch, (Right, Elbow))))"
         ),
         "right_supination": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            f"{_MI_SENSORY}, "
             "(Agent-action, (Imagine, (Turn, (Right, Forearm), (Label/supination))))"
         ),
         "right_pronation": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            f"{_MI_SENSORY}, "
             "(Agent-action, (Imagine, (Turn, (Right, Forearm), (Label/pronation))))"
         ),
         "right_hand_close": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Close, (Right, Hand))))"
+            f"{_MI_SENSORY}, (Agent-action, (Imagine, (Close, (Right, Hand))))"
         ),
         "right_hand_open": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Open, (Right, Hand))))"
+            f"{_MI_SENSORY}, (Agent-action, (Imagine, (Open, (Right, Hand))))"
         ),
         # BNCI2019_001 — motor imagery without laterality prefix
-        "hand_open": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Open, Hand)))"
-        ),
+        "hand_open": f"{_MI_SENSORY}, (Agent-action, (Imagine, (Open, Hand)))",
         "pronation": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Turn, Forearm, (Label/pronation))))"
+            f"{_MI_SENSORY}, (Agent-action, (Imagine, (Turn, Forearm, (Label/pronation))))"
         ),
         "supination": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, (Turn, Forearm, (Label/supination))))"
+            f"{_MI_SENSORY}, (Agent-action, (Imagine, (Turn, Forearm, (Label/supination))))"
         ),
         # BNCI2015_004 — mental/cognitive tasks
-        "math": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, Think, (Label/math)))"
-        ),
-        "letter": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, Think, (Label/letter)))"
-        ),
-        "rotation": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, Think, (Label/rotation)))"
-        ),
-        "count": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, Count))"
-        ),
-        "baseline": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), " "Rest"
-        ),
+        "math": f"{_MI_SENSORY}, (Agent-action, (Imagine, Think, (Label/math)))",
+        "letter": f"{_MI_SENSORY}, (Agent-action, (Imagine, Think, (Label/letter)))",
+        "rotation": f"{_MI_SENSORY}, (Agent-action, (Imagine, Think, (Label/rotation)))",
+        "count": f"{_MI_SENSORY}, (Agent-action, (Imagine, Count))",
+        "baseline": f"{_MI_SENSORY}, Rest",
         # Shin2017B — mental arithmetic
         "subtraction": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Imagine, Think, (Label/subtraction)))"
+            f"{_MI_SENSORY}, (Agent-action, (Imagine, Think, (Label/subtraction)))"
         ),
         # BNCI2024_001 — handwritten character writing
-        "letter_a": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/a)))"
-        ),
-        "letter_d": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/d)))"
-        ),
-        "letter_e": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/e)))"
-        ),
-        "letter_f": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/f)))"
-        ),
-        "letter_j": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/j)))"
-        ),
-        "letter_n": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/n)))"
-        ),
-        "letter_o": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/o)))"
-        ),
-        "letter_s": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/s)))"
-        ),
-        "letter_t": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/t)))"
-        ),
-        "letter_v": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Write, Hand, (Label/v)))"
-        ),
+        "letter_a": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/a)))",
+        "letter_d": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/d)))",
+        "letter_e": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/e)))",
+        "letter_f": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/f)))",
+        "letter_j": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/j)))",
+        "letter_n": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/n)))",
+        "letter_o": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/o)))",
+        "letter_s": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/s)))",
+        "letter_t": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/t)))",
+        "letter_v": f"{_MI_SENSORY}, (Agent-action, (Write, Hand, (Label/v)))",
         # BNCI2022_001 — drone piloting / waypoint events
         "trajectory_start": "Experiment-structure, (Label/trajectory_start)",
         "waypoint_hit": "Experiment-structure, (Label/waypoint_hit)",
         "waypoint_miss": "Experiment-structure, (Label/waypoint_miss)",
         "trajectory_end": "Experiment-structure, (Label/trajectory_end)",
         # BNCI2025_001 — discrete reaching (direction × speed × distance)
-        "up_slow_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Upward, (Label/slow), (Label/near)))"
-        ),
-        "up_slow_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Upward, (Label/slow), (Label/far)))"
-        ),
-        "up_fast_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Upward, (Label/fast), (Label/near)))"
-        ),
-        "up_fast_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Upward, (Label/fast), (Label/far)))"
-        ),
+        "up_slow_near": f"{_MI_SENSORY}, (Agent-action, (Reach, Upward, (Label/slow), (Label/near)))",
+        "up_slow_far": f"{_MI_SENSORY}, (Agent-action, (Reach, Upward, (Label/slow), (Label/far)))",
+        "up_fast_near": f"{_MI_SENSORY}, (Agent-action, (Reach, Upward, (Label/fast), (Label/near)))",
+        "up_fast_far": f"{_MI_SENSORY}, (Agent-action, (Reach, Upward, (Label/fast), (Label/far)))",
         "down_slow_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Downward, (Label/slow), (Label/near)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Downward, (Label/slow), (Label/near)))"
         ),
         "down_slow_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Downward, (Label/slow), (Label/far)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Downward, (Label/slow), (Label/far)))"
         ),
         "down_fast_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Downward, (Label/fast), (Label/near)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Downward, (Label/fast), (Label/near)))"
         ),
         "down_fast_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Downward, (Label/fast), (Label/far)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Downward, (Label/fast), (Label/far)))"
         ),
         "left_slow_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Left, (Label/slow), (Label/near)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Left, (Label/slow), (Label/near)))"
         ),
         "left_slow_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Left, (Label/slow), (Label/far)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Left, (Label/slow), (Label/far)))"
         ),
         "left_fast_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Left, (Label/fast), (Label/near)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Left, (Label/fast), (Label/near)))"
         ),
         "left_fast_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Left, (Label/fast), (Label/far)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Left, (Label/fast), (Label/far)))"
         ),
         "right_slow_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Right, (Label/slow), (Label/near)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Right, (Label/slow), (Label/near)))"
         ),
         "right_slow_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Right, (Label/slow), (Label/far)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Right, (Label/slow), (Label/far)))"
         ),
         "right_fast_near": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Right, (Label/fast), (Label/near)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Right, (Label/fast), (Label/near)))"
         ),
         "right_fast_far": (
-            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
-            "(Agent-action, (Reach, Right, (Label/fast), (Label/far)))"
+            f"{_MI_SENSORY}, (Agent-action, (Reach, Right, (Label/fast), (Label/far)))"
         ),
         # BNCI2025_002 — continuous 2D trajectory tracking
         "snakerun": "Experiment-structure, (Label/snakerun)",

--- a/moabb/tests/test_bids_enrichment.py
+++ b/moabb/tests/test_bids_enrichment.py
@@ -1427,11 +1427,14 @@ class TestBuildHedSidecarAnnotations:
         hed = _build_hed_sidecar_annotations(ds)
         assert "left_hand" in hed
         assert "Imagine" in hed["left_hand"]
-        assert "Experimental-stimulus" in hed["left_hand"]
+        assert "Agent-action" in hed["left_hand"]
+        assert "Visual-presentation" in hed["left_hand"]
         assert "right_hand" in hed
-        assert "Experimental-stimulus" in hed["right_hand"]
+        assert "Agent-action" in hed["right_hand"]
+        assert "Visual-presentation" in hed["right_hand"]
         assert "feet" in hed
-        assert "Experimental-stimulus" in hed["feet"]
+        assert "Agent-action" in hed["feet"]
+        assert "Visual-presentation" in hed["feet"]
 
     def test_p300_default_tags(self):
         ds = self._make_dataset("p300", {"Target": 2, "NonTarget": 1})
@@ -1592,26 +1595,26 @@ class TestBuildHedSidecarAnnotations:
         )
         hed = _build_hed_sidecar_annotations(ds)
         # Each mental task must be distinguishable via Label qualifier
-        assert (
-            hed["math"]
-            == "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/math))"
+        assert hed["math"] == (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/math)))"
         )
-        assert (
-            hed["letter"]
-            == "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/letter))"
+        assert hed["letter"] == (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/letter)))"
         )
-        assert (
-            hed["rotation"]
-            == "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/rotation))"
+        assert hed["rotation"] == (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/rotation)))"
         )
-        assert (
-            hed["subtraction"]
-            == "Sensory-event, Experimental-stimulus, Cue, (Imagine, Think, (Label/subtraction))"
+        assert hed["subtraction"] == (
+            "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+            "(Agent-action, (Imagine, Think, (Label/subtraction)))"
         )
         assert "Count" in hed["count"]
-        assert "Experimental-stimulus" in hed["count"]
+        assert "Agent-action" in hed["count"]
         assert "Rest" in hed["baseline"]
-        assert "Experimental-stimulus" in hed["baseline"]
+        assert "Visual-presentation" in hed["baseline"]
 
     def test_label_fallback_sanitizes_dots(self):
         """Label fallback sanitizes dots for HED nameClass compliance."""
@@ -1658,7 +1661,12 @@ class TestUpdateEventsJsonWithHed:
     def test_adds_hed_to_trial_type(self, tmp_path):
         content = {"trial_type": {"Description": "Event type."}}
         bp, json_path = self._make_bids_path(tmp_path, content)
-        hed_tags = {"left_hand": "Sensory-event, Cue, (Imagine, (Move, Hand))"}
+        hed_tags = {
+            "left_hand": (
+                "(Sensory-event, Experimental-stimulus, Visual-presentation), "
+                "(Agent-action, (Imagine, (Move, (Left, Hand))))"
+            )
+        }
         _update_events_json_sidecar(bp, hed_tags, None)
 
         with open(json_path) as f:
@@ -1769,8 +1777,8 @@ class TestExtractReferencesFromDocstring:
 
 class TestSplitHedTopLevel:
     def test_flat_tags(self):
-        result = _split_hed_top_level("Sensory-event, Cue, Rest")
-        assert result == ["Sensory-event", "Cue", "Rest"]
+        result = _split_hed_top_level("Experiment-structure, Rest")
+        assert result == ["Experiment-structure", "Rest"]
 
     def test_single_group(self):
         result = _split_hed_top_level("Sensory-event, (Imagine, (Move, Hand))")
@@ -1864,13 +1872,13 @@ class TestRenderHedTree:
     def test_nested_tree(self):
         nodes = [
             ("Sensory-event", []),
-            ("Cue", []),
+            ("Visual-presentation", []),
             ("Imagine", [("Move", [("Right, Hand", [])])]),
         ]
         lines = _render_hed_tree(nodes)
         assert len(lines) == 5
         assert "├─ Sensory-event" in lines[0]
-        assert "├─ Cue" in lines[1]
+        assert "├─ Visual-presentation" in lines[1]
         assert "└─ Imagine" in lines[2]
         assert "└─ Move" in lines[3]
         assert "└─ Right, Hand" in lines[4]
@@ -1930,7 +1938,8 @@ class TestReadmeHedSection:
         ds = self._make_dataset()
         readme = _build_readme(ds)
         assert "Sensory-event" in readme
-        assert "Imagine" in readme
+        assert "Agent-action" in readme
+        assert "Visual-presentation" in readme
 
     def test_hed_schema_link(self):
         ds = self._make_dataset()


### PR DESCRIPTION
## Summary

- Restructure all Motor Imagery HED event tags to properly decompose stimulus and action per [HED Annotation Semantics](https://www.hedtags.org/hed-resources/HedAnnotationSemantics.html) Rules 2b/2e/2f, based on Kay's expert feedback
- Each MI event now has two top-level groups: `(Sensory-event, Experimental-stimulus, Visual-presentation)` for what the participant sees, and `(Agent-action, ...)` for what the participant does
- Remove conflated `Cue` + `Experimental-stimulus` roles from MI events
- Fix SSVEP `rest` tag from `Sensory-event, Cue, Rest` to `Experiment-structure, Rest`
- Add `cue` event entry for datasets that expose it separately

## Test plan

- [x] All 284 tests in `test_bids_enrichment.py` pass
- [ ] Verify assembled HED strings translate back to coherent English (reversibility principle)
- [ ] Validate tag names against HED schema 8.4.0