### PR TITLE
feat(preprocessing): add EuclideanAlignment trial-level transformer

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -324,6 +324,21 @@ Utilities
     utils.plot_datasets_grid
     utils.plot_datasets_cluster
 
+-------------
+Preprocessing
+-------------
+.. currentmodule:: moabb.datasets
+
+Trial-level transformers applied to the epoched/array data, usable as
+pipeline steps (inductive in a cross-validation, transductive via
+``fit_transform`` on a single recording).
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    preprocessing.EuclideanAlignment
+
 Paradigms
 ---------
 .. currentmodule:: moabb.paradigms

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -38,6 +38,7 @@ Enhancements
 - Skip zip extraction in :class:`moabb.datasets.GuttmannFlury2025` when files are already extracted, with ``/scratch`` fallback for NFS filesystems on compute nodes (by `Bruno Aristimunha`_)
 - Re-enable auto-execution of the Riemannian Artifact Rejection tutorial (``examples/advanced_examples/plot_riemannian_artifact_rejection.py``) now that pyRiemann 0.11 is on PyPI with per-potato metrics and ``method_combination`` support on ``PotatoField`` (by `Bruno Aristimunha`_)
 - Use NEMAR as the default download source for datasets with an assigned ``nemar_id``, while preserving existing dataset-specific downloaders as a fallback (by `Bruno Aristimunha`_).
+- Add :class:`moabb.datasets.preprocessing.EuclideanAlignment`, a trial-level Euclidean Alignment transformer (He & Wu 2020; Junqueira et al. 2024) that whitens each trial by the inverse square root of the Euclidean mean covariance to remove per-domain covariance shift before a (deep) model sees the data. Inductive and leakage-free by default (``fit`` learns the reference from training trials, ``transform`` re-applies it to unseen trials); ``fit_transform`` gives the transductive, per-recording form. Accepts an :class:`mne.BaseEpochs` or an ``(n_trials, n_channels, n_times)`` ndarray, uses a shrinkage covariance estimator (``"lwf"``) for robustness, and adds no new dependency (``pyriemann >= 0.11`` is already required). Distinct from :class:`pyriemann.transfer.TLCenter`, which recenters covariance *matrices* (:gh:`1108` by `Bruno Aristimunha`_).
 
 API changes
 ~~~~~~~~~~~

