### PR TITLE
Make datasets print their code instead of <...object at 0x...>

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -51,6 +51,7 @@ Requirements
 
 Bugs
 ~~~~
+- Add a ``__repr__`` to :class:`moabb.datasets.base.BaseDataset` so datasets display by their code (e.g. ``BNCI2014-001``) when printed, instead of the verbose default ``<...object at 0x...>``. This declutters the output of ``print(paradigm.datasets)`` in the tutorials and of the paradigm and evaluation compatibility warnings (by `Danae`_)
 - Add ``age_median`` field to :class:`moabb.datasets.metadata.schema.ParticipantMetadata` and populate ``age_std`` / ``age_median`` / ``n_blocks`` metadata for :class:`moabb.datasets.Rodrigues2017` (Alphawaves), fixing a ``TypeError`` at import time (by `Grace Xu`_)
 - Fix :class:`moabb.datasets.BNCI2014_001` descriptive ``METADATA``, which had many fields copied from BCI Competition IV Data set 1. Correct ``n_subjects`` (4 → 9), ``n_classes`` (2 → 4), ``class_labels`` / ``events`` / ``imagery_tasks`` (now ``left_hand`` / ``right_hand`` / ``feet`` / ``tongue``), ``synchronicity`` (asynchronous → synchronous), ``sessions_per_subject`` (1 → 2), the per-session trial structure (288 trials, 6 runs of 48), the acquisition ``reference`` / ``ground`` / ``filters`` and the ``preprocessing`` band (0.5–100 Hz with a 50 Hz notch, no 100 Hz downsampling), and the dataset ``description`` so they all match the dataset's own constructor and docstring (by `YG-paaleee`_)
 - Fix :class:`moabb.datasets.BNCI2014_001` stimulus protocol timing in the generated documentation figure to show 2 s fixation, 1.25 s cue, and motor imagery through t=6 s (by `Bruno Aristimunha`_)
@@ -906,3 +907,4 @@ API changes
 .. _YG-paaleee: https://github.com/YG-paaleee
 .. _Grace Xu: https://github.com/grookymonster
 .. _copilot-swe-agent: https://github.com/apps/copilot-swe-agent
+.. _Danae: https://github.com/dnplchrn

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -718,6 +718,9 @@ class BaseDataset(metaclass=MetaclassDataset):
         self.doi = doi
         self.unit_factor = unit_factor
 
+    def __repr__(self):
+        return self.code
+
     @property
     def all_subjects(self):
         """Full list of subjects available in this dataset (unfiltered)."""

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -136,6 +136,20 @@ class Test_Datasets:
         with pytest.raises(ValueError):
             ds.get_data([1000])
 
+    def test_repr_shows_code(self):
+        """Datasets should print their code, not the default object repr."""
+        ds = FakeDataset(code="FakeRepr")
+
+        # readable instead of "<...FakeDataset object at 0x...>"
+        assert "FakeRepr" in repr(ds)
+        assert "object at 0x" not in repr(ds)
+
+        # str() falls back to repr, so f-strings/print stay readable too
+        assert "FakeRepr" in f"{ds}"
+
+        # the repr is what shows when a dataset is printed inside a list
+        assert "FakeRepr" in repr([ds])
+
     @pytest.mark.parametrize("paradigm", ["imagery", "p300", "ssvep"])
     def test_fake_dataset_seed(self, paradigm):
         """this test will insure the fake dataset's random seed works"""


### PR DESCRIPTION
Hey there, new here. Thanks for this project!

I was running through the tutorial examples to get familiar with moabb, and it got a bit hard for me to scan with the printed objects. Small fix: added a __repr__ to BaseDataset that returns the dataset's code, so they show up as BNCI2014-001 instead. This also tidies up the paradigm and evaluation compatibility warnings that print during a benchmark run.

Feel free to adjust or reject this. 