### PR TITLE
fix(encoding): handle UnicodeEncodeError when GBK codec fails on '\xef'

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -49,6 +49,7 @@ Bugs
 - Fix :class:`moabb.datasets.castillos2023.BaseCastillos2023` extraction check using wrong directory name (``4Class-VEP`` instead of ``4Class-CVEP``), causing re-extraction on every call, and replace fragile ``rstrip`` path derivation with proper ``os.path`` manipulation (by `Bruno Aristimunha`_)
 - Fix data path lookup in :class:`moabb.datasets.Forenzo2023` that makes MOABB unable to find the downloaded data (:gh:`1048` by `Ethan Davis`_).
 - Fix wrong paper reference in :class:`moabb.datasets.Thielen2021` (``associated_paper_doi`` pointed to the Ahmadi electrode-montage reference instead of the dataset's primary publication), restore Radboud data-repository DOI as ``__init__.doi``, and add regression test ``test_primary_paper_matches_dataset_code`` that validates every ``<Surname><Year>`` dataset against its cited primary paper (by `Bruno Aristimunha`_)
+- Fix ``UnicodeEncodeError`` when the GBK codec fails on ``'\xef'`` in BIDS metadata export by explicitly setting ``encoding="utf-8"`` on file writes in ``bids_interface`` (:gh:`1059` by `sli930`_)
 
 Code health
 ~~~~~~~~~~~
@@ -877,3 +878,4 @@ API changes
 .. _Sarthak Tayal: https://github.com/tayal-sarthak
 .. _Benedetto Leto: https://github.com/ben9809
 .. _Zach Munro: https://github.com/zmunro
+.. _sli930: https://github.com/sli930

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -961,7 +961,7 @@ def _update_participants_tsv(root, subject, metadata, raw=None):
                 row["bci_experience"] = bci_experience
 
     # Write back
-    with open(tsv_path, "w", newline="") as f:
+    with open(tsv_path, "w", newline="", encoding='utf-8') as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
         writer.writeheader()
         writer.writerows(rows)
@@ -1368,7 +1368,7 @@ def _write_metadata_yaml(root, dataset):
     code_dir = Path(root) / "code"
     code_dir.mkdir(exist_ok=True)
     yaml_path = code_dir / f"{type(dataset).__name__}.metadata.yaml"
-    with open(yaml_path, "w") as f:
+    with open(yaml_path, "w", encoding='utf-8') as f:
         yaml.dump(
             data,
             f,

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -961,7 +961,7 @@ def _update_participants_tsv(root, subject, metadata, raw=None):
                 row["bci_experience"] = bci_experience
 
     # Write back
-    with open(tsv_path, "w", newline="", encoding='utf-8') as f:
+    with open(tsv_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
         writer.writeheader()
         writer.writerows(rows)
@@ -1368,7 +1368,7 @@ def _write_metadata_yaml(root, dataset):
     code_dir = Path(root) / "code"
     code_dir.mkdir(exist_ok=True)
     yaml_path = code_dir / f"{type(dataset).__name__}.metadata.yaml"
-    with open(yaml_path, "w", encoding='utf-8') as f:
+    with open(yaml_path, "w", encoding="utf-8") as f:
         yaml.dump(
             data,
             f,


### PR DESCRIPTION
The issue occurs because the script tries to write a string containing non-GBK characters to a file opened with default GBK encoding on Windows.

## Solution
- Explicitly open the file with `encoding='utf-8'` instead of relying on system default.

## Changes made
- `moabb\datasets\bids_interface.py`: changed `open(file, 'w')` to `open(file, 'w', encoding='utf-8')`

## Testing
- [x] Tested on Windows 11 with Chinese locale.
- [x] No more UnicodeEncodeError.
- [x] All existing tests pass.

## Related issue (if any)
Fixes #1058 