### PR TITLE
Fix dataset download path integrity

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -57,6 +57,7 @@ Requirements
 
 Bugs
 ~~~~
+- Fix dataset download paths that silently omitted files, returned nonexistent paths, or repeatedly extracted archives (:gh:`1135`).
 - Use NEMAR's OpenNeuro rehosts for :class:`moabb.datasets.TrianaGuzman2024` and :class:`moabb.datasets.Chailloux2020` (:gh:`1136`).
 - Fix how the benchmark results page (:doc:`paper_results`) describes what its tables report. It stated that results are "mean accuracy and standard deviation across all folds for all sessions and subjects", and both halves are inaccurate: :class:`moabb.paradigms.MotorImagery` selects the metric from the number of classes, so two-class scenarios are scored with ROC-AUC rather than accuracy, and :class:`moabb.evaluations.WithinSessionEvaluation` averages the cross-validation folds within each session before returning a score, so the reported standard deviation is across (subject, session) pairs and not across individual folds (:gh:`1128` by `Bhargav Kowshik`_)
 - Fix datasets ignoring a change of download directory: datasets now inherit ``MNE_DATA`` without persisting a redundant per-dataset mirror, and :func:`moabb.utils.set_download_dir` removes legacy ``MNE_DATASETS_<SIGN>_PATH`` entries that still mirror the previous shared location while preserving explicit overrides. :class:`moabb.datasets.RomaniBF2025ERP` now uses the same path mechanism and honours ``path`` and ``force_update``. Adds isolated regression coverage across every dataset (:gh:`1115` by `Bruno Aristimunha`_).

--- a/moabb/datasets/braininvaders.py
+++ b/moabb/datasets/braininvaders.py
@@ -406,7 +406,7 @@ def _bi_data_path(  # noqa: C901
             osp.join(
                 path_folder,
                 f"group_{(subject + 1) // 2:02}",
-                f"group_{(subject + 1) // 2:02}_s{i}",
+                f"group_{(subject + 1) // 2:02}_s{i}.mat",
             )
             for i in range(1, 5)
         ]

--- a/moabb/datasets/hefmi_ich2025.py
+++ b/moabb/datasets/hefmi_ich2025.py
@@ -220,7 +220,8 @@ class HefmiIch2025(BaseDataset):
 
     def _get_single_subject_data(self, subject):
         """Return data for a single subject."""
-        base = Path(self.data_path(subject))
+        self.data_path(subject)
+        base = Path(dl.get_dataset_path("HefmiIch2025", None)) / "MNE-hefmiich2025-data"
 
         # Find epoch files for this subject.
         manifest = self._get_manifest(base)
@@ -377,8 +378,22 @@ class HefmiIch2025(BaseDataset):
         if subject not in self.subject_list:
             raise ValueError("Invalid subject number")
 
-        path = dl.get_dataset_path("HefmiIch2025", path)
-        basepath = Path(path) / "MNE-hefmiich2025-data"
+        root = Path(dl.get_dataset_path("HefmiIch2025", path))
+        basepath = root / "MNE-hefmiich2025-data"
         basepath.mkdir(parents=True, exist_ok=True)
 
-        return str(basepath)
+        manifest = self._get_manifest(basepath)
+        if subject not in manifest:
+            raise FileNotFoundError(f"No EEG epoch files found for subject {subject}")
+
+        paths = []
+        for file_id, file_name in manifest[subject]:
+            local_path = basepath / file_name
+            if not local_path.exists() or force_update:
+                url = f"https://ndownloader.figshare.com/files/{file_id}"
+                downloaded = Path(dl.data_dl(url, self.code, root, force_update, verbose))
+                if downloaded != local_path:
+                    downloaded.replace(local_path)
+            paths.append(str(local_path))
+
+        return paths

--- a/moabb/datasets/kojima2024a.py
+++ b/moabb/datasets/kojima2024a.py
@@ -549,8 +549,16 @@ class Kojima2024A(BaseDataset):
         # checking it there is manifest file in the dataset folder.
         dl.download_if_missing(path / "kojima2024_manifest.json", _manifest_link)
 
-        with open(path / "kojima2024_manifest.json", "r") as f:
-            manifest = json.load(f)
+        manifest_path = path / "kojima2024_manifest.json"
+        try:
+            with open(manifest_path, "r") as f:
+                manifest = json.load(f)
+        except json.JSONDecodeError as err:
+            manifest_path.unlink(missing_ok=True)
+            raise RuntimeError(
+                "Downloaded Kojima2024 manifest is invalid and has been removed; retry "
+                "once the upstream service is available."
+            ) from err
 
         files = self._get_files_list(subject, manifest)
 