--- a/examples/advanced_examples/plot_euclidean_alignment.py
+++ b/examples/advanced_examples/plot_euclidean_alignment.py
@@ -1,0 +1,225 @@
+r"""
+=====================================================
+Euclidean Alignment for cross-subject transfer
+=====================================================
+
+EEG covariance statistics drift from subject to subject (and session to
+session): the same mental task produces differently-shaped data on each
+recording. That domain shift is the main reason a decoder trained on one set of
+subjects transfers poorly to a new one. **Euclidean Alignment** (EA) removes it
+with a single, label-free whitening step — cheap enough to put in front of any
+model, deep or classical [1]_.
+
+In a systematic evaluation across MOABB motor-imagery datasets, Junqueira,
+Aristimunha, Chevallier & de Camargo (2024) [2]_ showed that aligning each
+recording with EA before training a *shared* deep model improved target-subject
+decoding by **+4.33%** on average and cut convergence time by **more than 70%** —
+for almost no compute and no extra labels. This example reproduces the core
+idea on the workhorse CSP+LDA motor-imagery pipeline using
+:class:`moabb.datasets.preprocessing.EuclideanAlignment`.
+
+Each trial :math:`X_i` is whitened by the inverse square root of the
+**Euclidean (arithmetic) mean** of the per-trial covariances of its recording,
+
+.. math::
+
+    \bar{C} = \frac{1}{N}\sum_{i=1}^{N} C_i,
+    \qquad \tilde{X}_i = \bar{C}^{-1/2} X_i,
+
+so after alignment every recording shares an identity-like average covariance
+and the subjects become comparable. We apply EA **per subject** (the
+transductive, per-recording form — :meth:`fit_transform` on one recording; it
+uses only the trial covariances, never the labels) and compare leave-one-subject
+-out decoding with and without it.
+"""
+
+# Authors: Bruno Aristimunha <b.aristimunha@gmail.com>
+#
+# License: BSD (3-clause)
+
+import matplotlib.pyplot as plt
+import mne
+import numpy as np
+from mne.decoding import CSP
+from pyriemann.estimation import Covariances
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
+from sklearn.metrics import roc_auc_score
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import LabelEncoder
+
+import moabb
+from moabb.datasets import BNCI2014_001
+from moabb.datasets.preprocessing import EuclideanAlignment
+from moabb.paradigms import LeftRightImagery
+
+
+moabb.set_log_level("info")
+mne.set_log_level("WARNING")  # keep the gallery output readable
+
+###############################################################################
+# Load the data per subject
+# -------------------------
+#
+# We use the BCI Competition IV 2a dataset (:class:`moabb.datasets.BNCI2014_001`)
+# and the :class:`moabb.paradigms.LeftRightImagery` paradigm (left- vs right-hand
+# motor imagery, scored with ROC-AUC). We keep the trials of each subject
+# separate, because Euclidean Alignment is defined **per recording**.
+
+paradigm = LeftRightImagery()
+dataset = BNCI2014_001()
+subjects = dataset.subject_list[:8]
+
+# Pull each subject's trials once; X is (n_trials, n_channels, n_times).
+data = {}
+for subject in subjects:
+    X, labels, _ = paradigm.get_data(dataset, [subject])
+    data[subject] = (X, LabelEncoder().fit_transform(labels))
+
+###############################################################################
+# Euclidean Alignment reduces the between-subject covariance shift
+# ----------------------------------------------------------------
+#
+# Before any classification, we can *see* what EA does. For every subject we
+# compute the mean trial covariance, then measure how far apart the subjects are
+# as the average pairwise distance between those mean covariances. EA pulls them
+# together — each subject's mean covariance becomes ~identity.
+
+
+def mean_covariance(X):
+    """Euclidean mean of the per-trial covariances of one recording."""
+    return Covariances("oas").transform(X).mean(axis=0)
+
+
+def between_subject_dispersion(means):
+    """Average pairwise Frobenius distance between subject mean covariances."""
+    dists = [
+        np.linalg.norm(means[i] - means[j])
+        for i in range(len(means))
+        for j in range(i + 1, len(means))
+    ]
+    return float(np.mean(dists))
+
+
+raw_means, aligned_means = [], []
+for subject in subjects:
+    X, _ = data[subject]
+    raw_means.append(mean_covariance(X))
+    # Per-subject (transductive) Euclidean Alignment: label-free, leakage-free.
+    X_aligned = EuclideanAlignment().fit_transform(X)
+    aligned_means.append(mean_covariance(X_aligned))
+
+dispersion = {
+    "No alignment": between_subject_dispersion(raw_means),
+    "Euclidean Alignment": between_subject_dispersion(aligned_means),
+}
+print("Between-subject covariance dispersion:", dispersion)
+
+fig, ax = plt.subplots(figsize=(5, 4))
+ax.bar(dispersion.keys(), dispersion.values(), color=["#999999", "#0072B2"])
+ax.set_ylabel("Mean pairwise distance between\nsubject covariances (Frobenius)")
+ax.set_title("Euclidean Alignment shrinks the\nbetween-subject domain shift")
+fig.tight_layout()
+plt.show()
+
+###############################################################################
+# Leave-one-subject-out decoding, with and without alignment
+# ----------------------------------------------------------
+#
+# Now the payoff. For each held-out subject we train a standard CSP+LDA pipeline
+# on the *other* subjects and test on the held-out one — the cross-subject
+# transfer setting. We run it twice: on the raw trials, and on trials that have
+# each been Euclidean-aligned per subject.
+#
+# CSP+LDA is a *Euclidean* classifier and is therefore sensitive to the
+# covariance shift EA removes. (Riemannian tangent-space pipelines already
+# recenter covariances internally, so they benefit less — EA is most valuable
+# for Euclidean and deep models, exactly the setting of [2]_.)
+
+
+def decode_loso(aligned):
+    """Leave-one-subject-out ROC-AUC, optionally with per-subject EA."""
+    scores = []
+    for test_subject in subjects:
+        train_subjects = [s for s in subjects if s != test_subject]
+
+        def prep(subject):
+            X, y = data[subject]
+            if aligned:
+                X = EuclideanAlignment().fit_transform(X)
+            return X, y
+
+        X_train = np.concatenate([prep(s)[0] for s in train_subjects])
+        y_train = np.concatenate([prep(s)[1] for s in train_subjects])
+        X_test, y_test = prep(test_subject)
+
+        clf = make_pipeline(CSP(n_components=8), LDA())
+        clf.fit(X_train, y_train)
+        proba = clf.predict_proba(X_test)[:, 1]
+        scores.append(roc_auc_score(y_test, proba))
+    return np.array(scores)
+
+
+raw_scores = decode_loso(aligned=False)
+aligned_scores = decode_loso(aligned=True)
+
+for subject, raw, aligned in zip(subjects, raw_scores, aligned_scores):
+    print(f"subject {subject}: raw={raw:.3f}  aligned={aligned:.3f}")
+print(
+    f"mean: raw={raw_scores.mean():.3f}  aligned={aligned_scores.mean():.3f}  "
+    f"(EA wins on {(aligned_scores > raw_scores).sum()}/{len(subjects)} subjects)"
+)
+
+###############################################################################
+# A point per held-out subject: above the diagonal means Euclidean Alignment
+# helped that subject's cross-subject transfer.
+
+fig, ax = plt.subplots(figsize=(5, 5))
+ax.scatter(raw_scores, aligned_scores, c="#0072B2", s=70, zorder=3)
+for subject, raw, aligned in zip(subjects, raw_scores, aligned_scores):
+    ax.annotate(f"S{subject}", (raw, aligned), textcoords="offset points", xytext=(6, 0))
+lims = [min(raw_scores.min(), aligned_scores.min()) - 0.02, 1.0]
+ax.plot(lims, lims, "--", color="grey", zorder=1)
+ax.set_xlim(lims)
+ax.set_ylim(lims)
+ax.set_xlabel("ROC-AUC without alignment")
+ax.set_ylabel("ROC-AUC with Euclidean Alignment")
+ax.set_title("Cross-subject transfer (leave-one-subject-out)")
+ax.set_aspect("equal")
+fig.tight_layout()
+plt.show()
+
+###############################################################################
+# Using it inside a MOABB evaluation
+# ----------------------------------
+#
+# Above we used the **transductive** per-recording form (``fit_transform`` on
+# each subject). :class:`~moabb.datasets.preprocessing.EuclideanAlignment` is
+# also a regular scikit-learn transformer, so its **inductive**, leakage-free
+# form drops straight into a pipeline for any MOABB evaluation: ``fit`` learns
+# the reference whitener from the training trials only and ``transform`` reuses
+# it on the test trials. For example::
+#
+#     from moabb.evaluations import CrossSubjectEvaluation
+#
+#     pipelines = {
+#         "EA+CSP+LDA": make_pipeline(
+#             EuclideanAlignment(), CSP(n_components=8), LDA()
+#         )
+#     }
+#     evaluation = CrossSubjectEvaluation(paradigm=paradigm, datasets=[dataset])
+#     results = evaluation.process(pipelines)
+#
+# For the full deep-learning story — where EA shines most, improving target
+# accuracy by +4.33% and cutting training time by >70% — see Junqueira et al.
+# (2024) [2]_.
+#
+# References
+# ----------
+# .. [1] He, H., & Wu, D. (2020). Transfer learning for brain-computer
+#        interfaces: A Euclidean space data alignment approach. *IEEE
+#        Transactions on Biomedical Engineering*, 67(2), 399-410.
+#        https://doi.org/10.1109/TBME.2019.2913914
+# .. [2] Junqueira, B., Aristimunha, B., Chevallier, S., & de Camargo, R. Y.
+#        (2024). A systematic evaluation of Euclidean alignment with deep
+#        learning for EEG decoding. *Journal of Neural Engineering*, 21(3),
+#        036038. https://doi.org/10.1088/1741-2552/ad4f18

