### PR TITLE
fix: improve code robustness and add type hints

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -82,6 +82,7 @@ Requirements
 - Allows CodeCarbon environment variables or a configuration file to be defined in the home directory or the current working directory (:gh:`866` by `Ethan Davis`_).
 - Added ``filelock`` as a core dependency to fix missing import errors in utils (:gh:`959` by `Mateusz Naklicki`_).
 - Temporarily track ``pyriemann`` from GitHub source (``master``) to use new ``PotatoField`` capabilities introduced in pyRiemann PR #423 (:gh:`1011` by `Bruno Aristimunha`_)
+- Add type hints to :class:`moabb.evaluations.base.BaseEvaluation` and all concrete evaluation classes (:gh:`732` by `Sarthak Tayal`_)
 
 Bugs
 ~~~~
@@ -108,6 +109,10 @@ Bugs
 - Fix copytree FileExistsError in BrainInvaders2013a download by adding dirs_exist_ok=True (by `Bruno Aristimunha`_)
 - Ensure optional additional scoring columns in evaluation results (:gh:`957` by `Ethan Davis`_)
 - Fix pandas ``ArrowStringArray`` shuffle warning by converting ``.unique()`` results to numpy arrays in splitters, avoiding issues with newer pandas versions (:gh:`963` by `Bruno Aristimunha`_)
+- Fix crash in :class:`moabb.datasets.Huebner2022` when regex match on vhdr filenames returns ``None`` (:gh:`1036` by `Sarthak Tayal`_)
+- Replace production ``assert`` statements with proper ``ValueError`` / ``TypeError`` exceptions across analysis, pipelines, paradigms, and datasets modules (:gh:`1036` by `Sarthak Tayal`_)
+- Fix silent pipeline name collision in :func:`moabb.pipelines.utils.create_pipeline_from_config` by raising ``ValueError`` on duplicate names (:gh:`1036` by `Sarthak Tayal`_)
+- Replace bare ``print()`` calls with proper logging in :class:`moabb.datasets.MartinezCagigal2023Checker` (:gh:`1036` by `Sarthak Tayal`_)
 - ``LearningCurveSplitter`` now skips training splits that collapse to a single class (e.g., with very small ``data_size``) and emits a ``RuntimeWarning`` instead of producing NaN results (:gh:`963` by `Bruno Aristimunha`_)
 - Fix double µV-to-V conversion in BNCI2003-004 and BNCI2015-006: data loaded in microvolts was labeled as volts without unit conversion, causing a second scaling during EDF export via ``mne_bids`` (by `Bruno Aristimunha`_)
 - Fix ``Beetl2021_A`` and ``Beetl2021_B`` 403 Forbidden errors by skipping Figshare API calls when data already exists locally, and fix double-nested zip extraction directory structure (:gh:`969` by `Bruno Aristimunha`_)
@@ -814,3 +819,4 @@ API changes
 .. _Matthias Dold: https://github.com/matthiasdold
 .. _Davoud Hajhassani: https://github.com/Davoud-Hajhassani
 .. _Katelyn Begany: https://github.com/kbegany
+.. _Sarthak Tayal: https://github.com/tayal-sarthak

--- a/moabb/analysis/meta_analysis.py
+++ b/moabb/analysis/meta_analysis.py
@@ -55,8 +55,8 @@ def compute_pvals_wilcoxon(df, order=None):
     if order is None:
         order = df.columns
     else:
-        errormsg = "provided order does not have all columns of dataframe"
-        assert set(order) == set(df.columns), errormsg
+        if set(order) != set(df.columns):  # was assert, now raises properly
+            raise ValueError("provided order does not have all columns of dataframe")
 
     out = np.zeros((len(df.columns), len(df.columns)))
     for i in range(len(order)):
@@ -170,8 +170,8 @@ def compute_pvals_perm(df, order=None, seed=None):
     if order is None:
         order = df.columns
     else:
-        errormsg = "provided order does not have all columns of dataframe"
-        assert set(order) == set(df.columns), errormsg
+        if set(order) != set(df.columns):  # was assert, now raises properly
+            raise ValueError("provided order does not have all columns of dataframe")
     # reshape df into matrix (sub, k, k) of differences
     data = np.zeros((df.shape[0], len(order), len(order)))
     for i in range(len(order) - 1):