--- a/moabb/datasets/kojima2024b.py
+++ b/moabb/datasets/kojima2024b.py
@@ -587,8 +587,16 @@ class Kojima2024B(BaseDataset):
         # checking it there is manifest file in the dataset folder.
         dl.download_if_missing(path / "kojima2024_manifest.json", _manifest_link)
 
-        with open(path / "kojima2024_manifest.json", "r") as f:
-            manifest = json.load(f)
+        manifest_path = path / "kojima2024_manifest.json"
+        try:
+            with open(manifest_path, "r") as f:
+                manifest = json.load(f)
+        except json.JSONDecodeError as err:
+            manifest_path.unlink(missing_ok=True)
+            raise RuntimeError(
+                "Downloaded Kojima2024 manifest is invalid and has been removed; retry "
+                "once the upstream service is available."
+            ) from err
 
         files = self._get_files_list(subject, manifest)
 

--- a/moabb/datasets/mainsah2025.py
+++ b/moabb/datasets/mainsah2025.py
@@ -234,8 +234,8 @@ def _parse_manifest(manifest_path):
                 continue
             path = parts[1]
             m = re.match(
-                r"bigP3BCI-data/Study(\w+)/(\w+)/SE(\d+)/"
-                r"(Test|Train)/(\w+)/(.+\.edf)",
+                r"bigP3BCI-data/Study([\w-]+)/([\w-]+)/SE(\d+)/"
+                r"(Test|Train)/([\w-]+)/(.+\.edf)",
                 path,
             )
             if not m:

--- a/moabb/datasets/ssvep_chen2017.py
+++ b/moabb/datasets/ssvep_chen2017.py
@@ -359,7 +359,7 @@ class Chen2017SingleFlicker(BaseDataset):
 
         # Check if already extracted
         mat_files = sorted(data_dir.rglob(f"{subject}_*.mat"))
