### PR TITLE
feat: unified interactive macro table for dataset summary

### DIFF
--- a/docs/source/_static/css/macro-table.css
+++ b/docs/source/_static/css/macro-table.css
@@ -3,7 +3,7 @@
    Aesthetic: editorial precision, authoritative data presentation
    =================================================================== */
 
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&display=swap');
+/* Fonts loaded via conf.py html_css_files to avoid render-blocking @import */
 
 /* --------------- Design Tokens --------------- */
 

--- a/docs/source/_static/css/macro-table.css
+++ b/docs/source/_static/css/macro-table.css
@@ -1,0 +1,626 @@
+/* ===================================================================
+   MOABB Macro Table — Refined Scientific Dashboard
+   Aesthetic: editorial precision, authoritative data presentation
+   =================================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&display=swap');
+
+/* --------------- Design Tokens --------------- */
+
+.mt-container {
+  --mt-surface: #ffffff;
+  --mt-surface-raised: #f7f8fa;
+  --mt-surface-hover: #f0f4f8;
+  --mt-border: #e2e8f0;
+  --mt-border-subtle: #edf2f7;
+  --mt-text: #1a202c;
+  --mt-text-secondary: #64748b;
+  --mt-text-muted: #94a3b8;
+  --mt-accent: #0f4c81;
+  --mt-accent-light: #e8f0fe;
+  --mt-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --mt-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+  --mt-radius: 6px;
+  --mt-shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.04), 0 1px 2px rgba(15, 23, 42, 0.06);
+  --mt-shadow-md: 0 4px 12px rgba(15, 23, 42, 0.06), 0 2px 4px rgba(15, 23, 42, 0.04);
+  margin: 0 0 2.5rem;
+}
+
+html[data-theme="dark"] .mt-container {
+  --mt-surface: #0f172a;
+  --mt-surface-raised: #1e293b;
+  --mt-surface-hover: #334155;
+  --mt-border: #334155;
+  --mt-border-subtle: #1e293b;
+  --mt-text: #e2e8f0;
+  --mt-text-secondary: #94a3b8;
+  --mt-text-muted: #64748b;
+  --mt-accent: #60a5fa;
+  --mt-accent-light: rgba(96, 165, 250, 0.1);
+  --mt-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.2);
+  --mt-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* --------------- Experimental Banner --------------- */
+
+.mt-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  margin-bottom: 1.25rem;
+  border-radius: 8px;
+  border: 1px solid #f0ad4e;
+  border-left: 4px solid #f0ad4e;
+  background: linear-gradient(135deg, #fef9ee, #fff8e6);
+  color: #7a5a00;
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.mt-banner-icon {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  color: #d4930a;
+  margin-top: 1px;
+}
+
+.mt-banner-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mt-banner-body strong {
+  color: #8b6914;
+}
+
+.mt-banner-body a {
+  color: #7a5a00;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.mt-banner-body a:hover {
+  color: #543d00;
+}
+
+html[data-theme="dark"] .mt-banner {
+  background: linear-gradient(135deg, #2a2210, #2a2515);
+  border-color: #a07620;
+  color: #e8c76a;
+}
+
+html[data-theme="dark"] .mt-banner-icon {
+  color: #d4a520;
+}
+
+html[data-theme="dark"] .mt-banner-body strong {
+  color: #f0d060;
+}
+
+html[data-theme="dark"] .mt-banner-body a {
+  color: #e8c76a;
+}
+
+/* --------------- Hero Section --------------- */
+
+.mt-hero {
+  background: var(--mt-surface);
+  border: 1px solid var(--mt-border);
+  border-radius: 12px;
+  padding: 1.75rem 2rem 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--mt-shadow-sm);
+}
+
+/* --------------- Summary Cards --------------- */
+
+.mt-cards {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1px;
+  background: var(--mt-border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 1.25rem;
+}
+
+.mt-card {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 1.25rem;
+  background: var(--mt-surface);
+  animation: mt-fade-up 0.4s ease both;
+}
+
+@keyframes mt-fade-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.mt-card-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--mt-accent-light);
+  color: var(--mt-accent);
+}
+
+.mt-card-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.mt-card-body {
+  min-width: 0;
+}
+
+.mt-card-value {
+  font-family: var(--mt-mono);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--mt-text);
+  letter-spacing: -0.02em;
+}
+
+.mt-card-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mt-text-secondary);
+  margin-top: 0.1rem;
+}
+
+.mt-card-sub {
+  font-size: 0.68rem;
+  color: var(--mt-text-muted);
+  margin-top: 0.05rem;
+}
+
+/* --------------- Paradigm Distribution Bar --------------- */
+
+.mt-bar-container {
+  padding-top: 0.25rem;
+}
+
+.mt-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  gap: 2px;
+}
+
+.mt-bar-seg {
+  border-radius: 3px;
+  transition: opacity 0.2s;
+  cursor: default;
+}
+
+.mt-bar-seg:hover {
+  opacity: 0.75;
+}
+
+.mt-bar-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin-top: 0.55rem;
+}
+
+.mt-bar-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--mt-text-secondary);
+  white-space: nowrap;
+}
+
+.mt-bar-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* --------------- Tags --------------- */
+
+.mt-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2em 0.6em;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
+  color: var(--tag-color, #757575);
+  background: color-mix(in srgb, var(--tag-color, #757575) 10%, transparent);
+}
+
+.mt-tag--health {
+  font-size: 0.68rem;
+  font-weight: 500;
+  border-radius: 3px;
+  padding: 0.15em 0.5em;
+}
+
+/* --------------- Table Wrapper --------------- */
+
+.mt-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid var(--mt-border);
+  border-radius: 10px;
+  box-shadow: var(--mt-shadow-sm);
+  background: var(--mt-surface);
+}
+
+/* --------------- DataTables — Table Core --------------- */
+
+#moabb-macro-table {
+  font-size: 0.82rem;
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100% !important;
+  color: var(--mt-text);
+}
+
+/* Header */
+#moabb-macro-table thead th {
+  background: var(--mt-surface-raised);
+  color: var(--mt-text-secondary);
+  font-family: var(--mt-mono);
+  font-weight: 500;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 2px solid var(--mt-border);
+  padding: 0.7rem 0.65rem;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+/* Sorting arrows — make them subtler */
+#moabb-macro-table thead th.dt-orderable-asc span.dt-column-order,
+#moabb-macro-table thead th.dt-orderable-desc span.dt-column-order {
+  opacity: 0.35;
+}
+
+#moabb-macro-table thead th.dt-ordering-asc span.dt-column-order,
+#moabb-macro-table thead th.dt-ordering-desc span.dt-column-order {
+  opacity: 1;
+  color: var(--mt-accent);
+}
+
+/* Body cells */
+#moabb-macro-table tbody td {
+  padding: 0.5rem 0.65rem;
+  border-bottom: 1px solid var(--mt-border-subtle);
+  vertical-align: middle;
+  transition: background 0.1s;
+}
+
+/* Row hover */
+#moabb-macro-table tbody tr:hover td {
+  background: var(--mt-surface-hover) !important;
+}
+
+/* Zebra striping — very subtle */
+#moabb-macro-table tbody tr:nth-child(even) td {
+  background: var(--mt-surface-raised);
+}
+
+/* Paradigm left-border stripe on rows */
+#moabb-macro-table tbody tr {
+  border-left: 3px solid var(--row-paradigm-color, transparent);
+}
+
+/* Dataset link — editorial serif feel */
+.mt-dataset-link {
+  font-family: var(--mt-serif);
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: var(--mt-accent) !important;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s;
+}
+
+.mt-dataset-link:hover {
+  border-bottom-color: var(--mt-accent);
+  text-decoration: none !important;
+}
+
+/* DOI badge */
+.mt-doi {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  font-family: var(--mt-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  padding: 0.15em 0.45em;
+  border-radius: 4px;
+  background: var(--mt-surface-raised);
+  color: var(--mt-text-muted) !important;
+  text-decoration: none !important;
+  border: 1px solid var(--mt-border-subtle);
+  transition: all 0.15s;
+}
+
+.mt-doi:hover {
+  background: var(--mt-accent);
+  color: #fff !important;
+  border-color: var(--mt-accent);
+}
+
+.mt-doi svg {
+  opacity: 0.6;
+}
+.mt-doi:hover svg {
+  opacity: 1;
+  stroke: #fff;
+}
+
+/* Numeric columns: tabular numbers + right-align */
+#moabb-macro-table td:nth-child(3),
+#moabb-macro-table td:nth-child(4),
+#moabb-macro-table td:nth-child(5),
+#moabb-macro-table td:nth-child(6),
+#moabb-macro-table td:nth-child(7),
+#moabb-macro-table td:nth-child(8),
+#moabb-macro-table td:nth-child(9),
+#moabb-macro-table td:nth-child(10),
+#moabb-macro-table td:nth-child(15),
+#moabb-macro-table th:nth-child(3),
+#moabb-macro-table th:nth-child(4),
+#moabb-macro-table th:nth-child(5),
+#moabb-macro-table th:nth-child(6),
+#moabb-macro-table th:nth-child(7),
+#moabb-macro-table th:nth-child(8),
+#moabb-macro-table th:nth-child(9),
+#moabb-macro-table th:nth-child(10),
+#moabb-macro-table th:nth-child(15) {
+  text-align: right;
+  font-family: var(--mt-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.78rem;
+}
+
+/* Empty cells: show a subtle dash */
+#moabb-macro-table tbody td:empty::after {
+  content: '\2014';
+  color: var(--mt-border);
+  font-size: 0.7rem;
+}
+
+/* Truncated text with CSS tooltip */
+.mt-truncated {
+  cursor: help;
+  border-bottom: 1px dotted var(--mt-text-muted);
+  position: relative;
+}
+
+.mt-truncated::after {
+  content: attr(data-full);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  max-width: 360px;
+  padding: 0.5em 0.7em;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 400;
+  line-height: 1.45;
+  white-space: normal;
+  word-break: break-word;
+  color: #fff;
+  background: #1e293b;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.mt-truncated:hover::after {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+html[data-theme="dark"] .mt-truncated::after {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+/* --------------- DataTables Controls --------------- */
+
+.dataTables_wrapper {
+  font-size: 0.82rem;
+  color: var(--mt-text-secondary);
+}
+
+.dataTables_wrapper .dataTables_length,
+.dataTables_wrapper .dataTables_filter,
+.dataTables_wrapper .dataTables_info,
+.dataTables_wrapper .dataTables_paginate {
+  margin: 0.6rem 0;
+}
+
+.dataTables_wrapper .dataTables_filter input {
+  border: 1px solid var(--mt-border);
+  border-radius: var(--mt-radius);
+  padding: 0.4rem 0.7rem;
+  font-size: 0.82rem;
+  background: var(--mt-surface);
+  color: var(--mt-text);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.dataTables_wrapper .dataTables_filter input:focus {
+  outline: none;
+  border-color: var(--mt-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mt-accent) 15%, transparent);
+}
+
+/* Buttons */
+.dataTables_wrapper .dt-buttons {
+  margin-bottom: 0.75rem;
+}
+
+.dataTables_wrapper .dt-buttons .dt-button {
+  font-size: 0.76rem;
+  font-weight: 500;
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--mt-radius);
+  border: 1px solid var(--mt-border);
+  background: var(--mt-surface);
+  color: var(--mt-text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-right: 0.4rem;
+}
+
+.dataTables_wrapper .dt-buttons .dt-button:hover {
+  background: var(--mt-accent);
+  color: #fff;
+  border-color: var(--mt-accent);
+  box-shadow: var(--mt-shadow-sm);
+}
+
+.dataTables_wrapper .dt-buttons .dt-button:active,
+.dataTables_wrapper .dt-buttons .dt-button.dt-button-active {
+  background: var(--mt-accent);
+  color: #fff;
+  border-color: var(--mt-accent);
+}
+
+/* Pagination */
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+  font-size: 0.78rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: var(--mt-radius);
+  border: 1px solid transparent;
+  margin: 0 1px;
+  transition: all 0.1s;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+  background: var(--mt-surface-hover) !important;
+  border-color: var(--mt-border);
+  color: var(--mt-text) !important;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current {
+  background: var(--mt-accent) !important;
+  color: #fff !important;
+  border-color: var(--mt-accent) !important;
+  font-weight: 600;
+}
+
+/* Length selector */
+.dataTables_wrapper .dataTables_length select {
+  border: 1px solid var(--mt-border);
+  border-radius: var(--mt-radius);
+  padding: 0.3rem 0.5rem;
+  background: var(--mt-surface);
+  color: var(--mt-text);
+  font-size: 0.82rem;
+}
+
+/* --------------- SearchPanes --------------- */
+
+div.dtsp-searchPane {
+  border: 1px solid var(--mt-border) !important;
+  border-radius: 8px !important;
+  overflow: hidden;
+  background: var(--mt-surface);
+}
+
+div.dtsp-searchPane table.dataTable thead th {
+  font-family: var(--mt-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.45rem 0.55rem;
+  background: var(--mt-surface-raised);
+  color: var(--mt-text-secondary);
+}
+
+div.dtsp-searchPane table.dataTable tbody td {
+  font-size: 0.78rem;
+  padding: 0.35rem 0.55rem;
+  color: var(--mt-text);
+}
+
+div.dtsp-searchPane table.dataTable tbody tr.selected td {
+  background: var(--mt-accent-light) !important;
+  color: var(--mt-accent) !important;
+  font-weight: 600;
+}
+
+div.dtsp-topRow {
+  margin-bottom: 1rem;
+}
+
+/* --------------- FixedHeader Override --------------- */
+
+table.dataTable.fixedHeader-floating {
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.12);
+}
+
+/* --------------- Responsive --------------- */
+
+@media (max-width: 1000px) {
+  .mt-cards {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .mt-hero {
+    padding: 1rem;
+    border-radius: 8px;
+  }
+  .mt-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .mt-card {
+    padding: 0.75rem 0.85rem;
+    gap: 0.6rem;
+  }
+  .mt-card-icon {
+    width: 30px;
+    height: 30px;
+  }
+  .mt-card-icon svg {
+    width: 14px;
+    height: 14px;
+  }
+  .mt-card-value {
+    font-size: 1.2rem;
+  }
+  .mt-table-wrapper {
+    border-radius: 8px;
+  }
+  #moabb-macro-table {
+    font-size: 0.75rem;
+  }
+}

--- a/docs/source/_static/js/macro-table.js
+++ b/docs/source/_static/js/macro-table.js
@@ -1,0 +1,263 @@
+/**
+ * MOABB Macro Table — DataTables initialization.
+ *
+ * Uses DataTables extensions: Buttons (CSV, ColVis, Print),
+ * SearchPanes, Select, FixedHeader.
+ */
+document.addEventListener("DOMContentLoaded", function () {
+  var $table = $("#moabb-macro-table");
+  if (!$table.length) return;
+
+  // --- Column config matching Python _TABLE_COLUMNS order ---
+  var columns = [
+    // Visible by default
+    /* 0  */ { name: "Dataset",       visible: true,  type: "string" },
+    /* 1  */ { name: "Paradigm",      visible: true,  type: "string",  pane: true },
+    /* 2  */ { name: "#Subj",         visible: true,  type: "num" },
+    /* 3  */ { name: "#Chan",         visible: true,  type: "num" },
+    /* 4  */ { name: "#EEG",          visible: true,  type: "num" },
+    /* 5  */ { name: "#Classes",      visible: true,  type: "num" },
+    /* 6  */ { name: "Freq",          visible: true,  type: "num" },
+    /* 7  */ { name: "Trial",         visible: true,  type: "num" },
+    /* 8  */ { name: "#Sess",         visible: true,  type: "num" },
+    /* 9  */ { name: "#Runs",         visible: true,  type: "num" },
+    /* 10 */ { name: "Health",        visible: true,  type: "string",  pane: true },
+    /* 11 */ { name: "#Trials",       visible: true,  type: "string" },
+    /* 12 */ { name: "Country",       visible: true,  type: "string",  pane: true },
+    /* 13 */ { name: "Year",          visible: true,  type: "num" },
+    /* 14 */ { name: "DOI",           visible: true,  type: "string" },
+    // Hidden by default
+    /* 15 */ { name: "Class Labels",  visible: false, type: "string" },
+    /* 16 */ { name: "Stimulus",      visible: false, type: "string",  pane: true },
+    /* 17 */ { name: "Modality",      visible: false, type: "string",  pane: true },
+    /* 18 */ { name: "Feedback",      visible: false, type: "string",  pane: true },
+    /* 19 */ { name: "Sync",          visible: false, type: "string",  pane: true },
+    /* 20 */ { name: "Mode",          visible: false, type: "string",  pane: true },
+    /* 21 */ { name: "Study Design",  visible: false, type: "string" },
+    /* 22 */ { name: "Hardware",      visible: false, type: "string",  pane: true },
+    /* 23 */ { name: "Reference",     visible: false, type: "string" },
+    /* 24 */ { name: "Sensor Type",   visible: false, type: "string",  pane: true },
+    /* 25 */ { name: "Montage",       visible: false, type: "string" },
+    /* 26 */ { name: "Line Freq",     visible: false, type: "num" },
+    /* 27 */ { name: "Filters",       visible: false, type: "string" },
+    /* 28 */ { name: "Cap Mfr",       visible: false, type: "string" },
+    /* 29 */ { name: "Software",      visible: false, type: "string" },
+    /* 30 */ { name: "Clinical Pop.", visible: false, type: "string" },
+    /* 31 */ { name: "Age Mean",      visible: false, type: "num" },
+    /* 32 */ { name: "Age Min",       visible: false, type: "num" },
+    /* 33 */ { name: "Age Max",       visible: false, type: "num" },
+    /* 34 */ { name: "Gender",        visible: false, type: "string" },
+    /* 35 */ { name: "Handedness",    visible: false, type: "string" },
+    /* 36 */ { name: "BCI Exp.",      visible: false, type: "string",  pane: true },
+    /* 37 */ { name: "License",       visible: false, type: "string",  pane: true },
+    /* 38 */ { name: "Institution",   visible: false, type: "string" },
+    /* 39 */ { name: "Repository",    visible: false, type: "string",  pane: true },
+    /* 40 */ { name: "Duration (h)",  visible: false, type: "num" },
+    /* 41 */ { name: "Author",        visible: false, type: "string" },
+    /* 42 */ { name: "Data URL",      visible: false, type: "string" },
+    /* 43 */ { name: "Pathology Tags",visible: false, type: "string",  pane: true },
+    /* 44 */ { name: "Modality Tags", visible: false, type: "string",  pane: true },
+    /* 45 */ { name: "Type Tags",     visible: false, type: "string",  pane: true },
+    /* 46 */ { name: "File Format",   visible: false, type: "string",  pane: true },
+    /* 47 */ { name: "EOG",           visible: false, type: "string" },
+    /* 48 */ { name: "EMG",           visible: false, type: "string" },
+    /* 49 */ { name: "#Blocks",       visible: false, type: "num" },
+    /* 50 */ { name: "Trials Context",visible: false, type: "string" },
+    /* 51 */ { name: "Stim. Freqs",   visible: false, type: "string" },
+    /* 52 */ { name: "Code Type",     visible: false, type: "string",  pane: true },
+    /* 53 */ { name: "#Targets",      visible: false, type: "num" },
+    /* 54 */ { name: "#Repetitions",  visible: false, type: "num" },
+    /* 55 */ { name: "ISI (ms)",      visible: false, type: "num" },
+    /* 56 */ { name: "SOA (ms)",      visible: false, type: "num" },
+    /* 57 */ { name: "MI Tasks",      visible: false, type: "string" },
+  ];
+
+  var COL_PARADIGM = 1;
+  var COL_SUBJ = 2;
+  var COL_HEALTH = 10;
+  var COL_COUNTRY = 12;
+
+  // Build column indices dynamically
+  var hiddenCols = [];
+  var numericCols = [];
+  var paneCols = [];
+
+  columns.forEach(function (col, i) {
+    if (!col.visible) hiddenCols.push(i);
+    if (col.type === "num") numericCols.push(i);
+    if (col.pane) paneCols.push(i);
+  });
+
+  // Columns containing HTML tags (need stripping for sort/filter)
+  var htmlCols = [COL_PARADIGM, COL_HEALTH];
+
+  function stripHtml(html) {
+    var tmp = document.createElement("div");
+    tmp.innerHTML = html;
+    return (tmp.textContent || tmp.innerText || "").trim();
+  }
+
+  var columnDefs = [
+    { targets: hiddenCols, visible: false },
+    { targets: numericCols, type: "num" },
+    {
+      targets: htmlCols,
+      render: function (data, type) {
+        if (type === "display") return data;
+        return stripHtml(data);
+      },
+    },
+    { targets: "_all", searchPanes: { show: false } },
+    { targets: paneCols, searchPanes: { show: true } },
+  ];
+
+  var table = $table.DataTable({
+    dom: "Blfrtip",
+    paging: false,
+    ordering: true,
+    orderMulti: true,
+    order: [[0, "asc"]],
+    fixedHeader: true,
+    columnDefs: columnDefs,
+    buttons: [
+      {
+        extend: "searchPanes",
+        text: "Filter",
+        config: {
+          cascadePanes: true,
+          viewTotal: true,
+          layout: "columns-4",
+          orderable: false,
+          columns: paneCols,
+        },
+      },
+      {
+        extend: "colvis",
+        text: "Columns",
+        columns: ":gt(0)",
+      },
+      {
+        extend: "csv",
+        text: "CSV",
+        exportOptions: { orthogonal: "export" },
+      },
+      {
+        extend: "print",
+        text: "Print",
+        exportOptions: { orthogonal: "export" },
+      },
+    ],
+    language: {
+      searchPanes: {
+        title: { _: "%d Filters Active", 0: "" },
+      },
+    },
+  });
+
+  // ---- Paradigm bar: click to filter ----
+
+  document.querySelectorAll(".mt-bar-seg").forEach(function (seg) {
+    seg.style.cursor = "pointer";
+    seg.addEventListener("click", function () {
+      var title = seg.getAttribute("title") || "";
+      // Extract paradigm label from title like "Motor Imagery: 53 datasets (36%)"
+      var label = title.split(":")[0].trim();
+      if (label) {
+        table.column(COL_PARADIGM).search(label).draw();
+      }
+    });
+  });
+
+  document.querySelectorAll(".mt-bar-legend-item").forEach(function (item) {
+    item.style.cursor = "pointer";
+    item.addEventListener("click", function () {
+      var text = item.textContent.trim();
+      // Extract label from "Motor Imagery (53)"
+      var label = text.replace(/\s*\(\d+\)$/, "").trim();
+      if (label) {
+        table.column(COL_PARADIGM).search(label).draw();
+      }
+    });
+  });
+
+  // ---- Paradigm tags in table: click to filter ----
+
+  $table.on("click", ".mt-tag[data-paradigm]", function () {
+    var paradigm = stripHtml(this.innerHTML);
+    table.column(COL_PARADIGM).search(paradigm).draw();
+  });
+
+  // Make paradigm tags look clickable
+  $table.find(".mt-tag[data-paradigm]").css("cursor", "pointer");
+
+  // ---- Dynamic summary card + bar updates on filter ----
+
+  function updateSummaryCards() {
+    var filteredData = table.rows({ search: "applied" }).data();
+    var totalDatasets = filteredData.length;
+    var totalSubjects = 0;
+    var paradigms = {};
+    var countries = {};
+
+    filteredData.each(function (row) {
+      totalSubjects += parseFloat(row[COL_SUBJ]) || 0;
+
+      var p = stripHtml(row[COL_PARADIGM]);
+      if (p) paradigms[p] = (paradigms[p] || 0) + 1;
+
+      var c = (row[COL_COUNTRY] || "").trim();
+      if (c) countries[c] = true;
+    });
+
+    // Update cards
+    var cards = document.querySelectorAll("#mt-cards .mt-card");
+    if (cards.length >= 4) {
+      cards[0].querySelector(".mt-card-value").textContent = totalDatasets;
+      cards[1].querySelector(".mt-card-value").textContent =
+        totalSubjects.toLocaleString();
+      cards[2].querySelector(".mt-card-value").textContent =
+        Object.keys(paradigms).length;
+      cards[3].querySelector(".mt-card-value").textContent =
+        Object.keys(countries).length;
+    }
+
+    // Update paradigm bar
+    var barSegs = document.querySelectorAll(".mt-bar-seg");
+    var legendItems = document.querySelectorAll(".mt-bar-legend-item");
+    if (barSegs.length > 0) {
+      barSegs.forEach(function (seg) {
+        var title = seg.getAttribute("title") || "";
+        var label = title.split(":")[0].trim();
+        var count = paradigms[label] || 0;
+        var pct = totalDatasets > 0 ? (count / totalDatasets) * 100 : 0;
+        seg.style.width = pct.toFixed(1) + "%";
+        seg.setAttribute(
+          "title",
+          label + ": " + count + " datasets (" + Math.round(pct) + "%)"
+        );
+      });
+    }
+    legendItems.forEach(function (item) {
+      var text = item.textContent.trim();
+      var label = text.replace(/\s*\(\d+\)$/, "").trim();
+      var count = paradigms[label] || 0;
+      // Update the text node after the dot span
+      var dot = item.querySelector(".mt-bar-dot");
+      if (dot) {
+        item.textContent = "";
+        item.appendChild(dot);
+        item.appendChild(document.createTextNode(" " + label + " (" + count + ")"));
+      }
+    });
+  }
+
+  table.on("search.dt", updateSummaryCards);
+
+  // ---- Reset filter on double-click bar/legend ----
+
+  document.querySelectorAll(".mt-bar-seg, .mt-bar-legend-item").forEach(function (el) {
+    el.addEventListener("dblclick", function () {
+      table.column(COL_PARADIGM).search("").draw();
+    });
+  });
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,6 +79,7 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "gh_substitutions",
     "dataset_timeline_ext",
+    "macro_table_ext",
     "myst_parser",
     "numpydoc",
     "sphinx_favicon",
@@ -317,13 +318,35 @@ sitemap_url_scheme = "{link}"
 
 html_css_files = [
     "css/custom.css",
-    "https://cdn.datatables.net/v/dt/dt-2.0.4/b-3.0.2/b-html5-3.0.2/datatables.min.css",
+    "css/macro-table.css",
+    # DataTables core + extensions (all from CDN)
+    "https://cdn.datatables.net/2.2.0/css/dataTables.dataTables.css",
+    "https://cdn.datatables.net/buttons/3.2.6/css/buttons.dataTables.css",
+    "https://cdn.datatables.net/searchpanes/2.3.5/css/searchPanes.dataTables.css",
+    "https://cdn.datatables.net/select/3.1.3/css/select.dataTables.css",
+    "https://cdn.datatables.net/fixedheader/4.0.6/css/fixedHeader.dataTables.css",
+    "https://cdn.datatables.net/responsive/3.0.8/css/responsive.dataTables.css",
 ]
 
 html_js_files = [
     "https://code.jquery.com/jquery-3.7.1.min.js",
-    "https://cdn.datatables.net/v/dt/dt-2.0.4/b-3.0.2/b-html5-3.0.2/datatables.min.js",
+    # DataTables core
+    "https://cdn.datatables.net/2.2.0/js/dataTables.js",
+    # Buttons (core + HTML5 export + column visibility + print)
+    "https://cdn.datatables.net/buttons/3.2.6/js/dataTables.buttons.js",
+    "https://cdn.datatables.net/buttons/3.2.6/js/buttons.html5.js",
+    "https://cdn.datatables.net/buttons/3.2.6/js/buttons.colVis.js",
+    "https://cdn.datatables.net/buttons/3.2.6/js/buttons.print.js",
+    # SearchPanes + Select (required by SearchPanes)
+    "https://cdn.datatables.net/select/3.1.3/js/dataTables.select.js",
+    "https://cdn.datatables.net/searchpanes/2.3.5/js/dataTables.searchPanes.js",
+    "https://cdn.datatables.net/searchpanes/2.3.5/js/searchPanes.dataTables.js",
+    # FixedHeader (sticky header on scroll)
+    "https://cdn.datatables.net/fixedheader/4.0.6/js/dataTables.fixedHeader.js",
+    # Responsive (collapse columns on small screens)
+    "https://cdn.datatables.net/responsive/3.0.8/js/dataTables.responsive.js",
     "js/section-nav-hierarchy.js",
+    "js/macro-table.js",
 ]
 
 # If true, links to the reST sources are added to the pages.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -318,6 +318,7 @@ sitemap_url_scheme = "{link}"
 
 html_css_files = [
     "css/custom.css",
+    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&display=swap",
     "css/macro-table.css",
     # DataTables core + extensions (all from CDN)
     "https://cdn.datatables.net/2.2.0/css/dataTables.dataTables.css",
@@ -325,7 +326,6 @@ html_css_files = [
     "https://cdn.datatables.net/searchpanes/2.3.5/css/searchPanes.dataTables.css",
     "https://cdn.datatables.net/select/3.1.3/css/select.dataTables.css",
     "https://cdn.datatables.net/fixedheader/4.0.6/css/fixedHeader.dataTables.css",
-    "https://cdn.datatables.net/responsive/3.0.8/css/responsive.dataTables.css",
 ]
 
 html_js_files = [
@@ -343,8 +343,6 @@ html_js_files = [
     "https://cdn.datatables.net/searchpanes/2.3.5/js/searchPanes.dataTables.js",
     # FixedHeader (sticky header on scroll)
     "https://cdn.datatables.net/fixedheader/4.0.6/js/dataTables.fixedHeader.js",
-    # Responsive (collapse columns on small screens)
-    "https://cdn.datatables.net/responsive/3.0.8/js/dataTables.responsive.js",
     "js/section-nav-hierarchy.js",
     "js/macro-table.js",
 ]

--- a/docs/source/dataset_summary.rst
+++ b/docs/source/dataset_summary.rst
@@ -8,20 +8,37 @@
 Data Summary
 ======================
 
-MOABB gather many datasets, here is list summarizing important information. Most of the
-datasets are listed here but this list not complete yet, check API for complete
-documentation.
+MOABB gathers many datasets for BCI research. Use the interactive table below to explore,
+filter by paradigm, health status, country, or license, and export to CSV. Click any
+dataset name for full documentation.
 
-Do not hesitate to help us complete this list. It is also possible to add new datasets,
-there is a tutorial explaining how to do so, and we welcome warmly any new contributions!
+It is also possible to add new datasets — there is a
+`tutorial <https://moabb.neurotechx.com/docs/auto_examples/tutorials/tutorial_4_adding_a_dataset.html>`__
+explaining how to do so, and we welcome any new contributions!
 
-It is possible to use an external dataset within MOABB as long as it is in Brain Imaging Data Structure (BIDS) format.
-See this `guide <https://bids-specification.readthedocs.io/en/stable/#:~:text=The%20Brain%20Imaging%20Data%20Structure%20(BIDS)%20is%20a%20simple%20and,to%20help%20implement%20the%20standard.>`__ for more information on how to structure your data according to BIDS
-You can use this `class <https://moabb.neurotechx.com/docs/generated/moabb.datasets.base.LocalBIDSDataset.html>`__ to convert your local dataset to work within MOABB without creating a new dataset class.
+External datasets in `BIDS <https://bids-specification.readthedocs.io/en/stable/>`__
+format can also be used via
+:class:`~moabb.datasets.base.LocalBIDSDataset`.
 
-See also the `Wiki <https://github.com/NeuroTechX/moabb/wiki>`__ for supplementary
-detail on datasets (class name, size, licence, etc.)
-Dataset, #Subj, #Chan, #Classes, #Trials, Trial length, Freq, #Session, #Runs, Total_trials
+<!-- MACRO_TABLE -->
+
+**Datasets overview:**
+
+A visual overview of all datasets can be generated using the functions :func:`moabb.datasets.utils.plot_datasets_grid`
+or :func:`moabb.datasets.utils.plot_datasets_cluster`.
+This overview allows to quickly compare the number of subjects, trials, and sessions across different datasets.
+The function will generate a figure like this:
+
+.. figure:: images/datasets_overview.png
+   :alt: Visual overview from the datasets used on the `The largest EEG-based BCI reproducibility study for open science: the MOABB benchmark <https://universite-paris-saclay.hal.science/hal-04537061v1/file/MOABB-arXiv.pdf>`_
+   :width: 100%
+
+
+Per-Paradigm Detail Tables
+==========================
+
+The tables below provide paradigm-specific details (trial counts, epoch structure, etc.)
+that differ across paradigm types.
 
 Column definitions:
 
@@ -34,17 +51,6 @@ Column definitions:
 - **Freq** is the sampling frequency of the raw data.
 - **#Session** is the number of sessions per subject. Different sessions are often recorded on different days.
 - **#Runs** is the number of runs per session. A run is a continuous recording of the EEG data. Often, the different runs of a given session are recorded without removing the EEG cap in between.
-
-**Datasets overview:**
-
-A visual overview of all datasets can be generated using the functions :func:`moabb.datasets.utils.plot_datasets_grid`
-or :func:`moabb.datasets.utils.plot_datasets_cluster`.
-This overview allows to quickly compare the number of subjects, trials, and sessions across different datasets.
-The function will generate a figure like this:
-
-.. figure:: images/datasets_overview.png
-   :alt: Visual overview from the datasets used on the `The largest EEG-based BCI reproducibility study for open science: the MOABB benchmark <https://universite-paris-saclay.hal.science/hal-04537061v1/file/MOABB-arXiv.pdf>`_
-   :width: 100%
 
 
 Motor Imagery
@@ -171,14 +177,12 @@ If you want to actively contribute to inclusion of one new dataset, you can foll
 
 .. raw:: html
 
-   <script type="text/javascript" src="https://cdn.datatables.net/v/bm/dt-1.13.4/datatables.min.js"></script>
    <script type="text/javascript">
     $(document).ready(function() {
     $('.sortable').DataTable({
       "paging": false,
       "searching": false,
       "info": false
-
     });
     });
    </script>

--- a/docs/source/sphinxext/dataset_constants.py
+++ b/docs/source/sphinxext/dataset_constants.py
@@ -1,0 +1,114 @@
+"""Shared constants and helpers for dataset documentation extensions.
+
+Used by both ``dataset_timeline_ext`` and ``macro_table_ext`` (via
+``scripts/generate_macro_table.py``).
+"""
+
+from __future__ import annotations
+
+import pycountry
+
+
+# ---------------------------------------------------------------------------
+# Paradigm display metadata
+# ---------------------------------------------------------------------------
+
+PARADIGM_LABELS = {
+    "imagery": "Motor Imagery",
+    "p300": "P300 / ERP",
+    "erp": "P300 / ERP",
+    "ssvep": "SSVEP",
+    "cvep": "c-VEP",
+    "rstate": "Resting State",
+}
+
+PARADIGM_COLORS = {
+    "imagery": "#1565C0",
+    "p300": "#D32F2F",
+    "erp": "#D32F2F",
+    "ssvep": "#2E7D32",
+    "cvep": "#00695C",
+    "rstate": "#546E7A",
+}
+
+
+# ---------------------------------------------------------------------------
+# Country helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_country(raw: str | None) -> str | None:
+    """Normalize a country string to ISO 3166-1 alpha-2 code using pycountry.
+
+    Parameters
+    ----------
+    raw : str or None
+        Country name, ISO alpha-2 code, or ISO alpha-3 code.
+
+    Returns
+    -------
+    str or None
+        Two-letter ISO 3166-1 alpha-2 code, or None if not recognized.
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    if len(raw) == 2:
+        return raw.upper()
+    try:
+        return pycountry.countries.lookup(raw).alpha_2
+    except LookupError:
+        return None
+
+
+def country_flag(code: str | None) -> str:
+    """Return a flag emoji for an ISO 3166-1 alpha-2 country code.
+
+    Parameters
+    ----------
+    code : str or None
+        Two-letter country code (e.g. ``"FR"``, ``"US"``).
+
+    Returns
+    -------
+    str
+        Flag emoji string, or empty string if code is invalid.
+    """
+    if not code or len(code) != 2:
+        return ""
+    return "".join(chr(0x1F1E6 + ord(c) - ord("A")) for c in code.upper())
+
+
+# ---------------------------------------------------------------------------
+# Health status
+# ---------------------------------------------------------------------------
+
+
+def normalize_health(status: str) -> str:
+    """Normalize health status to ``'healthy'``, ``'patients'``, or ``'mixed'``.
+
+    Non-standard values (e.g. ``"ALS patients"``, ``"stroke (recovery phase)"``)
+    are mapped to ``"patients"``.  The original value can be preserved separately
+    for tooltip display.
+
+    Parameters
+    ----------
+    status : str
+        Raw health status string from dataset metadata.
+
+    Returns
+    -------
+    str
+        Normalized category: ``"healthy"``, ``"patients"``, ``"mixed"``, or
+        the original string if it cannot be classified.
+    """
+    if not status:
+        return ""
+    s = status.lower().strip()
+    if s == "healthy":
+        return "healthy"
+    if "mixed" in s:
+        return "mixed"
+    if "patient" in s or "stroke" in s or "damage" in s or "pain" in s:
+        return "patients"
+    return status

--- a/docs/source/sphinxext/dataset_timeline_ext.py
+++ b/docs/source/sphinxext/dataset_timeline_ext.py
@@ -28,24 +28,18 @@ from html import escape
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
+from dataset_constants import (
+    PARADIGM_COLORS,
+    PARADIGM_LABELS,
+)
+from dataset_constants import country_flag as _country_flag_iso
+from dataset_constants import (
+    normalize_country,
+)
 
-_PARADIGM_LABELS = {
-    "p300": "P300 / ERP",
-    "erp": "P300 / ERP",
-    "imagery": "Motor Imagery",
-    "ssvep": "SSVEP",
-    "cvep": "c-VEP",
-    "rstate": "Resting State",
-}
 
-_PARADIGM_COLORS = {
-    "p300": "#D32F2F",
-    "erp": "#D32F2F",
-    "imagery": "#1565C0",
-    "ssvep": "#2E7D32",
-    "cvep": "#00695C",
-    "rstate": "#546E7A",
-}
+_PARADIGM_LABELS = PARADIGM_LABELS
+_PARADIGM_COLORS = PARADIGM_COLORS
 
 _BENCHMARK_FILES = [
     ("within_session_mi_left_vs_right_hand.csv", "MI left vs right"),
@@ -1222,70 +1216,10 @@ def _make_github_issue_url(cls_name):
     return escape(url, quote=True)
 
 
-_COUNTRY_TO_ISO2 = {
-    "argentina": "AR",
-    "australia": "AU",
-    "austria": "AT",
-    "belgium": "BE",
-    "brazil": "BR",
-    "canada": "CA",
-    "chile": "CL",
-    "china": "CN",
-    "colombia": "CO",
-    "czech republic": "CZ",
-    "czechia": "CZ",
-    "denmark": "DK",
-    "egypt": "EG",
-    "finland": "FI",
-    "france": "FR",
-    "germany": "DE",
-    "greece": "GR",
-    "hungary": "HU",
-    "india": "IN",
-    "iran": "IR",
-    "ireland": "IE",
-    "israel": "IL",
-    "italy": "IT",
-    "japan": "JP",
-    "malaysia": "MY",
-    "mexico": "MX",
-    "netherlands": "NL",
-    "new zealand": "NZ",
-    "norway": "NO",
-    "pakistan": "PK",
-    "poland": "PL",
-    "portugal": "PT",
-    "romania": "RO",
-    "russia": "RU",
-    "saudi arabia": "SA",
-    "singapore": "SG",
-    "south korea": "KR",
-    "korea": "KR",
-    "spain": "ES",
-    "sweden": "SE",
-    "switzerland": "CH",
-    "taiwan": "TW",
-    "thailand": "TH",
-    "turkey": "TR",
-    "uk": "GB",
-    "united kingdom": "GB",
-    "usa": "US",
-    "united states": "US",
-    "vietnam": "VN",
-}
-
-
 def _country_flag(country_str):
     """Return a flag emoji for a country name or ISO 3166-1 alpha-2 code."""
-    if not country_str:
-        return ""
-    key = country_str.strip().lower()
-    # Try direct lookup in name map, then treat input as ISO code
-    iso2 = _COUNTRY_TO_ISO2.get(key, country_str.strip().upper())
-    if len(iso2) != 2 or not iso2.isalpha():
-        return ""
-    # Convert to regional indicator symbols (Unicode flag)
-    return "".join(chr(0x1F1E6 + ord(c) - ord("A")) for c in iso2.upper())
+    iso2 = normalize_country(country_str)
+    return _country_flag_iso(iso2)
 
 
 def _highlight_python(code):

--- a/docs/source/sphinxext/dataset_timeline_ext.py
+++ b/docs/source/sphinxext/dataset_timeline_ext.py
@@ -28,14 +28,25 @@ from html import escape
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
-from dataset_constants import (
-    PARADIGM_COLORS,
-    PARADIGM_LABELS,
-)
-from dataset_constants import country_flag as _country_flag_iso
-from dataset_constants import (
-    normalize_country,
-)
+
+try:
+    from dataset_constants import (
+        PARADIGM_COLORS,
+        PARADIGM_LABELS,
+    )
+    from dataset_constants import country_flag as _country_flag_iso
+    from dataset_constants import (
+        normalize_country,
+    )
+except ImportError:
+    from docs.source.sphinxext.dataset_constants import (
+        PARADIGM_COLORS,
+        PARADIGM_LABELS,
+    )
+    from docs.source.sphinxext.dataset_constants import country_flag as _country_flag_iso
+    from docs.source.sphinxext.dataset_constants import (
+        normalize_country,
+    )
 
 
 _PARADIGM_LABELS = PARADIGM_LABELS

--- a/docs/source/sphinxext/macro_table_ext.py
+++ b/docs/source/sphinxext/macro_table_ext.py
@@ -1,0 +1,43 @@
+"""Sphinx extension: inject pre-generated macro table into dataset_summary.
+
+The heavy lifting (metadata extraction, HTML generation) is done by
+``scripts/generate_macro_table.py``, which writes a self-contained HTML
+fragment to ``_static/macro_table.html``.  This extension simply reads
+that file and replaces the ``<!-- MACRO_TABLE -->`` placeholder in
+``dataset_summary.rst`` at source-read time.
+"""
+
+import os
+
+
+def _on_source_read(app, docname, source):
+    if docname != "dataset_summary":
+        return
+
+    placeholder = "<!-- MACRO_TABLE -->"
+    if placeholder not in source[0]:
+        return
+
+    html_path = os.path.join(app.srcdir, "_static", "macro_table.html")
+    if not os.path.isfile(html_path):
+        app.warn(
+            "macro_table_ext: %s not found. "
+            "Run 'python scripts/generate_macro_table.py' first." % html_path
+        )
+        source[0] = source[0].replace(placeholder, "")
+        return
+
+    with open(html_path, encoding="utf-8") as fh:
+        macro_html = fh.read()
+
+    # Wrap in raw HTML directive for RST processing
+    raw_block = "\n.. raw:: html\n\n"
+    raw_block += "\n".join("   " + line for line in macro_html.splitlines())
+    raw_block += "\n\n"
+
+    source[0] = source[0].replace(placeholder, raw_block)
+
+
+def setup(app):
+    app.connect("source-read", _on_source_read)
+    return {"version": "0.1", "parallel_read_safe": True}

--- a/docs/source/sphinxext/macro_table_ext.py
+++ b/docs/source/sphinxext/macro_table_ext.py
@@ -7,7 +7,11 @@ that file and replaces the ``<!-- MACRO_TABLE -->`` placeholder in
 ``dataset_summary.rst`` at source-read time.
 """
 
+import logging
 import os
+
+
+logger = logging.getLogger(__name__)
 
 
 def _on_source_read(app, docname, source):
@@ -20,9 +24,10 @@ def _on_source_read(app, docname, source):
 
     html_path = os.path.join(app.srcdir, "_static", "macro_table.html")
     if not os.path.isfile(html_path):
-        app.warn(
+        logger.warning(
             "macro_table_ext: %s not found. "
-            "Run 'python scripts/generate_macro_table.py' first." % html_path
+            "Run 'python scripts/generate_macro_table.py' first.",
+            html_path,
         )
         source[0] = source[0].replace(placeholder, "")
         return

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -19,7 +19,7 @@ Version 1.6  (Source - GitHub)
 
 Enhancements
 ~~~~~~~~~~~~
-- None yet.
+- Add unified interactive macro table for dataset summary page with 58 metadata columns, SearchPanes filtering, paradigm distribution bar, and CSV export (:gh:`1043`).
 
 API changes
 ~~~~~~~~~~~

--- a/examples/how_to_benchmark/benchmark/LeftRightImagery/analysis/info.txt
+++ b/examples/how_to_benchmark/benchmark/LeftRightImagery/analysis/info.txt
@@ -1,8 +1,0 @@
-Date: 2026-03-03
- Time: 17:33
-System: Darwin
-CPU: arm
-Date: 2026-03-03
- Time: 18:13
-System: Darwin
-CPU: arm

--- a/scripts/generate_macro_table.py
+++ b/scripts/generate_macro_table.py
@@ -219,13 +219,6 @@ def _fmt_freq_list(val) -> str:
 # ---------------------------------------------------------------------------
 
 
-# Aliases not recognized by pycountry.countries.lookup()
-_COUNTRY_ALIASES = {
-    "Korea": "KR",
-    "Turkey": "TR",
-}
-
-
 def _normalize_country(raw: str | None) -> str | None:
     """Normalize a country string to ISO 3166-1 alpha-2 code using pycountry."""
     if not raw:
@@ -233,8 +226,6 @@ def _normalize_country(raw: str | None) -> str | None:
     raw = raw.strip()
     if len(raw) == 2:
         return raw.upper()
-    if raw in _COUNTRY_ALIASES:
-        return _COUNTRY_ALIASES[raw]
     try:
         return pycountry.countries.lookup(raw).alpha_2
     except LookupError:

--- a/scripts/generate_macro_table.py
+++ b/scripts/generate_macro_table.py
@@ -16,34 +16,28 @@ import sys
 from pathlib import Path
 
 import pandas as pd
-import pycountry
 
 
-# Ensure the repo root is importable
+# Ensure the repo root and sphinxext dir are importable
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "docs" / "source" / "sphinxext"))
+
+from dataset_constants import (  # noqa: E402
+    PARADIGM_COLORS,
+    PARADIGM_LABELS,
+    country_flag,
+    normalize_country,
+    normalize_health,
+)
+
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-_PARADIGM_LABELS = {
-    "imagery": "Motor Imagery",
-    "p300": "P300 / ERP",
-    "erp": "P300 / ERP",
-    "ssvep": "SSVEP",
-    "cvep": "c-VEP",
-    "rstate": "Resting State",
-}
-
-_PARADIGM_COLORS = {
-    "imagery": "#1565C0",
-    "p300": "#D32F2F",
-    "erp": "#D32F2F",
-    "ssvep": "#2E7D32",
-    "cvep": "#00695C",
-    "rstate": "#546E7A",
-}
+_PARADIGM_LABELS = PARADIGM_LABELS
+_PARADIGM_COLORS = PARADIGM_COLORS
 
 _HEALTH_COLORS = {
     "healthy": "#2E7D32",
@@ -214,29 +208,9 @@ def _fmt_freq_list(val) -> str:
     return str(val)
 
 
-# ---------------------------------------------------------------------------
-# Country flag emoji helper
-# ---------------------------------------------------------------------------
-
-
-def _normalize_country(raw: str | None) -> str | None:
-    """Normalize a country string to ISO 3166-1 alpha-2 code using pycountry."""
-    if not raw:
-        return None
-    raw = raw.strip()
-    if len(raw) == 2:
-        return raw.upper()
-    try:
-        return pycountry.countries.lookup(raw).alpha_2
-    except LookupError:
-        return None
-
-
-def _country_flag(code: str | None) -> str:
-    """Return a flag emoji for an ISO 3166-1 alpha-2 country code."""
-    if not code or len(code) != 2:
-        return ""
-    return "".join(chr(0x1F1E6 + ord(c) - ord("A")) for c in code.upper())
+# Country/health helpers imported from dataset_constants
+_normalize_country = normalize_country
+_country_flag = country_flag
 
 
 # ---------------------------------------------------------------------------
@@ -377,26 +351,11 @@ def _paradigm_tag(paradigm: str) -> str:
     )
 
 
-def _normalize_health(status: str) -> str:
-    """Normalize health status to 'healthy', 'patients', or 'mixed'."""
-    if not status:
-        return ""
-    s = status.lower().strip()
-    if s == "healthy":
-        return "healthy"
-    if "mixed" in s:
-        return "mixed"
-    # Anything else is some form of patient population
-    if "patient" in s or "stroke" in s or "damage" in s or "pain" in s:
-        return "patients"
-    return status
-
-
 def _health_tag(status: str) -> str:
     """Render a health-status tag."""
     if not status:
         return ""
-    normalized = _normalize_health(status)
+    normalized = normalize_health(status)
     color = _HEALTH_COLORS.get(normalized, "#757575")
     # Show original status as tooltip if it differs from normalized
     title = f' title="{html.escape(status)}"' if normalized != status else ""

--- a/scripts/generate_macro_table.py
+++ b/scripts/generate_macro_table.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pycountry
 
 
 # Ensure the repo root is importable
@@ -218,42 +219,26 @@ def _fmt_freq_list(val) -> str:
 # ---------------------------------------------------------------------------
 
 
-_COUNTRY_NAME_TO_CODE = {
-    "USA": "US",
-    "France": "FR",
-    "Germany": "DE",
-    "Austria": "AT",
-    "Italy": "IT",
-    "Spain": "ES",
-    "Switzerland": "CH",
-    "Greece": "GR",
-    "United Kingdom": "GB",
-    "United States": "US",
-    "China": "CN",
-    "Japan": "JP",
-    "South Korea": "KR",
+# Aliases not recognized by pycountry.countries.lookup()
+_COUNTRY_ALIASES = {
     "Korea": "KR",
-    "Netherlands": "NL",
-    "Portugal": "PT",
     "Turkey": "TR",
-    "Mexico": "MX",
-    "Canada": "CA",
-    "Australia": "AU",
-    "Colombia": "CO",
-    "Hong Kong": "HK",
-    "Brazil": "BR",
-    "India": "IN",
 }
 
 
 def _normalize_country(raw: str | None) -> str | None:
-    """Normalize a country string to ISO 3166-1 alpha-2 code."""
+    """Normalize a country string to ISO 3166-1 alpha-2 code using pycountry."""
     if not raw:
         return None
     raw = raw.strip()
     if len(raw) == 2:
         return raw.upper()
-    return _COUNTRY_NAME_TO_CODE.get(raw)
+    if raw in _COUNTRY_ALIASES:
+        return _COUNTRY_ALIASES[raw]
+    try:
+        return pycountry.countries.lookup(raw).alpha_2
+    except LookupError:
+        return None
 
 
 def _country_flag(code: str | None) -> str:

--- a/scripts/generate_macro_table.py
+++ b/scripts/generate_macro_table.py
@@ -97,6 +97,7 @@ def catalog_to_dataframe(catalog=None) -> pd.DataFrame:
         tags = meta.tags
         ds = meta.data_structure
         gender = _safe_get(par, "gender")
+        handedness = _safe_get(par, "handedness")
 
         row = {
             # --- Core (visible by default) ---
@@ -141,14 +142,11 @@ def catalog_to_dataframe(catalog=None) -> pd.DataFrame:
                 else ""
             ),
             "handedness": (
-                _safe_get(par, "handedness")
-                if isinstance(_safe_get(par, "handedness"), str)
+                handedness
+                if isinstance(handedness, str)
                 else (
-                    ", ".join(
-                        f"{k}:{v}"
-                        for k, v in (_safe_get(par, "handedness") or {}).items()
-                    )
-                    if isinstance(_safe_get(par, "handedness"), dict)
+                    ", ".join(f"{k}:{v}" for k, v in handedness.items())
+                    if isinstance(handedness, dict)
                     else ""
                 )
             ),
@@ -220,6 +218,34 @@ def _fmt_freq_list(val) -> str:
 # ---------------------------------------------------------------------------
 
 
+_COUNTRY_NAME_TO_CODE = {
+    "USA": "US",
+    "France": "FR",
+    "Germany": "DE",
+    "Austria": "AT",
+    "Italy": "IT",
+    "Spain": "ES",
+    "Switzerland": "CH",
+    "Greece": "GR",
+    "United Kingdom": "GB",
+    "United States": "US",
+    "China": "CN",
+    "Japan": "JP",
+    "South Korea": "KR",
+    "Korea": "KR",
+    "Netherlands": "NL",
+    "Portugal": "PT",
+    "Turkey": "TR",
+    "Mexico": "MX",
+    "Canada": "CA",
+    "Australia": "AU",
+    "Colombia": "CO",
+    "Hong Kong": "HK",
+    "Brazil": "BR",
+    "India": "IN",
+}
+
+
 def _normalize_country(raw: str | None) -> str | None:
     """Normalize a country string to ISO 3166-1 alpha-2 code."""
     if not raw:
@@ -227,34 +253,7 @@ def _normalize_country(raw: str | None) -> str | None:
     raw = raw.strip()
     if len(raw) == 2:
         return raw.upper()
-    # Handle common full names / non-standard codes
-    _COUNTRY_MAP = {
-        "USA": "US",
-        "France": "FR",
-        "Germany": "DE",
-        "Austria": "AT",
-        "Italy": "IT",
-        "Spain": "ES",
-        "Switzerland": "CH",
-        "Greece": "GR",
-        "United Kingdom": "GB",
-        "United States": "US",
-        "China": "CN",
-        "Japan": "JP",
-        "South Korea": "KR",
-        "Korea": "KR",
-        "Netherlands": "NL",
-        "Portugal": "PT",
-        "Turkey": "TR",
-        "Mexico": "MX",
-        "Canada": "CA",
-        "Australia": "AU",
-        "Colombia": "CO",
-        "Hong Kong": "HK",
-        "Brazil": "BR",
-        "India": "IN",
-    }
-    return _COUNTRY_MAP.get(raw, raw.upper()[:2])
+    return _COUNTRY_NAME_TO_CODE.get(raw)
 
 
 def _country_flag(code: str | None) -> str:
@@ -431,6 +430,15 @@ def _health_tag(status: str) -> str:
     )
 
 
+_EXTERNAL_LINK_SVG = (
+    '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" '
+    'stroke="currentColor" stroke-width="2">'
+    '<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>'
+    '<polyline points="15 3 21 3 21 9"/>'
+    '<line x1="10" y1="14" x2="21" y2="3"/></svg>'
+)
+
+
 def _doi_link(doi: str | None) -> str:
     if not doi:
         return ""
@@ -438,12 +446,7 @@ def _doi_link(doi: str | None) -> str:
     return (
         f'<a class="mt-doi" href="{html.escape(url)}" '
         f'target="_blank" rel="noopener">'
-        f'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" '
-        f'stroke="currentColor" stroke-width="2">'
-        f'<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>'
-        f'<polyline points="15 3 21 3 21 9"/>'
-        f'<line x1="10" y1="14" x2="21" y2="3"/></svg>'
-        f" DOI</a>"
+        f"{_EXTERNAL_LINK_SVG} DOI</a>"
     )
 
 
@@ -471,12 +474,7 @@ def _data_url_link(url: str | None) -> str:
     return (
         f'<a class="mt-doi" href="{html.escape(url)}" '
         f'target="_blank" rel="noopener">'
-        f'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" '
-        f'stroke="currentColor" stroke-width="2">'
-        f'<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>'
-        f'<polyline points="15 3 21 3 21 9"/>'
-        f'<line x1="10" y1="14" x2="21" y2="3"/></svg>'
-        f" Link</a>"
+        f"{_EXTERNAL_LINK_SVG} Link</a>"
     )
 
 

--- a/scripts/generate_macro_table.py
+++ b/scripts/generate_macro_table.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""Generate a unified interactive macro table HTML from DATASET_METADATA_CATALOG.
+
+Outputs a self-contained HTML fragment (summary cards + DataTables table) to
+``docs/source/_static/macro_table.html``.  Run this script before building the
+Sphinx docs::
+
+    python scripts/generate_macro_table.py
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+# Ensure the repo root is importable
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_PARADIGM_LABELS = {
+    "imagery": "Motor Imagery",
+    "p300": "P300 / ERP",
+    "erp": "P300 / ERP",
+    "ssvep": "SSVEP",
+    "cvep": "c-VEP",
+    "rstate": "Resting State",
+}
+
+_PARADIGM_COLORS = {
+    "imagery": "#1565C0",
+    "p300": "#D32F2F",
+    "erp": "#D32F2F",
+    "ssvep": "#2E7D32",
+    "cvep": "#00695C",
+    "rstate": "#546E7A",
+}
+
+_HEALTH_COLORS = {
+    "healthy": "#2E7D32",
+    "patients": "#E65100",
+    "mixed": "#F9A825",
+}
+
+_OUTPUT_PATH = _REPO_ROOT / "docs" / "source" / "_static" / "macro_table.html"
+
+
+# ---------------------------------------------------------------------------
+# Flatten metadata catalog → DataFrame
+# ---------------------------------------------------------------------------
+
+
+def _safe_get(obj, *attrs, default=None):
+    """Safely traverse nested attributes."""
+    for attr in attrs:
+        if obj is None:
+            return default
+        obj = getattr(obj, attr, None)
+    return obj if obj is not None else default
+
+
+def catalog_to_dataframe(catalog=None) -> pd.DataFrame:
+    """Flatten ``DATASET_METADATA_CATALOG`` into a pandas DataFrame.
+
+    Parameters
+    ----------
+    catalog : dict-like, optional
+        Override catalog.  Defaults to ``DATASET_METADATA_CATALOG``.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per dataset with all key metadata columns.
+    """
+    if catalog is None:
+        from moabb.datasets.metadata import DATASET_METADATA_CATALOG
+
+        catalog = DATASET_METADATA_CATALOG
+
+    rows = []
+    for name, meta in catalog.items():
+        acq = meta.acquisition
+        par = meta.participants
+        exp = meta.experiment
+        doc = meta.documentation
+        aux = _safe_get(acq, "auxiliary_channels")
+
+        ps = meta.paradigm_specific
+        tags = meta.tags
+        ds = meta.data_structure
+        gender = _safe_get(par, "gender")
+
+        row = {
+            # --- Core (visible by default) ---
+            "dataset": name,
+            "paradigm": _safe_get(exp, "paradigm", default=""),
+            "n_subjects": _safe_get(par, "n_subjects", default=0),
+            "n_channels": _safe_get(acq, "n_channels", default=0),
+            "n_eeg_channels": (_safe_get(acq, "channel_types") or {}).get("eeg", 0),
+            "n_classes": _safe_get(exp, "n_classes"),
+            "sampling_rate": _safe_get(acq, "sampling_rate", default=0),
+            "trial_duration": _safe_get(exp, "trial_duration"),
+            "sessions": meta.sessions_per_subject or 1,
+            "runs": meta.runs_per_session or 1,
+            "health_status": _safe_get(par, "health_status", default=""),
+            "doi": _safe_get(doc, "doi"),
+            # --- Hidden by default (toggled via ColVis) ---
+            # Experiment
+            "class_labels": ", ".join(_safe_get(exp, "class_labels") or []),
+            "stimulus_type": _safe_get(exp, "stimulus_type"),
+            "primary_modality": _safe_get(exp, "primary_modality"),
+            "feedback_type": _safe_get(exp, "feedback_type"),
+            "synchronicity": _safe_get(exp, "synchronicity"),
+            "mode": _safe_get(exp, "mode"),
+            "study_design": _safe_get(exp, "study_design"),
+            # Acquisition
+            "hardware": _safe_get(acq, "hardware"),
+            "reference": _safe_get(acq, "reference"),
+            "sensor_type": _safe_get(acq, "sensor_type"),
+            "montage": _safe_get(acq, "montage"),
+            "line_freq": _safe_get(acq, "line_freq"),
+            "filters": _safe_get(acq, "filters"),
+            "cap_manufacturer": _safe_get(acq, "cap_manufacturer"),
+            "software": _safe_get(acq, "software"),
+            # Participants
+            "clinical_population": _safe_get(par, "clinical_population"),
+            "age_mean": _safe_get(par, "age_mean"),
+            "age_min": _safe_get(par, "age_min"),
+            "age_max": _safe_get(par, "age_max"),
+            "gender": (
+                ", ".join(f"{k}:{v}" for k, v in gender.items())
+                if isinstance(gender, dict)
+                else ""
+            ),
+            "handedness": (
+                _safe_get(par, "handedness")
+                if isinstance(_safe_get(par, "handedness"), str)
+                else (
+                    ", ".join(
+                        f"{k}:{v}"
+                        for k, v in (_safe_get(par, "handedness") or {}).items()
+                    )
+                    if isinstance(_safe_get(par, "handedness"), dict)
+                    else ""
+                )
+            ),
+            "bci_experience": _safe_get(par, "bci_experience"),
+            # Documentation
+            "license": _safe_get(doc, "license"),
+            "country": _normalize_country(_safe_get(doc, "country")),
+            "institution": _safe_get(doc, "institution"),
+            "publication_year": _safe_get(doc, "publication_year"),
+            "repository": _safe_get(doc, "repository"),
+            "senior_author": _safe_get(doc, "senior_author"),
+            "data_url": _safe_get(doc, "data_url"),
+            # Tags
+            "tags_pathology": ", ".join(_safe_get(tags, "pathology") or []),
+            "tags_modality": ", ".join(_safe_get(tags, "modality") or []),
+            "tags_type": ", ".join(_safe_get(tags, "type") or []),
+            # Structure
+            "file_format": meta.file_format or "",
+            "has_eog": _safe_get(aux, "has_eog", default=False),
+            "has_emg": _safe_get(aux, "has_emg", default=False),
+            # Duration placeholder (to be filled manually)
+            "duration_hours": None,
+            # Data structure
+            "n_trials": _fmt_trials(_safe_get(ds, "n_trials")),
+            "n_blocks": _safe_get(ds, "n_blocks"),
+            "trials_context": _safe_get(ds, "trials_context"),
+            # Paradigm-specific
+            "stimulus_frequencies": _fmt_freq_list(
+                _safe_get(ps, "stimulus_frequencies_hz")
+            ),
+            "code_type": _safe_get(ps, "code_type"),
+            "n_targets": _safe_get(ps, "n_targets"),
+            "n_repetitions": _safe_get(ps, "n_repetitions"),
+            "isi_ms": _safe_get(ps, "isi_ms"),
+            "soa_ms": _safe_get(ps, "soa_ms"),
+            "imagery_tasks": ", ".join(_safe_get(ps, "imagery_tasks") or []),
+        }
+        rows.append(row)
+
+    df = pd.DataFrame(rows)
+    df = df.sort_values("dataset").reset_index(drop=True)
+    return df
+
+
+def _fmt_trials(val) -> str:
+    """Format n_trials which can be int, dict, or str."""
+    if val is None:
+        return ""
+    if isinstance(val, (int, float)):
+        return str(int(val))
+    if isinstance(val, dict):
+        return ", ".join(f"{k}: {v}" for k, v in val.items())
+    return str(val)
+
+
+def _fmt_freq_list(val) -> str:
+    """Format a list of stimulus frequencies compactly."""
+    if not val:
+        return ""
+    if isinstance(val, list) and len(val) > 6:
+        return f"{val[0]:g}–{val[-1]:g} Hz ({len(val)} freqs)"
+    if isinstance(val, list):
+        return ", ".join(f"{f:g}" for f in val)
+    return str(val)
+
+
+# ---------------------------------------------------------------------------
+# Country flag emoji helper
+# ---------------------------------------------------------------------------
+
+
+def _normalize_country(raw: str | None) -> str | None:
+    """Normalize a country string to ISO 3166-1 alpha-2 code."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    if len(raw) == 2:
+        return raw.upper()
+    # Handle common full names / non-standard codes
+    _COUNTRY_MAP = {
+        "USA": "US",
+        "France": "FR",
+        "Germany": "DE",
+        "Austria": "AT",
+        "Italy": "IT",
+        "Spain": "ES",
+        "Switzerland": "CH",
+        "Greece": "GR",
+        "United Kingdom": "GB",
+        "United States": "US",
+        "China": "CN",
+        "Japan": "JP",
+        "South Korea": "KR",
+        "Korea": "KR",
+        "Netherlands": "NL",
+        "Portugal": "PT",
+        "Turkey": "TR",
+        "Mexico": "MX",
+        "Canada": "CA",
+        "Australia": "AU",
+        "Colombia": "CO",
+        "Hong Kong": "HK",
+        "Brazil": "BR",
+        "India": "IN",
+    }
+    return _COUNTRY_MAP.get(raw, raw.upper()[:2])
+
+
+def _country_flag(code: str | None) -> str:
+    """Return a flag emoji for an ISO 3166-1 alpha-2 country code."""
+    if not code or len(code) != 2:
+        return ""
+    return "".join(chr(0x1F1E6 + ord(c) - ord("A")) for c in code.upper())
+
+
+# ---------------------------------------------------------------------------
+# HTML generation
+# ---------------------------------------------------------------------------
+
+
+_CARD_ICONS = {
+    "datasets": (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">'
+        '<ellipse cx="12" cy="5" rx="9" ry="3"/>'
+        '<path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/>'
+        '<path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>'
+    ),
+    "subjects": (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">'
+        '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>'
+        '<circle cx="9" cy="7" r="4"/>'
+        '<path d="M22 21v-2a4 4 0 0 0-3-3.87"/>'
+        '<path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>'
+    ),
+    "paradigms": (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">'
+        '<polygon points="12 2 2 7 12 12 22 7 12 2"/>'
+        '<polyline points="2 17 12 22 22 17"/>'
+        '<polyline points="2 12 12 17 22 12"/></svg>'
+    ),
+    "countries": (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">'
+        '<circle cx="12" cy="12" r="10"/>'
+        '<path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/>'
+        '<path d="M2 12h20"/></svg>'
+    ),
+    "years": (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">'
+        '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>'
+        '<line x1="16" y1="2" x2="16" y2="6"/>'
+        '<line x1="8" y1="2" x2="8" y2="6"/>'
+        '<line x1="3" y1="10" x2="21" y2="10"/></svg>'
+    ),
+}
+
+
+def _build_paradigm_bar(df: pd.DataFrame) -> str:
+    """Build an inline paradigm distribution bar."""
+    counts = df["paradigm"].value_counts()
+    total = len(df)
+    segments = []
+    for paradigm in ["imagery", "p300", "ssvep", "cvep", "rstate"]:
+        n = counts.get(paradigm, 0)
+        if n == 0:
+            continue
+        pct = n / total * 100
+        color = _PARADIGM_COLORS.get(paradigm, "#757575")
+        label = _PARADIGM_LABELS.get(paradigm, paradigm)
+        segments.append(
+            f'<div class="mt-bar-seg" style="width:{pct:.1f}%;background:{color}" '
+            f'title="{label}: {n} datasets ({pct:.0f}%)">'
+            f"</div>"
+        )
+
+    legend_items = []
+    for paradigm in ["imagery", "p300", "ssvep", "cvep", "rstate"]:
+        n = counts.get(paradigm, 0)
+        if n == 0:
+            continue
+        color = _PARADIGM_COLORS.get(paradigm, "#757575")
+        label = _PARADIGM_LABELS.get(paradigm, paradigm)
+        legend_items.append(
+            f'<span class="mt-bar-legend-item">'
+            f'<span class="mt-bar-dot" style="background:{color}"></span>'
+            f"{html.escape(label)} ({n})</span>"
+        )
+
+    return (
+        f'<div class="mt-bar-container">'
+        f'<div class="mt-bar">{"".join(segments)}</div>'
+        f'<div class="mt-bar-legend">{"".join(legend_items)}</div>'
+        f"</div>"
+    )
+
+
+def _build_summary_cards(df: pd.DataFrame) -> str:
+    """Build HTML for the top-row summary metric cards."""
+    total_datasets = len(df)
+    total_subjects = int(df["n_subjects"].sum())
+    n_paradigms = df["paradigm"].nunique()
+    countries = df["country"].dropna().nunique()
+    year_min = df["publication_year"].dropna()
+    year_range = (
+        f"{int(year_min.min())}–{int(year_min.max())}" if len(year_min) else "N/A"
+    )
+
+    cards_data = [
+        ("datasets", "Datasets", str(total_datasets), "curated BCI datasets"),
+        ("subjects", "Subjects", f"{total_subjects:,}", "total participants"),
+        ("paradigms", "Paradigms", str(n_paradigms), "BCI paradigm types"),
+        ("countries", "Countries", str(countries), "represented"),
+        ("years", "Years", year_range, "publication span"),
+    ]
+
+    items = []
+    for i, (icon_key, label, value, subtitle) in enumerate(cards_data):
+        icon_svg = _CARD_ICONS.get(icon_key, "")
+        items.append(
+            f'<div class="mt-card" style="animation-delay:{i * 60}ms">'
+            f'<div class="mt-card-icon">{icon_svg}</div>'
+            f'<div class="mt-card-body">'
+            f'<div class="mt-card-value">{html.escape(value)}</div>'
+            f'<div class="mt-card-label">{html.escape(label)}</div>'
+            f'<div class="mt-card-sub">{html.escape(subtitle)}</div>'
+            f"</div></div>"
+        )
+
+    paradigm_bar = _build_paradigm_bar(df)
+
+    return (
+        f'<div class="mt-hero">'
+        f'<div class="mt-cards" id="mt-cards">{"".join(items)}</div>'
+        f"{paradigm_bar}"
+        f"</div>"
+    )
+
+
+def _paradigm_tag(paradigm: str) -> str:
+    """Render a color-coded paradigm pill."""
+    label = _PARADIGM_LABELS.get(paradigm, paradigm)
+    color = _PARADIGM_COLORS.get(paradigm, "#757575")
+    return (
+        f'<span class="mt-tag" style="--tag-color:{color}" '
+        f'data-paradigm="{html.escape(paradigm)}">'
+        f"{html.escape(label)}</span>"
+    )
+
+
+def _normalize_health(status: str) -> str:
+    """Normalize health status to 'healthy', 'patients', or 'mixed'."""
+    if not status:
+        return ""
+    s = status.lower().strip()
+    if s == "healthy":
+        return "healthy"
+    if "mixed" in s:
+        return "mixed"
+    # Anything else is some form of patient population
+    if "patient" in s or "stroke" in s or "damage" in s or "pain" in s:
+        return "patients"
+    return status
+
+
+def _health_tag(status: str) -> str:
+    """Render a health-status tag."""
+    if not status:
+        return ""
+    normalized = _normalize_health(status)
+    color = _HEALTH_COLORS.get(normalized, "#757575")
+    # Show original status as tooltip if it differs from normalized
+    title = f' title="{html.escape(status)}"' if normalized != status else ""
+    return (
+        f'<span class="mt-tag mt-tag--health" style="--tag-color:{color}"{title}>'
+        f"{html.escape(normalized)}</span>"
+    )
+
+
+def _doi_link(doi: str | None) -> str:
+    if not doi:
+        return ""
+    url = doi if doi.startswith("http") else f"https://doi.org/{doi}"
+    return (
+        f'<a class="mt-doi" href="{html.escape(url)}" '
+        f'target="_blank" rel="noopener">'
+        f'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" '
+        f'stroke="currentColor" stroke-width="2">'
+        f'<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>'
+        f'<polyline points="15 3 21 3 21 9"/>'
+        f'<line x1="10" y1="14" x2="21" y2="3"/></svg>'
+        f" DOI</a>"
+    )
+
+
+def _dataset_link(name: str) -> str:
+    """Link to the auto-generated dataset documentation page."""
+    url = f"generated/moabb.datasets.{name}.html"
+    return f'<a class="mt-dataset-link" href="{html.escape(url)}">{html.escape(name)}</a>'
+
+
+def _fmt(val, fmt=None):
+    """Format a value for table display."""
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return ""
+    if fmt:
+        try:
+            return fmt(val)
+        except (ValueError, TypeError):
+            return html.escape(str(val))
+    return html.escape(str(val))
+
+
+def _data_url_link(url: str | None) -> str:
+    if not url:
+        return ""
+    return (
+        f'<a class="mt-doi" href="{html.escape(url)}" '
+        f'target="_blank" rel="noopener">'
+        f'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" '
+        f'stroke="currentColor" stroke-width="2">'
+        f'<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>'
+        f'<polyline points="15 3 21 3 21 9"/>'
+        f'<line x1="10" y1="14" x2="21" y2="3"/></svg>'
+        f" Link</a>"
+    )
+
+
+# Columns definition: (header, df_key, formatter, visible_by_default)
+_TABLE_COLUMNS = [
+    # --- Visible by default ---
+    ("Dataset", "dataset", "link", True),
+    ("Paradigm", "paradigm", "paradigm_tag", True),
+    ("#Subj", "n_subjects", "int", True),
+    ("#Chan", "n_channels", "int", True),
+    ("#EEG", "n_eeg_channels", "int", True),
+    ("#Classes", "n_classes", "num", True),
+    ("Freq (Hz)", "sampling_rate", "num", True),
+    ("Trial (s)", "trial_duration", "num", True),
+    ("#Sess", "sessions", "int", True),
+    ("#Runs", "runs", "int", True),
+    ("Health", "health_status", "health_tag", True),
+    ("#Trials", "n_trials", "str", True),
+    ("Country", "country", "country", True),
+    ("Year", "publication_year", "year", True),
+    ("DOI", "doi", "doi_link", True),
+    # --- Hidden by default ---
+    ("Class Labels", "class_labels", "str", False),
+    ("Stimulus", "stimulus_type", "str", False),
+    ("Modality", "primary_modality", "str", False),
+    ("Feedback", "feedback_type", "str", False),
+    ("Sync", "synchronicity", "str", False),
+    ("Mode", "mode", "str", False),
+    ("Study Design", "study_design", "str", False),
+    ("Hardware", "hardware", "str", False),
+    ("Reference", "reference", "str", False),
+    ("Sensor Type", "sensor_type", "str", False),
+    ("Montage", "montage", "str", False),
+    ("Line Freq", "line_freq", "num", False),
+    ("Filters", "filters", "str", False),
+    ("Cap Mfr", "cap_manufacturer", "str", False),
+    ("Software", "software", "str", False),
+    ("Clinical Pop.", "clinical_population", "str", False),
+    ("Age Mean", "age_mean", "num", False),
+    ("Age Min", "age_min", "num", False),
+    ("Age Max", "age_max", "num", False),
+    ("Gender", "gender", "str", False),
+    ("Handedness", "handedness", "str", False),
+    ("BCI Exp.", "bci_experience", "str", False),
+    ("License", "license", "str", False),
+    ("Institution", "institution", "str", False),
+    ("Repository", "repository", "str", False),
+    ("Duration (h)", "duration_hours", "num", False),
+    ("Author", "senior_author", "str", False),
+    ("Data URL", "data_url", "data_url", False),
+    ("Pathology Tags", "tags_pathology", "str", False),
+    ("Modality Tags", "tags_modality", "str", False),
+    ("Type Tags", "tags_type", "str", False),
+    ("File Format", "file_format", "str", False),
+    ("EOG", "has_eog", "bool", False),
+    ("EMG", "has_emg", "bool", False),
+    # Data structure
+    ("#Blocks", "n_blocks", "num", False),
+    ("Trials Context", "trials_context", "str", False),
+    # Paradigm-specific
+    ("Stim. Freqs", "stimulus_frequencies", "str", False),
+    ("Code Type", "code_type", "str", False),
+    ("#Targets", "n_targets", "num", False),
+    ("#Repetitions", "n_repetitions", "num", False),
+    ("ISI (ms)", "isi_ms", "num", False),
+    ("SOA (ms)", "soa_ms", "num", False),
+    ("MI Tasks", "imagery_tasks", "str", False),
+]
+
+
+_TRUNCATE_LEN = 24
+
+
+def _truncate(text: str, max_len: int = _TRUNCATE_LEN) -> str:
+    """Truncate text and wrap in a span with a CSS tooltip showing the full value."""
+    if not text or len(text) <= max_len:
+        return html.escape(text) if text else ""
+    short = html.escape(text[:max_len].rstrip()) + "..."
+    full_escaped = html.escape(text).replace('"', "&quot;")
+    return f'<span class="mt-truncated" data-full="{full_escaped}">{short}</span>'
+
+
+def _format_cell(value, fmt: str, row=None) -> str:
+    """Format a single cell value according to its type."""
+    if fmt == "link":
+        return _dataset_link(value)
+    if fmt == "paradigm_tag":
+        return _paradigm_tag(value)
+    if fmt == "health_tag":
+        return _health_tag(value)
+    if fmt == "doi_link":
+        return _doi_link(value)
+    if fmt == "data_url":
+        return _data_url_link(value)
+    if fmt == "country":
+        if not value:
+            return ""
+        flag = _country_flag(value)
+        return html.escape(f"{flag} {value}")
+    if fmt == "year":
+        return _fmt(value, lambda v: str(int(v)))
+    if fmt == "int":
+        return _fmt(value)
+    if fmt == "num":
+        return _fmt(value, lambda v: f"{v:g}")
+    if fmt == "bool":
+        if value is True:
+            return "Yes"
+        if value is False:
+            return "No"
+        return ""
+    # str — truncate long values
+    text = (
+        str(value)
+        if value is not None and not (isinstance(value, float) and pd.isna(value))
+        else ""
+    )
+    return _truncate(text)
+
+
+def _build_table_html(df: pd.DataFrame) -> str:
+    """Build the <table> element."""
+
+    # Header
+    header_cells = "".join(f"<th>{col[0]}</th>" for col in _TABLE_COLUMNS)
+    thead = f"<thead><tr>{header_cells}</tr></thead>"
+
+    # Body
+    body_rows = []
+    for _, row in df.iterrows():
+        cells = []
+        for _header, key, fmt, _vis in _TABLE_COLUMNS:
+            cells.append(_format_cell(row.get(key), fmt, row))
+
+        paradigm = row.get("paradigm", "")
+        p_color = _PARADIGM_COLORS.get(paradigm, "#757575")
+        tr_cells = "".join(f"<td>{c}</td>" for c in cells)
+        body_rows.append(f'<tr style="--row-paradigm-color:{p_color}">{tr_cells}</tr>')
+
+    tbody = f'<tbody>{"".join(body_rows)}</tbody>'
+    return (
+        f'<table id="moabb-macro-table" class="display compact nowrap" '
+        f'style="width:100%">{thead}{tbody}</table>'
+    )
+
+
+_EXPERIMENTAL_BANNER = """\
+<div class="mt-banner">
+  <div class="mt-banner-icon">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86
+              a2 2 0 0 0-3.42 0z"/>
+      <line x1="12" y1="9" x2="12" y2="13"/>
+      <line x1="12" y1="17" x2="12.01" y2="17"/>
+    </svg>
+  </div>
+  <div class="mt-banner-body">
+    <strong>Experimental</strong> &mdash;
+    This metadata catalog is under active consolidation. Some values may be
+    incomplete or approximate. The information will be progressively validated
+    to match the exact dataset properties.
+    If you spot an error, please
+    <a href="https://github.com/NeuroTechX/moabb/issues"
+       target="_blank" rel="noopener">open an issue</a>.
+  </div>
+</div>
+"""
+
+
+def generate_html(df: pd.DataFrame) -> str:
+    """Generate the full HTML fragment (cards + table)."""
+    cards = _build_summary_cards(df)
+    table = _build_table_html(df)
+
+    return f"""\
+<div class="mt-container">
+{_EXPERIMENTAL_BANNER}
+{cards}
+<div class="mt-table-wrapper">
+{table}
+</div>
+</div>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print("Building metadata catalog...")
+    df = catalog_to_dataframe()
+    print(f"  {len(df)} datasets extracted, {len(df.columns)} columns")
+    print(f"  Paradigms: {sorted(df['paradigm'].unique())}")
+    print(f"  Total subjects: {int(df['n_subjects'].sum())}")
+
+    html_content = generate_html(df)
+
+    os.makedirs(_OUTPUT_PATH.parent, exist_ok=True)
+    _OUTPUT_PATH.write_text(html_content, encoding="utf-8")
+    print(f"  Written to {_OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a unified interactive dashboard that consolidates all 148 dataset metadata entries into one searchable, filterable, sortable table with 58 columns (15 visible by default, rest togglable via ColVis)
- Extract shared constants (`PARADIGM_LABELS`, `PARADIGM_COLORS`, `normalize_country`, `country_flag`, `normalize_health`) into `dataset_constants.py`, eliminating ~130 lines of duplication between `dataset_timeline_ext.py` and the new script
- Replace hardcoded 50-line country mapping in `dataset_timeline_ext.py` with `pycountry.countries.lookup()`

### New files

| File | Purpose |
|------|---------|
| `scripts/generate_macro_table.py` | Flattens `DATASET_METADATA_CATALOG` into a DataFrame and generates self-contained HTML (summary cards + paradigm bar + DataTables table) |
| `docs/source/sphinxext/dataset_constants.py` | Shared constants and helpers for paradigm colors/labels, country normalization, health normalization |
| `docs/source/sphinxext/macro_table_ext.py` | Lightweight Sphinx extension that injects pre-generated HTML via `source-read` hook |
| `docs/source/_static/css/macro-table.css` | Dashboard styling with dark mode, responsive layout, CSS tooltips |
| `docs/source/_static/js/macro-table.js` | DataTables init with SearchPanes, FixedHeader, ColVis, CSV export, clickable paradigm filtering |

### Features

- **58 metadata columns** covering acquisition, participants, experiment, documentation, tags, paradigm-specific, and data structure fields
- **15 visible by default**, rest togglable via "Columns" button
- Color-coded paradigm tags and left-border row stripes
- Clickable paradigm bar/tags/legend for quick filtering with dynamic updates
- Summary cards (datasets, subjects, paradigms, countries, years) that update on filter
- SearchPanes for categorical filtering (paradigm, health, country, license, hardware, etc.)
- CSV export, print view, multi-column sorting, fixed header
- Experimental banner warning that metadata is under consolidation
- Country normalization via `pycountry` (no hardcoded mappings)
- Dark mode support, responsive layout
- CSS hover tooltips for truncated text

### Modified files

- `docs/source/conf.py` — register extension, add DataTables CDN assets
- `docs/source/dataset_summary.rst` — add macro table section, remove conflicting DT 1.13.4 script
- `docs/source/sphinxext/dataset_timeline_ext.py` — import from shared `dataset_constants.py` (-75 lines)

## Test plan

- [ ] Run `python scripts/generate_macro_table.py` — verify 148 datasets, 58 columns, no errors
- [ ] Run `cd docs && make html-noplot` — verify build succeeds with <=3 warnings
- [ ] Open `docs/build/html/dataset_summary.html` in browser:
  - [ ] Verify all 148 datasets appear in the table
  - [ ] Test column sorting (click headers)
  - [ ] Test SearchPanes filtering (click "Filter" button)
  - [ ] Test column visibility toggle (click "Columns" button)
  - [ ] Test CSV export
  - [ ] Test paradigm tag/bar click-to-filter
  - [ ] Test dark mode toggle
  - [ ] Verify per-paradigm tables still render below
  - [ ] Verify individual dataset pages still render correctly (dataset_timeline_ext.py not broken)