--- a/moabb/datasets/preprocessing.py
+++ b/moabb/datasets/preprocessing.py
@@ -9,6 +9,7 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.pipeline import FunctionTransformer, Pipeline, _name_estimators
 from sklearn.utils import Bunch
+from sklearn.utils.validation import check_is_fitted
 
 from moabb.datasets._channel_pick import pick_channels_for_modalities
 
@@ -1102,3 +1103,116 @@ def get_resample_pipeline(sfreq):
         func=methodcaller("resample", sfreq=sfreq, verbose=False),
         display_name=f"Resample ({sfreq} Hz)",
     )
+
+
+class EuclideanAlignment(TransformerMixin, BaseEstimator):
+    r"""Euclidean Alignment of trials (He & Wu, 2020).
+
+    Euclidean Alignment (EA) removes the per-domain (subject / session /
+    recording) covariance shift that makes a model trained on one set of
+    recordings transfer poorly to another. It is the simplest member of a
+    larger family of trial-alignment methods — others recenter on the
+    Riemannian or log-Euclidean mean — and is the one most used with deep
+    networks because it is cheap, label-free, and leaves the data as raw trials
+    a network can ingest [He2020]_ [Junqueira2024]_.
+
+    Each trial is whitened by the inverse square root of a single reference
+    covariance,
+
+    .. math::
+
+        \bar{C} = \frac{1}{N} \sum_{i=1}^{N} C_i, \qquad
+        \tilde{X}_i = \bar{C}^{-1/2} X_i ,
+
+    where :math:`C_i` is the spatial covariance of trial :math:`X_i` and
+    :math:`\bar{C}` is their **arithmetic (Euclidean) mean**. After alignment
+    the trials share an identity-like average covariance, so the domain shift
+    that lived in the second-order statistics is gone.
+
+    The transformer is **inductive** by default: :meth:`fit` learns
+    :math:`\bar{C}^{-1/2}` from the *training* trials and :meth:`transform`
+    re-applies that same whitener to unseen trials, so no test information leaks
+    into the alignment (the leakage that the transductive, fit-on-everything
+    form silently introduces). Calling :meth:`fit_transform` on a single
+    recording recovers the usual transductive, per-recording EA people
+    hand-roll — same object, no second class.
+
+    Unlike :class:`pyriemann.transfer.TLCenter` (with ``metric="euclid"``),
+    which recenters covariance *matrices* for a Riemannian classifier, this
+    operates directly on the ``(n_trials, n_channels, n_times)`` trials, so it
+    drops in front of any time-series model (CSP, EEGNet, ...).
+
+    Parameters
+    ----------
+    estimator : str, default "lwf"
+        Covariance estimator passed to
+        :func:`pyriemann.utils.covariance.covariances`. The shrinkage default
+        ``"lwf"`` (Ledoit-Wolf) keeps the per-trial covariances symmetric
+        positive-definite — and hence the reference mean invertible — even on
+        short or noisy trials, where the plain sample covariance (``"scm"`` /
+        ``"cov"``) can be ill-conditioned.
+
+    Attributes
+    ----------
+    inv_sqrt_ref_ : ndarray, shape (n_channels, n_channels)
+        Inverse square root :math:`\bar{C}^{-1/2}` of the reference mean
+        covariance learned in :meth:`fit`; the whitening matrix applied in
+        :meth:`transform`.
+
+    See Also
+    --------
+    pyriemann.transfer.TLCenter
+
+    Notes
+    -----
+    Accepts an :class:`mne.BaseEpochs` (read via ``get_data``) or an ndarray of
+    shape ``(n_trials, n_channels, n_times)``; :meth:`transform` returns an
+    ndarray of the same shape. ``pyriemann >= 0.11`` is already a hard moabb
+    dependency, so this adds no new requirement.
+
+    References
+    ----------
+    .. [He2020] He, H., & Wu, D. (2020). Transfer learning for brain-computer
+       interfaces: A Euclidean space data alignment approach. *IEEE
+       Transactions on Biomedical Engineering*, 67(2), 399-410.
+       https://doi.org/10.1109/TBME.2019.2913914
+    .. [Junqueira2024] Junqueira, B., Aristimunha, B., Chevallier, S., &
+       de Camargo, R. Y. (2024). A systematic evaluation of Euclidean alignment
+       with deep learning for EEG decoding. *Journal of Neural Engineering*,
+       21(3), 036038. https://doi.org/10.1088/1741-2552/ad4f18
+    """
+
+    def __init__(self, estimator="lwf"):
+        self.estimator = estimator
+
+    @staticmethod
+    def _array(X):
+        """Return trials as a float ``(n_trials, n_channels, n_times)`` ndarray."""
+        if hasattr(X, "get_data"):  # mne Epochs
+            X = X.get_data(copy=False)
+        X = np.asarray(X, dtype=float)
+        if X.ndim != 3:
+            raise ValueError(
+                "EuclideanAlignment expects trials shaped "
+                f"(n_trials, n_channels, n_times), got a {X.ndim}D input."
+            )
+        return X
+
+    def fit(self, X, y=None):
+        # Lazy import: pyriemann.utils.base emits a DeprecationWarning at import
+        # time and this core module is imported almost everywhere, so only
+        # EuclideanAlignment users pay it. These paths are valid for the declared
+        # pyriemann >= 0.11 floor and match the rest of moabb (pipelines.csp,
+        # pipelines.classification). The Euclidean mean is the arithmetic mean of
+        # the per-trial covariances, so no mean_covariance() call is needed.
+        from pyriemann.utils.base import invsqrtm
+        from pyriemann.utils.covariance import covariances
+
+        covs = covariances(self._array(X), estimator=self.estimator)
+        self.inv_sqrt_ref_ = invsqrtm(covs.mean(axis=0))
+        return self
+
+    def transform(self, X):
+        check_is_fitted(self, "inv_sqrt_ref_")
+        # (n_chans, n_chans) @ (n_trials, n_chans, n_times) -> (n_trials, n_chans, n_times)
+        return np.matmul(self.inv_sqrt_ref_, self._array(X))