-        xdf_files = sorted(data_dir.rglob(f"{subject}_*.xdf"))
+        xdf_files = sorted(data_dir.rglob(f"sub_{subject}_*.xdf"))
         if (mat_files or xdf_files) and not force_update:
             return {
                 "mat": [str(f) for f in mat_files],
@@ -380,5 +380,5 @@ class Chen2017SingleFlicker(BaseDataset):
             safe_extract_zip(zf, data_dir, members=selected)
 
         mat_files = sorted(data_dir.rglob(f"{subject}_*.mat"))
-        xdf_files = sorted(data_dir.rglob(f"{subject}_*.xdf"))
+        xdf_files = sorted(data_dir.rglob(f"sub_{subject}_*.xdf"))
         return {"mat": [str(f) for f in mat_files], "xdf": [str(f) for f in xdf_files]}

--- a/moabb/datasets/yang2025.py
+++ b/moabb/datasets/yang2025.py
@@ -331,7 +331,9 @@ class Yang2025(BaseDataset):
 
         # Check if data already extracted (look for the extracted directory)
         extracted_dir = basepath / "WBCIC_SHU Motor Imagery dataset"
-        already_extracted = extracted_dir.is_dir() and any(extracted_dir.rglob("*.mat"))
+        already_extracted = extracted_dir.is_dir() and any(
+            extracted_dir.rglob("data.bdf")
+        )
 
         # Single 65.6 GB ZIP - download if needed.
         zip_path = basepath / "WBCIC_SHU_Motor_Imagery_dataset.zip"

--- a/moabb/tests/test_dataset_fixes.py
+++ b/moabb/tests/test_dataset_fixes.py
@@ -7,10 +7,17 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from moabb.datasets import download as _dl
 from moabb.datasets.bnci.bnci_2020 import _convert_attention_shift
+from moabb.datasets.braininvaders import BI2015b
+from moabb.datasets.hefmi_ich2025 import HefmiIch2025
+from moabb.datasets.kojima2024a import Kojima2024A
+from moabb.datasets.mainsah2025 import _parse_manifest
+from moabb.datasets.ssvep_chen2017 import Chen2017SingleFlicker
 from moabb.datasets.ssvep_mamem import MAMEM1
+from moabb.datasets.yang2025 import Yang2025
 
 
 def _fake_bciexp(n_channels=3, n_samples=4, n_trials=5):
@@ -121,3 +128,115 @@ def test_mamem_already_downloaded_does_not_ping_figshare(tmp_path: Path):
             assert paths
             assert all(Path(p).exists() for p in paths)
     _dl.fs_get_file_list.cache_clear()
+
+
+def test_mainsah_manifest_includes_hyphenated_path_components(tmp_path: Path):
+    manifest = tmp_path / "SHA256SUMS.txt"
+    paths = [
+        "bigP3BCI-data/StudyQ/Q_01/SE001/Train/Grey-to-White/run-1.edf",
+        "bigP3BCI-data/StudyQ/Q_01/SE001/Train/Grey-to-Color/run-2.edf",
+        "bigP3BCI-data/StudyQ/Q_01/SE001/Train/ColorIntensification/run-3.edf",
+    ]
+    manifest.write_text("\n".join(f"deadbeef  {path}" for path in reversed(paths)))
+
+    parsed = _parse_manifest(manifest)
+
+    assert parsed["Q"]["Q_01"][1] == sorted(paths)
+
+
+def test_chen2017_data_path_finds_prefixed_xdf_files(tmp_path: Path, monkeypatch):
+    dataset = Chen2017SingleFlicker()
+    xdf_file = (
+        tmp_path
+        / "MNE-chen2017singleflicker-data"
+        / "3.raw_data"
+        / "1.training_data"
+        / "sub_1_1.xdf"
+    )
+    xdf_file.parent.mkdir(parents=True)
+    xdf_file.touch()
+    monkeypatch.setattr(
+        "moabb.datasets.ssvep_chen2017.dl.get_dataset_path", lambda *args: tmp_path
+    )
+    monkeypatch.setattr(
+        "moabb.datasets.ssvep_chen2017.dl.data_dl",
+        lambda *args: (_ for _ in ()).throw(AssertionError("unexpected download")),
+    )
+
+    paths = dataset.data_path(1)
+
+    assert paths == {"mat": [], "xdf": [str(xdf_file)]}
+
+
+def test_yang2025_recognizes_extracted_bdf_files(tmp_path: Path, monkeypatch):
+    data_file = (
+        tmp_path
+        / "MNE-yang2025-data"
+        / "WBCIC_SHU Motor Imagery dataset"
+        / "sourcedata"
+        / "2C dataset"
+        / "sub-001"
+        / "ses-01"
+        / "eeg"
+        / "data.bdf"
+    )
+    data_file.parent.mkdir(parents=True)
+    data_file.touch()
+    monkeypatch.setattr(
+        "moabb.datasets.yang2025.dl.get_dataset_path", lambda *args: tmp_path
+    )
+    monkeypatch.setattr(
+        "moabb.datasets.yang2025.dl.data_dl",
+        lambda *args: (_ for _ in ()).throw(AssertionError("unexpected download")),
+    )
+
+    assert Yang2025().data_path(1) == str(tmp_path / "MNE-yang2025-data")
+
+
+def test_hefmi_ich_data_path_downloads_subject_files(tmp_path: Path, monkeypatch):
+    dataset = HefmiIch2025()
+    monkeypatch.setattr(
+        "moabb.datasets.hefmi_ich2025.dl.get_dataset_path", lambda *args: tmp_path
+    )
+    monkeypatch.setattr(
+        "moabb.datasets.hefmi_ich2025._MANIFEST", {1: [(42, "sub01_1_epo.mat")]}
+    )
+
+    def fake_download(url, sign, root, force_update, verbose):
+        downloaded = tmp_path / "MNE-hefmiich2025-data" / "42"
+        downloaded.write_bytes(b"data")
+        return downloaded
+
+    monkeypatch.setattr("moabb.datasets.hefmi_ich2025.dl.data_dl", fake_download)
+
+    assert dataset.data_path(1) == [
+        str(tmp_path / "MNE-hefmiich2025-data" / "sub01_1_epo.mat")
+    ]
+
+
+def test_bi2015b_data_path_returns_existing_mat_paths(tmp_path: Path, monkeypatch):
+    group_dir = tmp_path / "zenodo" / "3268762" / "group_01"
+    group_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        "moabb.datasets.braininvaders.dl.data_dl",
+        lambda *args, **kwargs: str(tmp_path / "zenodo" / "3268762" / "group_01_mat.zip"),
+    )
+
+    paths = BI2015b().data_path(1)
+
+    assert all(path.endswith(".mat") for path in paths)
+
+
+def test_kojima2024_removes_invalid_cached_manifest(tmp_path: Path, monkeypatch):
+    dataset = Kojima2024A()
+    manifest_path = tmp_path / f"MNE-{dataset.code}-data" / "kojima2024_manifest.json"
+    manifest_path.parent.mkdir()
+    manifest_path.write_text("<html>upstream error</html>")
+    monkeypatch.setattr(
+        "moabb.datasets.kojima2024a.dl.download_if_missing", lambda *args: None
+    )
+
+    with pytest.raises(RuntimeError, match="invalid and has been removed"):
+        dataset.download_by_subject(1, tmp_path)
+
+    assert not manifest_path.exists()


### PR DESCRIPTION
Fixes #1135.

Correct dataset download and discovery paths that could silently omit data, return nonexistent paths, repeatedly extract archives, or preserve an invalid Kojima manifest.

Includes focused regression coverage for each fixed loader path.

Tests:
- `pytest moabb/tests/test_dataset_fixes.py`
- `ruff check` and `ruff format --check` on changed Python files
- `git diff --check`