### PR TITLE
Fix Wairagkar2018 dataset zip extraction

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -57,6 +57,7 @@ Bugs
 - Fix wrong paper reference in :class:`moabb.datasets.Thielen2021` (``associated_paper_doi`` pointed to the Ahmadi electrode-montage reference instead of the dataset's primary publication), restore Radboud data-repository DOI as ``__init__.doi``, and add regression test ``test_primary_paper_matches_dataset_code`` that validates every ``<Surname><Year>`` dataset against its cited primary paper (by `Bruno Aristimunha`_)
 - Fix ``UnicodeEncodeError`` when the GBK codec fails on ``'\xef'`` in BIDS metadata export by explicitly setting ``encoding="utf-8"`` on file writes in ``bids_interface`` (:gh:`1059` by `sli930`_)
 - Modified example usage and fixed epoch extraction with an adjustable buffer that prevents last epochs being dropped in :class:`moabb.datasets.RomaniBF2025ERP`.
+- Fix zip extraction in :class:`moabb.datasets.Wairagkar2018` dataset loader.
 
 Code health
 ~~~~~~~~~~~

--- a/moabb/datasets/wairagkar2018.py
+++ b/moabb/datasets/wairagkar2018.py
@@ -6,6 +6,7 @@ Data DOI: 10.17864/1947.117
 """
 
 import logging
+import zipfile
 from pathlib import Path
 
 import mne
@@ -334,7 +335,8 @@ class Wairagkar2018(BaseDataset):
 
         # Extract all .mat files from the ZIP.
         if zip_path is not None and zip_path.exists() and not mat_file.exists():
-            safe_extract_zip(str(zip_path), str(basepath))
+            with zipfile.ZipFile(zip_path) as zf:
+                safe_extract_zip(zf, basepath)
 
         # Move mat files from subfolders to basepath.
         for mat in basepath.rglob("Participant*.mat"):


### PR DESCRIPTION
## Fix Wairagkar2018 dataset zip extraction

Related to #904

This PR fixes an issue in the Wairagkar2018 dataset loader where
`safe_extract_zip` was called with incorrect argument types, causing
the dataset extraction to fail on first download.

## Issue

`safe_extract_zip` expects a `zipfile.ZipFile` object and a `Path`, but
it was being called with string paths instead. As a result, the zip file
was not properly opened before extraction, leading to failures when
loading the dataset.

## Fix

- Added `import zipfile`
- Updated extraction logic to properly open the zip file:

```python
with zipfile.ZipFile(zip_path) as zf:
    safe_extract_zip(zf, basepath)