### PR TITLE
ci: install CPU-only PyTorch wheels in CI (UV_TORCH_BACKEND=cpu)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,11 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  # Install CPU-only PyTorch wheels (torch arrives transitively via the
+  # deeplearning extra -> braindecode). Avoids pulling CUDA builds on CI.
+  UV_TORCH_BACKEND: cpu
+
 jobs:
   build_docs:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-braindecode.yml
+++ b/.github/workflows/test-braindecode.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ develop ]
 
+env:
+  # Install CPU-only PyTorch wheels (braindecode pulls torch). Avoids
+  # pulling CUDA builds on CI.
+  UV_TORCH_BACKEND: cpu
+
 jobs:
   test:
     name: dev ${{ matrix.os }}, py-${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ develop, master ]
 
+env:
+  # Install CPU-only PyTorch wheels (torch arrives transitively via the
+  # deeplearning extra -> braindecode). Avoids pulling CUDA builds on CI.
+  UV_TORCH_BACKEND: cpu
+
 jobs:
   test:
     name: ${{ matrix.os }}, py-${{ matrix.python-version }}

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -66,7 +66,7 @@ Bugs
 - Fix Windows download path sanitization that changed absolute paths like ``C:\data`` into relative ``C-\data`` paths (:gh:`1079` by `Anton Andreev`_).
 Code health
 ~~~~~~~~~~~
-- None yet.
+- Install CPU-only PyTorch wheels in CI by setting ``UV_TORCH_BACKEND=cpu`` in the test, braindecode, and docs workflows, so runners no longer download multi-GB CUDA builds of ``torch`` (pulled transitively via the ``deeplearning`` extra / braindecode) (:gh:`1083` by `Bhargav Kowshik`_).
 
 Version 1.5.0  (Stable - PyPi)
 -------------------------------
@@ -893,3 +893,4 @@ API changes
 .. _Zach Munro: https://github.com/zmunro
 .. _sli930: https://github.com/sli930
 .. _Emily Schrag: https://github.com/emilyschrag
+.. _Bhargav Kowshik: https://github.com/bkowshik


### PR DESCRIPTION
## What

Adds a workflow-level `env: UV_TORCH_BACKEND: cpu` to the three CI workflows that install PyTorch:

- `.github/workflows/test.yml` — installs `.[tests,deeplearning,optuna]`
- `.github/workflows/test-braindecode.yml` — installs braindecode directly
- `.github/workflows/docs.yml` — installs `.[docs,deeplearning,optuna,external,carbonemission]`

## Why

`torch` is not a core dependency — it arrives transitively via the `deeplearning` extra (`braindecode>=0.8.1`). CI installs with uv (`astral-sh/setup-uv@v5`) and no backend hint, so uv may resolve the default PyTorch wheels and pull heavy CUDA builds onto runners that never use a GPU. `UV_TORCH_BACKEND=cpu` is uv's env-var equivalent of `--torch-backend=cpu`, forcing CPU-only wheels for faster, smaller installs.

## Scope

`download-test.yml` installs only `.[tests]` (no torch) and is intentionally left unchanged. Each `env` block is workflow-scoped so it applies to every job and step. No dependency or test logic changed; all workflows validate as well-formed YAML.

## Note

`UV_TORCH_BACKEND` is a recent uv feature. These workflows don't pin a uv version, so `setup-uv@v5` installs a version that supports it — worth a check if uv ever gets pinned to an older release.