@@ -208,8 +208,8 @@ def compute_effect(df, order=None):
     if order is None:
         order = df.columns
     else:
-        errormsg = "provided order does not have all columns of dataframe"
-        assert set(order) == set(df.columns), errormsg
+        if set(order) != set(df.columns):  # was assert, now raises properly
+            raise ValueError("provided order does not have all columns of dataframe")
 
     out = np.zeros((len(df.columns), len(df.columns)))
     for i, pipe1 in enumerate(order):

--- a/moabb/analysis/plotting.py
+++ b/moabb/analysis/plotting.py
@@ -1140,8 +1140,10 @@ def meta_analysis_plot(stats_df, alg1, alg2):  # noqa: C901
         else:
             raise ValueError("insignificant pval {}".format(pval))
 
-    assert alg1 in stats_df.pipe1.unique()
-    assert alg2 in stats_df.pipe1.unique()
+    if alg1 not in stats_df.pipe1.unique():  # was assert, now raises properly
+        raise ValueError(f"algorithm '{alg1}' not found in stats_df")
+    if alg2 not in stats_df.pipe1.unique():  # was assert
+        raise ValueError(f"algorithm '{alg2}' not found in stats_df")
     df_fw = stats_df.loc[(stats_df.pipe1 == alg1) & (stats_df.pipe2 == alg2)]
     df_fw = df_fw.sort_values(by="pipe1")
     df_bk = stats_df.loc[(stats_df.pipe1 == alg2) & (stats_df.pipe2 == alg1)]

--- a/moabb/analysis/results.py
+++ b/moabb/analysis/results.py
@@ -81,13 +81,24 @@ class Results:
         from moabb.evaluations.base import BaseEvaluation
         from moabb.paradigms.base import BaseParadigm
 
-        assert issubclass(evaluation_class, BaseEvaluation)
-        assert issubclass(paradigm_class, BaseParadigm)
+        if not issubclass(
+            evaluation_class, BaseEvaluation
+        ):  # was assert, raises properly
+            raise TypeError(
+                f"evaluation_class must be a subclass of BaseEvaluation, "
+                f"got {evaluation_class}"
+            )
+        if not issubclass(paradigm_class, BaseParadigm):  # was assert
+            raise TypeError(
+                f"paradigm_class must be a subclass of BaseParadigm, "
+                f"got {paradigm_class}"
+            )
 
         if additional_columns is None:
             self.additional_columns = []
         else:
-            assert all([isinstance(ac, str) for ac in additional_columns])
+            if not all([isinstance(ac, str) for ac in additional_columns]):  # was assert
+                raise TypeError("all additional_columns must be strings")
             self.additional_columns = additional_columns
 
         if hdf5_path is None:

--- a/moabb/datasets/huebner_llp.py
+++ b/moabb/datasets/huebner_llp.py
@@ -75,8 +75,10 @@ class _BaseVisualMatrixSpellerDataset(BaseDataset, ABC):
         vhdr_file_patter_match = re.match(run_file_pattern, vhdr_file_name)
 
         if not vhdr_file_patter_match:
-            # TODO: raise a wild exception?
-            logger.info(vhdr_file_path)
+            raise ValueError(
+                f"filename '{vhdr_file_name}' does not match expected pattern "
+                f"'{run_file_pattern}'"
+            )  # was a TODO, now properly raises instead of crashing on None.group()
 
         session_name = "0"
         block_idx = vhdr_file_patter_match.group(1)

--- a/moabb/datasets/martinezcagigal2023_checker_cvep.py
+++ b/moabb/datasets/martinezcagigal2023_checker_cvep.py
@@ -1,5 +1,5 @@
+import logging
 import tempfile
-import traceback
 import zipfile
 from datetime import timezone
 from glob import glob
@@ -20,6 +20,9 @@ from moabb.datasets.metadata.schema import (
 )
 from moabb.datasets.utils import add_stim_channel_epoch, add_stim_channel_trial
 from moabb.utils import _handle_deprecated_kwargs