--- a/moabb/tests/test_preprocessing.py
+++ b/moabb/tests/test_preprocessing.py
@@ -12,6 +12,7 @@ from moabb.datasets.bids_interface import StepType
 from moabb.datasets.preprocessing import (
     _REST_LABEL,
     EpochsToEvents,
+    EuclideanAlignment,
     EventsToLabels,
     FixedPipeline,
     FixedTransformer,
@@ -760,3 +761,105 @@ def test_fixed_pipeline_repr_html_with_steptype_keys():
     # StepType enums must not leak into the HTML output
     assert "StepType.RAW" not in html
     assert "StepType.EPOCHS" not in html
+
+
+# ── EuclideanAlignment ────────────────────────────────────────────────────────
+
+
+def _trials(seed=0, scale=1.0, n_trials=24, n_chans=4, n_times=128):
+    """Random trials with a non-trivial spatial covariance (random mixing matrix)."""
+    rng = np.random.RandomState(seed)
+    mix = rng.randn(n_chans, n_chans) * scale
+    return np.matmul(mix, rng.randn(n_trials, n_chans, n_times))
+
+
+def _epochs_from_array(X):
+    info = mne.create_info(
+        ch_names=[f"EEG{i + 1}" for i in range(X.shape[1])], sfreq=128, ch_types="eeg"
+    )
+    return mne.EpochsArray(X, info, verbose=False)
+
+
+def _euclid_mean_cov(X, estimator="lwf"):
+    """Euclidean (arithmetic) mean of the per-trial covariances."""
+    from pyriemann.utils.covariance import covariances
+
+    return covariances(X, estimator=estimator).mean(axis=0)
+
+
+def test_euclidean_alignment_cov_whitens_exactly():
+    """With the linear ``cov`` estimator, EA whitens exactly: the Euclidean mean
+    covariance of the aligned trials is the identity."""
+    X = _trials(seed=1)
+    Xa = EuclideanAlignment(estimator="cov").fit_transform(X)
+    assert Xa.shape == X.shape
+    np.testing.assert_allclose(_euclid_mean_cov(Xa, "cov"), np.eye(X.shape[1]), atol=1e-8)
+
+
+@pytest.mark.parametrize("estimator", ["lwf", "scm", "oas"])
+def test_euclidean_alignment_reduces_covariance_shift(estimator):
+    """For each covariance estimator, EA moves the mean covariance much closer to
+    the identity than the raw trials, and stays finite."""
+    X = _trials(seed=2)
+    eye = np.eye(X.shape[1])
+    orig = np.abs(_euclid_mean_cov(X, estimator) - eye).max()
+    Xa = EuclideanAlignment(estimator=estimator).fit_transform(X)
+    assert np.isfinite(Xa).all()
+    aligned = np.abs(_euclid_mean_cov(Xa, estimator) - eye).max()
+    assert aligned < orig
+
+
+def test_euclidean_alignment_whitener_is_spd():
+    W = EuclideanAlignment().fit(_trials(seed=3)).inv_sqrt_ref_
+    assert W.shape == (4, 4)
+    assert np.isfinite(W).all()
+    np.testing.assert_allclose(W, W.T, atol=1e-8)  # symmetric
+    assert np.all(np.linalg.eigvalsh(W) > 0)  # positive definite
+
+
+def test_euclidean_alignment_inductive_no_leakage():
+    """``transform`` reuses the train whitener; it must NOT re-fit on the test batch."""
+    al = EuclideanAlignment().fit(_trials(seed=4, scale=1.0))
+    test = _trials(seed=5, scale=3.0)  # different covariance from train
+    out = al.transform(test)
+    # transform is exactly the stored whitener applied to the test trials
+    np.testing.assert_allclose(out, np.matmul(al.inv_sqrt_ref_, test))
+    # and the train whitener does NOT whiten the (differently-scaled) test batch
+    assert not np.allclose(_euclid_mean_cov(out), np.eye(4), atol=0.05)
+
+
+def test_euclidean_alignment_fit_transform_is_transductive():
+    """``fit_transform`` equals ``fit(X).transform(X)`` (the per-recording form)."""
+    X = _trials(seed=6)
+    a = EuclideanAlignment().fit_transform(X)
+    b = EuclideanAlignment().fit(X).transform(X)
+    np.testing.assert_allclose(a, b)
+
+
+def test_euclidean_alignment_epochs_matches_ndarray():
+    X = _trials(seed=7)
+    from_arr = EuclideanAlignment().fit_transform(X)
+    from_epochs = EuclideanAlignment().fit_transform(_epochs_from_array(X))
+    np.testing.assert_allclose(from_arr, from_epochs, rtol=1e-6, atol=1e-9)
+
+
+def test_euclidean_alignment_transform_before_fit_raises():
+    from sklearn.exceptions import NotFittedError
+
+    with pytest.raises(NotFittedError):
+        EuclideanAlignment().transform(_trials())
+
+
+def test_euclidean_alignment_bad_ndim_raises():
+    with pytest.raises(ValueError, match="n_trials, n_channels, n_times"):
+        EuclideanAlignment().fit(np.random.RandomState(0).randn(4, 128))  # 2D, not 3D
+
+
+def test_euclidean_alignment_is_clonable():
+    """EuclideanAlignment follows the sklearn estimator contract (get_params / clone)."""
+    from sklearn.base import clone
+
+    al = EuclideanAlignment(estimator="scm")
+    assert al.get_params() == {"estimator": "scm"}
+    cloned = clone(al)
+    assert cloned.get_params() == al.get_params()


### PR DESCRIPTION
Closes #1108.

## What

Adds `moabb.datasets.preprocessing.EuclideanAlignment`, a generic, inductive, robust **trial-level** alignment transformer. Euclidean Alignment (He & Wu, 2020) whitens each trial by the inverse square root of the **Euclidean (arithmetic) mean** of the per-trial covariances, removing per-domain (subject/session/recording) covariance shift before a trial-input model sees the data.

```python
from moabb.datasets.preprocessing import EuclideanAlignment

# inductive, leakage-free: learns the whitener on train, re-applies on test
EuclideanAlignment().fit(X_train).transform(X_test)

# transductive per-recording form (what people usually hand-roll)
EuclideanAlignment().fit_transform(X)
```

## Why this shape

- **Inductive & leakage-free** — `fit` stores `inv_sqrt_ref_` from train only; `transform` reuses it on test. The transductive form is just `fit_transform` on one recording — same object, no second class.
- **Robust** — shrinkage covariance (`estimator="lwf"`) + `pyriemann.utils.base.invsqrtm` + `check_is_fitted`. The Euclidean mean is the arithmetic mean of the per-trial covariances, so no `mean_covariance` call is needed.
- **Generic input** — accepts an `mne.Epochs` (via `get_data`) or an `(n_trials, n_channels, n_times)` ndarray; returns an ndarray of the same shape.
- **No new dependency** — `pyriemann >= 0.11` is already a hard moabb requirement (imported lazily inside `fit` so the deprecation-warning paths are only paid by users of this class).
- Distinct from `pyriemann.transfer.TLCenter`, which recenters covariance *matrices* for Riemannian pipelines rather than the raw trials a (deep) network ingests.

Scoped to **Euclidean** alignment specifically (rather than a generic `metric=` selector) so the name matches the behaviour; Riemannian/log-Euclidean siblings can be added later if needed.

## Tests

`moabb/tests/test_preprocessing.py` (all pass): exact whitening with the linear `cov` estimator; covariance-shift reduction across `lwf`/`scm`/`oas`; SPD whitener; inductive no-leakage; `fit_transform == fit().transform()`; Epochs ≡ ndarray; not-fitted + bad-ndim raises; sklearn `clone`/`get_params` contract.

## Docs

- API reference: new **Preprocessing** subsection in `docs/source/api.rst` (`preprocessing.EuclideanAlignment`).
- `docs/source/whats_new.rst` enhancement entry.
- New gallery example `examples/advanced_examples/plot_euclidean_alignment.py`: a leave-one-subject-out cross-subject demo on BNCI2014_001 / LeftRightImagery showing (1) the between-subject covariance dispersion collapsing after EA and (2) CSP+LDA transfer improving with per-subject EA, grounded in [Junqueira, Aristimunha, Chevallier & de Camargo (2024)](https://doi.org/10.1088/1741-2552/ad4f18).

## References

- He, H., & Wu, D. (2020). Transfer learning for BCIs: A Euclidean space data alignment approach. *IEEE TBME*, 67(2), 399-410.
- Junqueira, B., Aristimunha, B., Chevallier, S., & de Camargo, R. Y. (2024). A systematic evaluation of Euclidean alignment with deep learning for EEG decoding. *J. Neural Eng.*, 21(3), 036038.