### PR TITLE
fix(Lee2019): session key off-by-one causes silent data loss

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -31,7 +31,7 @@ Requirements
 
 Bugs
 ~~~~
-- None yet.
+- Fix session key off-by-one in :class:`moabb.datasets.Lee2019` that caused silent data loss when filtering sessions, and improve session filtering in :class:`moabb.datasets.base.BaseDataset` to match compound session keys (e.g., ``"0train"``) by integer prefix (:gh:`1046` by `Benedetto Leto`_ and `Bruno Aristimunha`_).
 
 Code health
 ~~~~~~~~~~~
@@ -858,3 +858,4 @@ API changes
 .. _Davoud Hajhassani: https://github.com/Davoud-Hajhassani
 .. _Katelyn Begany: https://github.com/kbegany
 .. _Sarthak Tayal: https://github.com/tayal-sarthak
+.. _Benedetto Leto: https://github.com/ben9809

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -212,7 +212,7 @@ class Lee2019(BaseDataset):
             if self.train_run or self.test_run:
                 mat = loadmat(file_path_list[self.sessions.index(session)])
 
-            session_name = str(session - 1)
+            session_name = str(session)
             sessions[session_name] = {}
             if self.train_run:
                 sessions[session_name]["1train"] = self._get_single_run(

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -875,6 +875,12 @@ class BaseDataset(metaclass=MetaclassDataset):
         if process_pipeline is None:
             process_pipeline = self._create_process_pipeline()
 
+        if effective_sessions is not None:
+            str_sessions = {str(s) for s in effective_sessions}
+            pat = session_run_pattern()
+        else:
+            str_sessions = pat = None
+
         data = dict()
         for subject in subjects:
             if subject not in self.subject_list:
@@ -884,10 +890,12 @@ class BaseDataset(metaclass=MetaclassDataset):
                 cache_config,
                 process_pipeline,
             )
-            if effective_sessions is not None:
-                str_sessions = {str(s) for s in effective_sessions}
+            if str_sessions is not None:
                 subject_data = {
-                    k: v for k, v in subject_data.items() if k in str_sessions
+                    k: v
+                    for k, v in subject_data.items()
+                    if k in str_sessions
+                    or ((m := re.fullmatch(pat, k)) and m.group(1) in str_sessions)
                 }
             data[subject] = subject_data
         check_subject_names(data)

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -2,6 +2,7 @@ import inspect
 import logging
 import re
 import warnings
+from unittest.mock import patch
 
 import mne
 import numpy as np
@@ -574,6 +575,35 @@ class TestSubjectSessionFiltering:
         assert set(data.keys()) == {1, 2}
         for sess_data in data.values():
             assert set(sess_data.keys()) == {"0", "1"}
+
+    def test_session_filtering_matches_by_integer_prefix(self):
+        """Session selection by integer should match compound keys like '0train'."""
+        ds = FakeDataset(n_subjects=1, n_sessions=2, sessions=[0])
+        # Patch the cache layer to return compound keys
+        original = ds._get_single_subject_data_using_cache
+
+        def compound_keys(subject, cache_config, process_pipeline):
+            data = original(subject, cache_config, process_pipeline)
+            return {f"{k}desc": v for k, v in data.items()}
+
+        with patch.object(ds, "_get_single_subject_data_using_cache", compound_keys):
+            data = ds.get_data()
+            for sess_data in data.values():
+                assert list(sess_data.keys()) == ["0desc"]
+
+    def test_session_filtering_with_string_compound_key(self):
+        """Exact string session selection should work for compound keys."""
+        ds = FakeDataset(n_subjects=1, n_sessions=2, sessions=["0desc"])
+        original = ds._get_single_subject_data_using_cache
+
+        def compound_keys(subject, cache_config, process_pipeline):
+            data = original(subject, cache_config, process_pipeline)
+            return {f"{k}desc": v for k, v in data.items()}
+
+        with patch.object(ds, "_get_single_subject_data_using_cache", compound_keys):
+            data = ds.get_data()
+            for sess_data in data.values():
+                assert list(sess_data.keys()) == ["0desc"]
 
     def test_all_subjects_is_immutable_copy(self):
         ds = PhysionetMI(subjects=[1, 2])


### PR DESCRIPTION
## Problem

When calling `Lee2019_MI(sessions=[1, 2])`, only session 2 is returned
mislabelled as session 1. Session 1 is silently dropped.

## Cause

`_get_single_subject_data` stores data under zero-indexed keys:

    session_name = str(session - 1)  # sessions=[1,2] → keys "0","1"

But `BaseDataset.get_data` filters using one-indexed strings:

    str_sessions = {str(s) for s in effective_sessions}  # → {"1","2"}

So key "0" (session 1) never matches the filter and is dropped.
Key "1" (session 2) matches "1" and is returned as session 1.

## Fix

Remove the `- 1` offset so keys match the user-facing session numbers.

Closes #1045 