+
+
+log = logging.getLogger(__name__)
 
 
 MARTINEZCAGIGAL2023_CHECKER_URL = "https://uvadoc.uva.es/handle/10324/70973"
@@ -222,14 +225,14 @@ class MartinezCagigal2023Checker(BaseDataset):
                 train_paths = glob(f"{tempdir}/{user}/{cond}/*_calib*")
                 for j, train_path in enumerate(train_paths):
                     try:
-                        print(f"> Loading {user}, cond {cond}, train {j + 1}")
+                        log.info(f"Loading {user}, cond {cond}, train {j + 1}")
                         sessions[session_name][f"{j + 1}train"] = (
                             self._convert_to_mne_format(train_path)
                         )
                     except Exception:
-                        print(
-                            f"[EXCEPTION] Cannot convert signal {train_path}."
-                            f" More information: {traceback.format_exc()}"
+                        log.error(  # was print(), now uses proper logging
+                            f"Cannot convert signal {train_path}.",
+                            exc_info=True,
                         )
                 n = len(train_paths)
 
@@ -244,14 +247,14 @@ class MartinezCagigal2023Checker(BaseDataset):
                 assert len(test_paths) == len(true_labels)
                 for j, test_path in enumerate(test_paths):
                     try:
-                        print(f"> Loading {user}, cond {cond}, test {j+n+1}")
+                        log.info(f"Loading {user}, cond {cond}, test {j+n+1}")
                         sessions[session_name][f"{j + n + 1}test"] = (
                             self._convert_to_mne_format(test_path, true_labels[j])
                         )
                     except Exception:
-                        print(
-                            f"[EXCEPTION] Cannot convert signal {test_path}."
-                            f" More information: {traceback.format_exc()}"
+                        log.error(  # was print(), now uses proper logging
+                            f"Cannot convert signal {test_path}.",
+                            exc_info=True,
                         )
 
         return sessions

--- a/moabb/datasets/utils.py
+++ b/moabb/datasets/utils.py
@@ -104,7 +104,11 @@ def dataset_search(  # noqa: C901
         n_classes = len(events)
     else:
         n_classes = None
-    assert paradigm in ["imagery", "p300", "ssvep", "cvep", None]
+    if paradigm not in ["imagery", "p300", "ssvep", "cvep", None]:  # was assert
+        raise ValueError(
+            f"paradigm must be one of 'imagery', 'p300', 'ssvep', 'cvep', or None, "
+            f"got '{paradigm}'"
+        )
 
     for type_d in dataset_list:
         if type_d.__name__ in deprecated_names:

--- a/moabb/evaluations/base.py
+++ b/moabb/evaluations/base.py
@@ -2,6 +2,7 @@ import logging
 import math
 from abc import ABC, abstractmethod
 from time import perf_counter
+from typing import Optional, Union
 from uuid import uuid4
 from warnings import warn
 
@@ -11,7 +12,10 @@ from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator
 
 from moabb.analysis import Results
-from moabb.datasets.base import BaseDataset
+from moabb.datasets.base import (  # noqa: F401 - CacheConfig used in type hints
+    BaseDataset,
+    CacheConfig,
+)
 from moabb.evaluations.utils import (
     Emissions,
     _convert_sklearn_params_to_optuna,
@@ -111,27 +115,27 @@ class BaseEvaluation(ABC):
     @verbose
     def __init__(
         self,
-        paradigm,
-        datasets=None,
-        random_state=None,
-        n_jobs=1,
-        overwrite=False,
-        error_score="raise",
-        suffix="",
-        hdf5_path=None,
-        additional_columns=None,
-        return_epochs=False,
-        return_raws=False,
-        mne_labels=False,
-        n_splits=None,
-        cv_class=None,
-        cv_kwargs=None,
-        save_model=False,
-        cache_config=None,
-        optuna=False,
-        time_out=60 * 15,
-        verbose=None,
-        codecarbon_config=None,
+        paradigm: "BaseParadigm",
+        datasets: Optional[list["BaseDataset"]] = None,
+        random_state: Optional[int] = None,
+        n_jobs: int = 1,
+        overwrite: bool = False,
+        error_score: Union[str, float] = "raise",
+        suffix: str = "",
+        hdf5_path: Optional[str] = None,
+        additional_columns: Optional[list[str]] = None,
+        return_epochs: bool = False,
+        return_raws: bool = False,
+        mne_labels: bool = False,
+        n_splits: Optional[int] = None,
+        cv_class: Optional[type] = None,
+        cv_kwargs: Optional[dict] = None,
+        save_model: bool = False,
+        cache_config: Optional["CacheConfig"] = None,
+        optuna: bool = False,
+        time_out: int = 60 * 15,
+        verbose: Optional[Union[bool, str, int]] = None,
+        codecarbon_config: Optional[dict] = None,
     ):
         self.random_state = random_state
         self.n_jobs = n_jobs
@@ -413,7 +417,12 @@ class BaseEvaluation(ABC):
                 res[col] = extra.get(col, math.nan)
         return res
 
-    def process(self, pipelines, param_grid=None, postprocess_pipeline=None):
+    def process(
+        self,
+        pipelines: dict[str, BaseEstimator],
+        param_grid: Optional[dict[str, dict]] = None,
+        postprocess_pipeline: Optional[BaseEstimator] = None,
+    ) -> pd.DataFrame:
         """Runs all pipelines on all datasets.
 
         This function will apply all provided pipelines and return a dataframe
@@ -510,7 +519,12 @@ class BaseEvaluation(ABC):
 
     @abstractmethod
     def evaluate(
-        self, dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline=None
+        self,
+        dataset: "BaseDataset",
+        pipelines: dict[str, BaseEstimator],
+        param_grid: Optional[dict],
+        process_pipeline: BaseEstimator,
+        postprocess_pipeline: Optional[BaseEstimator] = None,
     ):
         """Evaluate results on a single dataset.
 
@@ -529,7 +543,7 @@ class BaseEvaluation(ABC):
         pass
 
     @abstractmethod
-    def is_valid(self, dataset):
+    def is_valid(self, dataset: "BaseDataset") -> bool:
         """Verify the dataset is compatible with evaluation.
 
         This method is called to verify dataset given in the constructor

--- a/moabb/evaluations/evaluations.py
+++ b/moabb/evaluations/evaluations.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 from sklearn.base import clone
@@ -18,6 +18,11 @@ from moabb.evaluations.splitters import (
     CrossSubjectSplitter,
     WithinSessionSplitter,
 )
+
+
+if TYPE_CHECKING:
+    from moabb.datasets.base import BaseDataset
+
 from moabb.evaluations.utils import (
     _average_scores,
     _create_scorer,
@@ -86,9 +91,9 @@ class WithinSessionEvaluation(BaseEvaluation):
     # flake8: noqa: C901
     def _evaluate(
         self,
-        dataset,
-        pipelines,
-        param_grid,
+        dataset: "BaseDataset",
+        pipelines: dict,
+        param_grid: Optional[dict],
         process_pipeline,
         postprocess_pipeline,
     ):
@@ -225,13 +230,18 @@ class WithinSessionEvaluation(BaseEvaluation):
                         yield res
 
     def evaluate(
-        self, dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline=None
+        self,
+        dataset: "BaseDataset",
+        pipelines: dict,
+        param_grid: Optional[dict],
+        process_pipeline,
+        postprocess_pipeline=None,
     ):
         yield from self._evaluate(
             dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline
         )
 
-    def is_valid(self, dataset):
+    def is_valid(self, dataset: "BaseDataset") -> bool:
         return True
 
 
@@ -283,7 +293,12 @@ class CrossSessionEvaluation(BaseEvaluation):
 
     # flake8: noqa: C901
     def evaluate(
-        self, dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline=None
+        self,
+        dataset: "BaseDataset",
+        pipelines: dict,
+        param_grid: Optional[dict],
+        process_pipeline,
+        postprocess_pipeline=None,
     ):
         if not self.is_valid(dataset):
             reason = self._get_incompatibility_reason(dataset)
@@ -378,7 +393,7 @@ class CrossSessionEvaluation(BaseEvaluation):
                 if _carbonfootprint:
                     tracker.stop()
 
-    def is_valid(self, dataset):
+    def is_valid(self, dataset: "BaseDataset") -> bool:
         return dataset.n_sessions > 1
 
     def _get_incompatibility_reason(self, dataset):
@@ -442,7 +457,12 @@ class CrossSubjectEvaluation(BaseEvaluation):
 
     # flake8: noqa: C901
     def evaluate(
-        self, dataset, pipelines, param_grid, process_pipeline, postprocess_pipeline=None
+        self,
+        dataset: "BaseDataset",
+        pipelines: dict,
+        param_grid: Optional[dict],
+        process_pipeline,
+        postprocess_pipeline=None,
     ):
         if not self.is_valid(dataset):
             reason = self._get_incompatibility_reason(dataset)
@@ -568,7 +588,7 @@ class CrossSubjectEvaluation(BaseEvaluation):
         if _carbonfootprint:
             tracker.stop()
 
-    def is_valid(self, dataset):
+    def is_valid(self, dataset: "BaseDataset") -> bool:
         return len(dataset.subject_list) > 1
 
     def _get_incompatibility_reason(self, dataset):

--- a/moabb/paradigms/motor_imagery.py
+++ b/moabb/paradigms/motor_imagery.py
@@ -235,7 +235,10 @@ class MotorImagery(BaseMotorImagery):
         if self.events is None:
             log.warning("Choosing from all possible events")
         elif self.n_classes is not None:
-            assert n_classes <= len(self.events), "More classes than events specified"
+            if n_classes > len(self.events):  # was assert, now raises properly
+                raise ValueError(
+                    f"n_classes ({n_classes}) exceeds number of events ({len(self.events)})"
+                )
 
     def is_valid(self, dataset):
         ret = True
@@ -343,7 +346,10 @@ class FilterBankMotorImagery(MotorImagery):
         if self.events is None:
             log.warning("Choosing from all possible events")
         else:
-            assert n_classes <= len(self.events), "More classes than events specified"
+            if n_classes > len(self.events):  # was assert, now raises properly
+                raise ValueError(
+                    f"n_classes ({n_classes}) exceeds number of events ({len(self.events)})"
+                )
 
     def is_valid(self, dataset):
         ret = True

--- a/moabb/paradigms/ssvep.py
+++ b/moabb/paradigms/ssvep.py
@@ -56,7 +56,10 @@ class BaseSSVEP(BaseParadigm):
                 + " from all possible events"
             )
         else:
-            assert n_classes <= len(self.events), "More classes than events specified"
+            if n_classes > len(self.events):  # was assert, now raises properly
+                raise ValueError(
+                    f"n_classes ({n_classes}) exceeds number of events ({len(self.events)})"
+                )
 
     def is_valid(self, dataset):
         """Check if dataset is valid for the SSVEP paradigm."""

--- a/moabb/pipelines/csp.py
+++ b/moabb/pipelines/csp.py
@@ -32,7 +32,8 @@ class TRCSP(CSP):
 
         Nt, Ne, Ns = X.shape
         classes = np.unique(y)
-        assert len(classes) == 2, "Can only do 2-class TRCSP"
+        if len(classes) != 2:  # was assert, now raises properly
+            raise ValueError(f"TRCSP only supports 2 classes, got {len(classes)}")
         # estimate class means
         C = []
         for c in classes:

--- a/moabb/pipelines/features.py
+++ b/moabb/pipelines/features.py
@@ -15,7 +15,8 @@ class LogVariance(BaseEstimator, TransformerMixin):
 
     def transform(self, X):
         """transform."""
-        assert X.ndim == 3
+        if X.ndim != 3:  # was assert, now raises properly
+            raise ValueError(f"X must be 3-dimensional, got {X.ndim}")
         return np.log(np.var(X, -1))
 
 

--- a/moabb/pipelines/utils.py
+++ b/moabb/pipelines/utils.py
@@ -91,14 +91,12 @@ def parse_pipelines_from_directory(dir_path):
         'paradigms': list of class names that are compatible with said pipeline
     """
     if dir_path.endswith(".yml"):
-        assert os.path.isfile(dir_path), "Given pipeline path {} is not valid".format(
-            dir_path
-        )
+        if not os.path.isfile(dir_path):  # was assert, now raises properly
+            raise ValueError(f"Given pipeline path {dir_path} is not valid")
         yaml_files = [dir_path]
     else:
-        assert os.path.isdir(
-            os.path.abspath(dir_path)
-        ), "Given pipeline path {} is not valid".format(dir_path)
+        if not os.path.isdir(os.path.abspath(dir_path)):  # was assert
+            raise ValueError(f"Given pipeline path {dir_path} is not valid")
 
         # get list of config files
         yaml_files = glob(os.path.join(dir_path, "*.yml"))
@@ -192,7 +190,11 @@ def generate_paradigms(pipeline_configs, context=None, logger=log):
             if paradigm not in paradigms.keys():
                 paradigms[paradigm] = {}
 
-            # FIXME name are not unique
+            if config["name"] in paradigms[paradigm]:  # detect name collisions
+                raise ValueError(
+                    f"duplicate pipeline name '{config['name']}' for paradigm "
+                    f"'{paradigm}'. each pipeline must have a unique name."
+                )
             logger.debug("Pipeline: \n\n {} \n".format(get_string_rep(pipeline)))
             paradigms[paradigm][config["name"]] = pipeline
 
@@ -239,14 +241,16 @@ class FilterBank(BaseEstimator, TransformerMixin):
         self.flatten = flatten
 
     def fit(self, X, y=None):
-        assert X.ndim == 4
+        if X.ndim != 4:  # was assert, now raises properly
+            raise ValueError(f"X must be 4-dimensional, got {X.ndim}")
         self.models = [
             deepcopy(self.estimator).fit(X[..., i], y) for i in range(X.shape[-1])
         ]
         return self
 
     def transform(self, X):
-        assert X.ndim == 4
+        if X.ndim != 4:  # was assert
+            raise ValueError(f"X must be 4-dimensional, got {X.ndim}")
         out = [self.models[i].transform(X[..., i]) for i in range(X.shape[-1])]
         assert out[0].ndim == 2, (
             "Each band must return a two dimensional "

--- a/moabb/tests/test_paradigms.py
+++ b/moabb/tests/test_paradigms.py
@@ -567,7 +567,7 @@ class TestMotorImagery(unittest.TestCase):
         assert isinstance(epochs, BaseEpochs)
 
     def test_FilterBankMotorImagery_moreclassesthanevent(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             FilterBankMotorImagery(n_classes=3, events=["hands", "feet"])
 
     def test_FilterBankLeftRightImagery_paradigm(self):
@@ -922,7 +922,7 @@ class TestSSVEP:
             paradigm.get_data(dataset)
 
     def test_BaseSSVEP_moreclassesthanevent(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             BaseSSVEP(n_classes=3, events=["13.", "14."])
 
     def test_BaseSSVEP_droppedevent(self):


### PR DESCRIPTION
## summary

Addresse several code quality and robustness issues across the codebase:

### 1. fix crash bug in huebner_llp.py
- regex match on vhdr filenames could return `None`, causing `.group(1)` to crash
- now raises `ValueError` with a clear message including the filename and expected pattern

### 2. replace `assert` with proper exceptions (14 locations)
- production `assert` statements silently disappear with `python -O`
- converted to `raise ValueError` / `TypeError` across:
  - `analysis/results.py`, `analysis/meta_analysis.py`, `analysis/plotting.py`
  - `pipelines/utils.py`, `pipelines/features.py`, `pipelines/csp.py`
  - `paradigms/ssvep.py`, `paradigms/motor_imagery.py`
  - `datasets/utils.py`
- updated corresponding tests to expect `ValueError` instead of `AssertionError`

### 3. fix pipeline name collision FIXME
- `pipelines/utils.py` had a FIXME for silently overwriting duplicate pipeline names
- now raises `ValueError` identifying the duplicate name and paradigm

### 4. add type hints to evaluation classes
- added type annotations to `BaseEvaluation.__init__`, `process`, `evaluate`, `is_valid`
- added type hints to all 3 concrete evaluation classes (`WithinSession`, `CrossSession`, `CrossSubject`)
- added `TYPE_CHECKING` conditional imports to avoid circular dependencies

### 5. replace `print()` with `logging` in martinezcagigal2023_checker_cvep.py
- replaced 4 bare `print()` calls with proper `log.info()` / `log.error(..., exc_info=True)`

Closes #732 