### PR TITLE
Derive AcquisitionMetadata.n_channels from channel_types instead of storing it

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -27,7 +27,7 @@ Enhancements
 
 API changes
 ~~~~~~~~~~~
-- None yet.
+- :attr:`moabb.datasets.metadata.AcquisitionMetadata.n_channels` is derived from ``channel_types`` instead of stored beside it. The two could disagree, and for 34 of the 147 catalogued datasets they did -- the field was being used with two meanings, some counting EEG electrodes only and others every recorded channel. It now consistently means the total, which is what each dataset's own ``sensors`` list and ``test_n_channels_matches_raw_data`` (which counts every non-``stim`` channel) already assumed: :class:`moabb.datasets.Dreyer2023A`, for instance, reported 27 against its own 32 sensors and now reports 32. Passing ``n_channels=`` to the constructor is no longer accepted (by `Bruno Aristimunha`_).
 
 Requirements
 ~~~~~~~~~~~~

--- a/moabb/datasets/Lee2019.py
+++ b/moabb/datasets/Lee2019.py
@@ -325,7 +325,6 @@ class Lee2019_MI(Lee2019):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62, "emg": 4},
             montage="standard_1005",
             hardware="BrainAmp",
@@ -610,7 +609,6 @@ class Lee2019_ERP(Lee2019):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62, "emg": 4},
             montage="standard_1005",
             hardware="BrainAmp",
@@ -858,7 +856,6 @@ class Lee2019_SSVEP(Lee2019):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62, "emg": 4},
             montage="standard_1005",
             hardware="BrainAmp",

--- a/moabb/datasets/Weibo2014.py
+++ b/moabb/datasets/Weibo2014.py
@@ -120,7 +120,6 @@ class Weibo2014(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=60,
             channel_types={"eeg": 60, "eog": 2, "misc": 2},
             montage="standard_1005",
             hardware="Neuroscan SynAmps2",

--- a/moabb/datasets/Zhou2016.py
+++ b/moabb/datasets/Zhou2016.py
@@ -72,7 +72,6 @@ class Zhou2016(BaseBIDSDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=14,
             channel_types={"eeg": 14},
             montage="standard_1020",
             sensor_type="EEG",

--- a/moabb/datasets/aguilera_rodriguez2025.py
+++ b/moabb/datasets/aguilera_rodriguez2025.py
@@ -154,7 +154,6 @@ class AguileraRodriguez2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=24,
             channel_types={"eeg": 24},
             hardware="mBrainTrain Smarting",
             reference="FCz",

--- a/moabb/datasets/alex_mi.py
+++ b/moabb/datasets/alex_mi.py
@@ -55,7 +55,6 @@ class AlexMI(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             reference="earlobe",
             software="Matlab/Simulink",

--- a/moabb/datasets/alphawaves.py
+++ b/moabb/datasets/alphawaves.py
@@ -89,7 +89,6 @@ class Rodrigues2017(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="standard_1010",
             hardware="g.tec g.USBamp",

--- a/moabb/datasets/bbci_eeg_fnirs.py
+++ b/moabb/datasets/bbci_eeg_fnirs.py
@@ -337,7 +337,6 @@ class Shin2017A(BaseShin2017):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=30,
             channel_types={"eeg": 30, "eog": 2},
             montage="10-5",
             hardware="BrainAmp",
@@ -665,7 +664,6 @@ class Shin2017B(BaseShin2017):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=30,
             channel_types={"eeg": 30, "eog": 2},
             montage="10-5",
             hardware="BrainAmp",

--- a/moabb/datasets/bcicomp2020_upper_limb.py
+++ b/moabb/datasets/bcicomp2020_upper_limb.py
@@ -195,7 +195,6 @@ class BCIComp2020UpperLimb(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=60,
             channel_types={"eeg": 60},
             montage="standard_1005",
             hardware="BrainAmp (BrainProducts GmbH)",

--- a/moabb/datasets/bcicomp2020_walking_erp.py
+++ b/moabb/datasets/bcicomp2020_walking_erp.py
@@ -209,7 +209,6 @@ class BCIComp2020WalkingERP(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=_SFREQ,
-            n_channels=len(_CH_NAMES),
             channel_types={
                 "eeg": len(_SCALP_CHANNELS) + len(_EAR_CHANNELS),
                 "eog": len(_EOG_CHANNELS),

--- a/moabb/datasets/beetl.py
+++ b/moabb/datasets/beetl.py
@@ -88,7 +88,6 @@ class Beetl2021_A(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=63,
             channel_types={"eeg": 63},
             sensors=[
                 "Fp1",
@@ -583,7 +582,6 @@ class Beetl2021_B(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             sensors=[
                 "Fp1",

--- a/moabb/datasets/bnci/bnci_2003.py
+++ b/moabb/datasets/bnci/bnci_2003.py
@@ -172,7 +172,6 @@ class BNCI2003_004(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=100.0,
-            n_channels=118,
             channel_types={"eeg": 118},
             hardware="BrainAmp",
             reference=None,

--- a/moabb/datasets/bnci/bnci_2014.py
+++ b/moabb/datasets/bnci/bnci_2014.py
@@ -326,7 +326,6 @@ class BNCI2014_001(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=25,
             channel_types={"eeg": 22, "eog": 3},
             montage="custom",
             hardware="BrainAmp MR plus",
@@ -607,7 +606,6 @@ class BNCI2014_002(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=15,
             channel_types={"eeg": 15},
             montage="Laplacian",
             hardware="g.USBamp",
@@ -794,7 +792,6 @@ class BNCI2014_004(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=3,
             channel_types={"eeg": 3, "eog": 3},
             montage="standard_1020",
             hardware="g.tec",
@@ -1034,7 +1031,6 @@ class BNCI2014_008(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="10-10",
             hardware="g.MOBILAB",
@@ -1216,7 +1212,6 @@ class BNCI2014_009(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="10-10",
             hardware="g.USBamp",

--- a/moabb/datasets/bnci/bnci_2015.py
+++ b/moabb/datasets/bnci/bnci_2015.py
@@ -484,7 +484,6 @@ class BNCI2015_001(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=13,
             channel_types={"eeg": 13},
             montage="10-20",
             hardware="g.tec",
@@ -643,7 +642,6 @@ class BNCI2015_003(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="standard_1005",
             hardware="BrainAmp",
@@ -873,7 +871,6 @@ class BNCI2015_004(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=30,
             channel_types={"eeg": 30},
             montage="10-20",
             hardware="g.tec",
@@ -1100,7 +1097,6 @@ class BNCI2015_006(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="10-10",
             hardware="Brain Products",
@@ -1469,7 +1465,6 @@ class BNCI2015_007(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=100.0,
-            n_channels=63,
             channel_types={"eeg": 63},
             montage="10-10",
             hardware="BrainAmp EEG amplifier",
@@ -1770,7 +1765,6 @@ class BNCI2015_008(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=63,
             channel_types={"eeg": 63},
             montage="10-10",
             hardware="Brain Products actiCAP",
@@ -2061,7 +2055,6 @@ class BNCI2015_009(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=60,
             channel_types={"eeg": 60, "eog": 2},
             montage="10-20",
             hardware="Brain Products 128-channel amplifier",
@@ -2251,7 +2244,6 @@ class BNCI2015_010(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=63,
             channel_types={"eeg": 63},
             montage="10-20",
             hardware="BrainAmp amplifiers",
@@ -2500,7 +2492,6 @@ class BNCI2015_012(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=63,
             channel_types={"eeg": 63},
             montage="10-20",
             hardware="Brain Products",
@@ -2786,7 +2777,6 @@ class BNCI2015_013(MNEBNCI):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="standard_1020",
             hardware="Biosemi ActiveTwo",

--- a/moabb/datasets/bnci/bnci_2016_002.py
+++ b/moabb/datasets/bnci/bnci_2016_002.py
@@ -317,7 +317,6 @@ class BNCI2016_002(BNCIBaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=59,
             channel_types={"eeg": 59, "emg": 1, "eog": 2, "misc": 7},
             montage="extended 10-20",
             hardware="BrainAmp",

--- a/moabb/datasets/bnci/bnci_2019.py
+++ b/moabb/datasets/bnci/bnci_2019.py
@@ -88,7 +88,6 @@ class BNCI2019_001(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=61,
             channel_types={"eeg": 61, "eog": 3},
             montage="10-5",
             hardware="g.tec",

--- a/moabb/datasets/bnci/bnci_2020.py
+++ b/moabb/datasets/bnci/bnci_2020.py
@@ -255,7 +255,6 @@ class BNCI2020_001(BNCIBaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=58,
             channel_types={"eeg": 58, "eog": 6},
             montage="5% grid system",
             hardware="g.tec USBamp/g.tec Ladybird",
@@ -826,7 +825,6 @@ class BNCI2020_002(BNCIBaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=30,
             channel_types={"eeg": 30, "eog": 2},
             montage="extended 10-20",
             hardware="BrainAmp DC Amplifier",

--- a/moabb/datasets/bnci/bnci_2022_001.py
+++ b/moabb/datasets/bnci/bnci_2022_001.py
@@ -436,7 +436,6 @@ class BNCI2022_001(BNCIBaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=64,
             channel_types={"eeg": 64, "eog": 3},
             montage="10-10",
             hardware="Biosemi ActiveTwo",

--- a/moabb/datasets/bnci/bnci_2024_001.py
+++ b/moabb/datasets/bnci/bnci_2024_001.py
@@ -298,7 +298,6 @@ class BNCI2024_001(BNCIBaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=60,
             channel_types={"eeg": 60, "eog": 4},
             montage="eogl1 eogl2 eogl3 eogr1 af7 af3 afz af4 af8 f7 f5 f3 f1 fz f2 f4 f6 f8 ft7 fc5 fc3 fc1 fcz fc2 fc4 fc6 ft8 t7 c5 c3 c1 cz c2 c4 c6 t8 tp7 cp5 cp3 cp1 cpz cp2 cp4 cp6 tp8 p7 p5 p3 p1 pz p2 p4 p6 p8 ppo1h ppo2h po7 po3 poz po4 po8 o1 oz o2",
             hardware="BrainVision",

--- a/moabb/datasets/bnci/bnci_2025.py
+++ b/moabb/datasets/bnci/bnci_2025.py
@@ -266,7 +266,6 @@ class BNCI2025_001(BNCIBaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=67,
             channel_types={"eeg": 67, "eog": 4},
             montage="af7 af3 afz af4 af8 f7 f5 f3 f1 fz f2 f4 f6 f8 ft7 fc5 fc3 fc1 fcz fc2 fc4 fc6 ft8 t7 c5 c3 c1 cz c2 c4 c6 t8 tp7 cp5 cp3 cp1 cpz cp2 cp4 cp6 tp8 p7 p5 p3 p1 pz p2 p4 p6 p8 ppo1h ppo2h po7 po3 poz po4 po8 o1 oz o2",
             sensor_type="EEG",
@@ -1045,7 +1044,6 @@ class BNCI2025_002(BNCIBaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=60,
             channel_types={"eeg": 60, "eog": 4},
             montage="af7 af3 afz af4 af8 f7 f5 f3 f1 fz f2 f4 f6 f8 ft7 fc5 fc3 fc1 fcz fc2 fc4 fc6 ft8 t7 c5 c3 c1 cz c2 c4 c6 t8 tp7 cp5 cp3 cp1 cpz cp2 cp4 cp6 tp8 p7 p5 p3 p1 pz p2 p4 p6 p8 ppo1h ppo2h po7 po3 poz po4 po8 o1 oz o2",
             sensor_type="EEG",

--- a/moabb/datasets/braininvaders.py
+++ b/moabb/datasets/braininvaders.py
@@ -463,7 +463,6 @@ class BI2012(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=128.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="standard_1020",
             hardware="NeXus-32 (MindMedia/TMSi)",
@@ -705,7 +704,6 @@ class BI2013a(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="standard_1020",
             hardware="g.USBamp (g.tec, Schiedlberg, Austria)",
@@ -939,7 +937,6 @@ class BI2014a(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="standard_1010",
             hardware="g.USBamp (g.tec, Schiedlberg, Austria)",
@@ -1141,7 +1138,6 @@ class BI2014b(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="standard_1010",
             hardware="g.USBamp (g.tec, Schiedlberg, Austria)",
@@ -1354,7 +1350,6 @@ class BI2015a(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="10-10",
             hardware="g.USBamp (g.tec, Schiedlberg, Austria)",
@@ -1555,7 +1550,6 @@ class BI2015b(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="10-10",
             hardware="g.USBamp (g.tec, Schiedlberg, Austria)",
@@ -1767,7 +1761,6 @@ class Cattan2019_VR(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="10-10",
             hardware="g.USBamp (g.tec, Schiedlberg, Austria)",

--- a/moabb/datasets/brandl2020.py
+++ b/moabb/datasets/brandl2020.py
@@ -198,7 +198,6 @@ class Brandl2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=63,
             channel_types={"eeg": 63},
             hardware="2x BrainAmp (Brain Products)",
             reference="nose",

--- a/moabb/datasets/castillos2023.py
+++ b/moabb/datasets/castillos2023.py
@@ -374,7 +374,6 @@ class CastillosBurstVEP100(BaseCastillos2023):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             sensors=[
                 "C3",
@@ -669,7 +668,6 @@ class CastillosBurstVEP40(BaseCastillos2023):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             sensors=[
                 "C3",
@@ -937,7 +935,6 @@ class CastillosCVEP100(BaseCastillos2023):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             sensors=[
                 "C3",
@@ -1196,7 +1193,6 @@ class CastillosCVEP40(BaseCastillos2023):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             sensors=[
                 "C3",

--- a/moabb/datasets/chailloux2020.py
+++ b/moabb/datasets/chailloux2020.py
@@ -85,7 +85,6 @@ class Chailloux2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="standard_1020",
             hardware="g.USBamp (g.tec)",

--- a/moabb/datasets/chang2025.py
+++ b/moabb/datasets/chang2025.py
@@ -104,7 +104,6 @@ class Chang2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=59,
             channel_types={"eeg": 59},
             montage="standard_1005",
             hardware="Neuracle BRK-NSW 2.0",

--- a/moabb/datasets/dreyer2023.py
+++ b/moabb/datasets/dreyer2023.py
@@ -54,7 +54,6 @@ class _Dreyer2023Base(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=27,
             channel_types={"eeg": 27, "emg": 2, "eog": 3},
             montage="10-20",
             hardware="g.USBAmp (g.tec, Austria)",

--- a/moabb/datasets/epfl.py
+++ b/moabb/datasets/epfl.py
@@ -82,7 +82,6 @@ class EPFLP300(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=2048.0,
-            n_channels=32,
             channel_types={"eeg": 32, "misc": 2},
             montage="standard_1020",
             hardware="Biosemi ActiveTwo",

--- a/moabb/datasets/forenzo2023.py
+++ b/moabb/datasets/forenzo2023.py
@@ -111,7 +111,6 @@ class Forenzo2023(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="standard_1005",
             hardware="Neuroscan Quik-Cap 64-ch, SynAmps 2/RT",

--- a/moabb/datasets/forenzo2024.py
+++ b/moabb/datasets/forenzo2024.py
@@ -117,7 +117,6 @@ class Forenzo2024(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62},
             montage="standard_1005",
             hardware="Neuroscan Quik-Cap 64-ch, SynAmps/RT",

--- a/moabb/datasets/gao2026.py
+++ b/moabb/datasets/gao2026.py
@@ -157,7 +157,6 @@ class Gao2026(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="standard_1005",
             hardware="Neuracle NeuSenW32",

--- a/moabb/datasets/gigadb.py
+++ b/moabb/datasets/gigadb.py
@@ -75,7 +75,6 @@ class Cho2017(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=68,
             channel_types={"eeg": 64, "emg": 4},
             montage="standard_1005",
             hardware="Biosemi ActiveTwo",

--- a/moabb/datasets/guttmann_flury2025.py
+++ b/moabb/datasets/guttmann_flury2025.py
@@ -168,7 +168,6 @@ _PARTICIPANTS = ParticipantMetadata(
 # Shared acquisition metadata.
 _ACQUISITION = AcquisitionMetadata(
     sampling_rate=1000.0,
-    n_channels=66,
     channel_types={"eeg": 64, "eog": 1, "stim": 1},
     montage="standard_1005",
     hardware="Neuroscan Quik-Cap 65-ch, SynAmps2",

--- a/moabb/datasets/guttmann_flury2025.py
+++ b/moabb/datasets/guttmann_flury2025.py
@@ -168,7 +168,7 @@ _PARTICIPANTS = ParticipantMetadata(
 # Shared acquisition metadata.
 _ACQUISITION = AcquisitionMetadata(
     sampling_rate=1000.0,
-    channel_types={"eeg": 64, "eog": 1, "stim": 1},
+    channel_types={"eeg": 64, "eog": 1},
     montage="standard_1005",
     hardware="Neuroscan Quik-Cap 65-ch, SynAmps2",
     sensor_type="Ag/AgCl",

--- a/moabb/datasets/hefmi_ich2025.py
+++ b/moabb/datasets/hefmi_ich2025.py
@@ -96,7 +96,6 @@ class HefmiIch2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="biosemi32",
             hardware="g.HIamp (g.tec medical engineering GmbH)",

--- a/moabb/datasets/hinss2021.py
+++ b/moabb/datasets/hinss2021.py
@@ -72,7 +72,6 @@ class Hinss2021(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=62,
             channel_types={"eeg": 62},
             montage="standard_1020",
             hardware="ActiCHamp (Brain Products Gmbh)",

--- a/moabb/datasets/huebner_llp.py
+++ b/moabb/datasets/huebner_llp.py
@@ -187,7 +187,6 @@ class Huebner2017(_BaseVisualMatrixSpellerDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=31,
             channel_types={"eeg": 31, "misc": 6},
             montage="standard_1020",
             hardware="BrainAmp DC",
@@ -439,7 +438,6 @@ class Huebner2018(_BaseVisualMatrixSpellerDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=31,
             channel_types={"eeg": 31, "misc": 6},
             montage="extended 10-20",
             hardware="BrainAmp DC",

--- a/moabb/datasets/jeong2020.py
+++ b/moabb/datasets/jeong2020.py
@@ -162,7 +162,6 @@ class Jeong2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=71,
             channel_types={"eeg": 60, "eog": 4, "emg": 7},
             montage="standard_1005",
             hardware="BrainAmp (BrainProducts GmbH)",

--- a/moabb/datasets/kaneshiro2015.py
+++ b/moabb/datasets/kaneshiro2015.py
@@ -79,7 +79,6 @@ class Kaneshiro2015(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=62.5,
-            n_channels=124,
             channel_types={"eeg": 124},
             montage="GSN-HydroCel-128",
             hardware="EGI Net Amps 300",

--- a/moabb/datasets/kaya2018.py
+++ b/moabb/datasets/kaya2018.py
@@ -148,7 +148,6 @@ class Kaya2018(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=200.0,
-            n_channels=19,
             channel_types={"eeg": 19},
             sensors=_EEG_CH_NAMES,
             montage="standard_1020",

--- a/moabb/datasets/kojima2024a.py
+++ b/moabb/datasets/kojima2024a.py
@@ -98,7 +98,6 @@ class Kojima2024A(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=64,
             channel_types={"eeg": 64, "eog": 2},
             sensors=[
                 "AF3",

--- a/moabb/datasets/kojima2024b.py
+++ b/moabb/datasets/kojima2024b.py
@@ -160,7 +160,6 @@ class Kojima2024B(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=64,
             channel_types={"eeg": 64, "eog": 2},
             sensors=[
                 "AF3",

--- a/moabb/datasets/kumar2024.py
+++ b/moabb/datasets/kumar2024.py
@@ -122,7 +122,6 @@ class Kumar2024(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=22,
             channel_types={"eeg": 22, "eog": 3},
             montage="standard_1020",
             hardware="ANT Neuro eego mylab",

--- a/moabb/datasets/lee2021_mobile.py
+++ b/moabb/datasets/lee2021_mobile.py
@@ -72,7 +72,6 @@ class Lee2021Mobile(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=100.0,
-            n_channels=73,
             channel_types={"eeg": 73},
             montage="standard_1005",
             hardware="BrainAmp (Brain Product GmbH)",
@@ -394,7 +393,6 @@ class Lee2021Mobile_ERP(Lee2021Mobile):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=100.0,
-            n_channels=73,
             channel_types={"eeg": 73},
             montage="standard_1005",
             hardware="BrainAmp (Brain Product GmbH)",

--- a/moabb/datasets/lee2024.py
+++ b/moabb/datasets/lee2024.py
@@ -146,7 +146,6 @@ def _make_metadata(experiment):
     return DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=config["n_eeg"],
             channel_types={"eeg": config["n_eeg"]},
             montage="standard_1020",
             hardware="actiCHamp (Brain Products)",

--- a/moabb/datasets/lenaig2026.py
+++ b/moabb/datasets/lenaig2026.py
@@ -152,7 +152,6 @@ class Lenaig2026(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500,
-            n_channels=28,
             channel_types={"eeg": 24, "misc": 3},
             sensor_type="EEG",
             electrode_material="Ag/AgCl",

--- a/moabb/datasets/liu2024.py
+++ b/moabb/datasets/liu2024.py
@@ -94,7 +94,6 @@ class Liu2024(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=29,
             channel_types={"eeg": 29, "eog": 2},
             montage="10-10",
             hardware="ZhenTec NT1 wireless multichannel EEG acquisition system",

--- a/moabb/datasets/liu2025.py
+++ b/moabb/datasets/liu2025.py
@@ -104,7 +104,6 @@ class Liu2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=64,
             channel_types={"eeg": 60, "ecg": 1, "eog": 4},
             montage="standard_1020",
             hardware="NeuSen W (Neuracle, Inc.)",

--- a/moabb/datasets/ma2020.py
+++ b/moabb/datasets/ma2020.py
@@ -167,7 +167,6 @@ class Ma2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62},
             montage="standard_1005",
             hardware="Neuroscan SynAmps2",

--- a/moabb/datasets/mainsah2025.py
+++ b/moabb/datasets/mainsah2025.py
@@ -468,7 +468,6 @@ def _make_study_metadata(study):
     return DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=config["n_eeg"],
             channel_types={"eeg": config["n_eeg"]},
             hardware="g.USBamp (g.tec)",
             montage="standard_1020",

--- a/moabb/datasets/martinezcagigal2023_checker_cvep.py
+++ b/moabb/datasets/martinezcagigal2023_checker_cvep.py
@@ -143,9 +143,7 @@ class MartinezCagigal2023Checker(BaseDataset):
     """
 
     METADATA = DatasetMetadata(
-        acquisition=AcquisitionMetadata(
-            sampling_rate=256.0, n_channels=16, channel_types={"eeg": 16}
-        ),
+        acquisition=AcquisitionMetadata(sampling_rate=256.0, channel_types={"eeg": 16}),
         participants=ParticipantMetadata(n_subjects=16),
         experiment=ExperimentMetadata(paradigm="cvep"),
         documentation=DocumentationMetadata(

--- a/moabb/datasets/martinezcagigal2023_pary_cvep.py
+++ b/moabb/datasets/martinezcagigal2023_pary_cvep.py
@@ -170,9 +170,7 @@ class MartinezCagigal2023Pary(BaseDataset):
     """
 
     METADATA = DatasetMetadata(
-        acquisition=AcquisitionMetadata(
-            sampling_rate=256.0, n_channels=16, channel_types={"eeg": 16}
-        ),
+        acquisition=AcquisitionMetadata(sampling_rate=256.0, channel_types={"eeg": 16}),
         participants=ParticipantMetadata(n_subjects=16),
         experiment=ExperimentMetadata(paradigm="cvep"),
         documentation=DocumentationMetadata(

--- a/moabb/datasets/metadata/__init__.py
+++ b/moabb/datasets/metadata/__init__.py
@@ -57,7 +57,7 @@ Example
 ... )
 >>> metadata = DatasetMetadata(
 ...     acquisition=AcquisitionMetadata(
-...         sampling_rate=512.0, n_channels=64, channel_types={"eeg": 60, "eog": 4}
+...         sampling_rate=512.0, channel_types={"eeg": 60, "eog": 4}
 ...     ),
 ...     participants=ParticipantMetadata(n_subjects=20),
 ...     experiment=ExperimentMetadata(paradigm="imagery"),
@@ -166,9 +166,7 @@ def _apply_manual_overrides(name: str, metadata: DatasetMetadata) -> DatasetMeta
 
     if "acquisition" in overrides:
         if acquisition is None:
-            acquisition = AcquisitionMetadata(
-                sampling_rate=1.0, n_channels=1, channel_types={"eeg": 1}
-            )
+            acquisition = AcquisitionMetadata(sampling_rate=1.0, channel_types={"eeg": 1})
         acquisition = replace(acquisition, **overrides["acquisition"])
 
     if "experiment" in overrides:
@@ -214,9 +212,7 @@ def _build_minimal_metadata(dataset) -> DatasetMetadata:
     )
     experiment = ExperimentMetadata(paradigm=getattr(dataset, "paradigm", "imagery"))
     acquisition = AcquisitionMetadata(
-        sampling_rate=float(sampling_rate),
-        n_channels=int(n_channels),
-        channel_types=channel_types,
+        sampling_rate=float(sampling_rate), channel_types=channel_types
     )
 
     return DatasetMetadata(
@@ -239,9 +235,7 @@ def _build_fallback_metadata(dataset_name: str) -> DatasetMetadata:
         stacklevel=2,
     )
     return DatasetMetadata(
-        acquisition=AcquisitionMetadata(
-            sampling_rate=1.0, n_channels=1, channel_types={"eeg": 1}
-        ),
+        acquisition=AcquisitionMetadata(sampling_rate=1.0, channel_types={"eeg": 1}),
         participants=ParticipantMetadata(n_subjects=1),
         experiment=ExperimentMetadata(paradigm="imagery"),
     )
@@ -290,11 +284,6 @@ def _merge_with_dataset(metadata: DatasetMetadata, dataset) -> DatasetMetadata:
                 acquisition.n_channels or getattr(dataset, "n_channels", None) or 1
             )
             acquisition = replace(acquisition, channel_types={"eeg": int(n_channels)})
-        if not acquisition.n_channels:
-            n_channels = getattr(
-                dataset, "n_channels", None
-            ) or acquisition.channel_types.get("eeg", 1)
-            acquisition = replace(acquisition, n_channels=int(n_channels))
         if not acquisition.sampling_rate or acquisition.sampling_rate <= 0:
             sampling_rate = (
                 getattr(dataset, "sampling_rate", None)
@@ -396,7 +385,6 @@ def _apply_dataset_family_defaults(
         acquisition = replace(
             acquisition,
             sampling_rate=1024.0,
-            n_channels=30,
             channel_types={"eeg": 30, "eog": 3},
             hardware="Biosemi ActiveTwo",
         )
@@ -433,9 +421,7 @@ def _apply_dataset_family_defaults(
     # MartinezCagigal cVEP defaults (documentation is set per-dataset in each class)
     if name.startswith("MartinezCagigal2023"):
         acquisition = metadata.acquisition or AcquisitionMetadata()
-        acquisition = replace(
-            acquisition, sampling_rate=256.0, n_channels=16, channel_types={"eeg": 16}
-        )
+        acquisition = replace(acquisition, sampling_rate=256.0, channel_types={"eeg": 16})
         participants = metadata.participants or ParticipantMetadata(n_subjects=16)
         participants = replace(participants, n_subjects=16)
         experiment = metadata.experiment or ExperimentMetadata(paradigm="cvep")
@@ -510,7 +496,6 @@ def _build_dataset_metadata_catalog():
                     metadata = DatasetMetadata(
                         acquisition=AcquisitionMetadata(
                             sampling_rate=1024.0,
-                            n_channels=30,
                             channel_types={"eeg": 30, "eog": 3},
                             hardware="Biosemi ActiveTwo",
                         ),

--- a/moabb/datasets/metadata/schema.py
+++ b/moabb/datasets/metadata/schema.py
@@ -320,10 +320,9 @@ class AcquisitionMetadata:
     ----------
     sampling_rate : float
         Sampling frequency in Hz.
-    n_channels : int
-        Total number of recorded channels.
     channel_types : Dict[str, int]
-        Channel type counts, e.g., {"eeg": 60, "eog": 4}.
+        Channel type counts, e.g., {"eeg": 60, "eog": 4}. ``n_channels`` is
+        derived from this, so the two cannot disagree.
     sensors : List[str], optional
         List of sensor/channel names. Default is empty list.
     sensor_type : str, optional
@@ -359,7 +358,6 @@ class AcquisitionMetadata:
     """
 
     sampling_rate: float
-    n_channels: int
     channel_types: Dict[str, int]
     sensors: List[str] = field(default_factory=list)
     sensor_type: Optional[str] = None
@@ -377,6 +375,16 @@ class AcquisitionMetadata:
     cap_model: Optional[str] = None
     electrode_type: Optional[str] = None
     electrode_material: Optional[str] = None
+
+    @property
+    def n_channels(self) -> int:
+        """Total number of recorded channels.
+
+        Derived from ``channel_types`` rather than stored: when it was a field
+        of its own, 34 of the catalogue's datasets declared a count that
+        disagreed with their own channel breakdown.
+        """
+        return sum(self.channel_types.values())
 
 
 @dataclass
@@ -674,7 +682,7 @@ class DatasetMetadata:
     ... )
     >>> metadata = DatasetMetadata(
     ...     acquisition=AcquisitionMetadata(
-    ...         sampling_rate=512.0, n_channels=64, channel_types={"eeg": 60, "eog": 4}
+    ...         sampling_rate=512.0, channel_types={"eeg": 60, "eog": 4}
     ...     ),
     ...     participants=ParticipantMetadata(n_subjects=20),
     ...     experiment=ExperimentMetadata(

--- a/moabb/datasets/mpi_mi.py
+++ b/moabb/datasets/mpi_mi.py
@@ -71,7 +71,6 @@ class GrosseWentrup2009(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=128,
             channel_types={"eeg": 128},
             montage="standard_1020",
             hardware="BrainAmp",

--- a/moabb/datasets/nguyen2017.py
+++ b/moabb/datasets/nguyen2017.py
@@ -162,7 +162,6 @@ def _nguyen_hed(label, unit="Word"):
 # Shared metadata sections identical across all 4 Nguyen conditions.
 _NGUYEN_ACQUISITION = AcquisitionMetadata(
     sampling_rate=256.0,
-    n_channels=64,
     channel_types={"eeg": 60, "eog": 4},
     montage="standard_1020",
     hardware="BrainProducts ActiCHamp",

--- a/moabb/datasets/nieto2022.py
+++ b/moabb/datasets/nieto2022.py
@@ -64,7 +64,6 @@ class Nieto2022(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=_SFREQ,
-            n_channels=136,
             channel_types={"eeg": 128, "emg": 8},
             montage="biosemi128",
             hardware="BioSemi ActiveTwo high resolution biopotential measuring system",

--- a/moabb/datasets/phmd_ml.py
+++ b/moabb/datasets/phmd_ml.py
@@ -66,7 +66,6 @@ class Cattan2019_PHMD(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="standard_1020",
             hardware="g.USBamp",

--- a/moabb/datasets/physionet_mi.py
+++ b/moabb/datasets/physionet_mi.py
@@ -93,7 +93,6 @@ class PhysionetMI(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=160.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             hardware="Brain Products",
             reference="mastoid",

--- a/moabb/datasets/pressel2016.py
+++ b/moabb/datasets/pressel2016.py
@@ -122,7 +122,6 @@ class Pressel2016(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1024.0,
-            n_channels=6,
             channel_types={"eeg": 6},
             montage="standard_1020",
             hardware="Grass 8-18-36 amplifier + DataTranslation DT9816 ADC",

--- a/moabb/datasets/romani_bf2025_erp.py
+++ b/moabb/datasets/romani_bf2025_erp.py
@@ -131,7 +131,6 @@ class RomaniBF2025ERP(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="standard_1020",
             hardware="g.tec Unicorn Hybrid Black",

--- a/moabb/datasets/rozado2015.py
+++ b/moabb/datasets/rozado2015.py
@@ -92,7 +92,6 @@ class Rozado2015(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="biosemi32",
             hardware="BioSemi ActiveTwo",

--- a/moabb/datasets/schirrmeister2017.py
+++ b/moabb/datasets/schirrmeister2017.py
@@ -71,7 +71,6 @@ class Schirrmeister2017(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=128,
             channel_types={"eeg": 128},
             hardware=None,
             reference=None,

--- a/moabb/datasets/schrag2026.py
+++ b/moabb/datasets/schrag2026.py
@@ -144,7 +144,6 @@ class Schrag2026Pediatric(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=_SFREQ,
-            n_channels=16,
             channel_types={"eeg": 16},
             montage="standard_1020",
             hardware="g.tec g.GAMMAsys + g.USBamp + g.GAMMAcap",

--- a/moabb/datasets/simoes2020.py
+++ b/moabb/datasets/simoes2020.py
@@ -82,7 +82,6 @@ class Simoes2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="standard_1020",
             hardware="g.Nautilus (g.tec, wireless)",

--- a/moabb/datasets/sosulski2019.py
+++ b/moabb/datasets/sosulski2019.py
@@ -93,7 +93,6 @@ class Sosulski2019(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=31,
             channel_types={"eeg": 31, "eog": 1, "misc": 5},
             montage="standard_1020",
             hardware="BrainProducts BrainAmp DC",

--- a/moabb/datasets/speier2017.py
+++ b/moabb/datasets/speier2017.py
@@ -261,7 +261,6 @@ class Speier2017(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="standard_1005",
             hardware="g.tec amplifier",

--- a/moabb/datasets/ssvep_chen2017.py
+++ b/moabb/datasets/ssvep_chen2017.py
@@ -82,7 +82,6 @@ class Chen2017SingleFlicker(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="biosemi32",
             hardware="BioSemi ActiveTwo",

--- a/moabb/datasets/ssvep_dong2023.py
+++ b/moabb/datasets/ssvep_dong2023.py
@@ -76,7 +76,6 @@ class Dong2023(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="standard_1005",
             hardware="NeuSenW (Neuracle)",

--- a/moabb/datasets/ssvep_exo.py
+++ b/moabb/datasets/ssvep_exo.py
@@ -75,7 +75,6 @@ class Kalunga2016(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="standard_1005",
             sensor_type="EEG",

--- a/moabb/datasets/ssvep_han2024.py
+++ b/moabb/datasets/ssvep_han2024.py
@@ -110,7 +110,6 @@ class Han2024Fatigue(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="standard_1005",
             hardware="Synamps2 (Neuroscan)",

--- a/moabb/datasets/ssvep_kim2025.py
+++ b/moabb/datasets/ssvep_kim2025.py
@@ -116,7 +116,6 @@ class Kim2025BetaRange(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1024.0,
-            n_channels=31,
             channel_types={"eeg": 31, "misc": 2},
             montage="standard_1005",
             hardware="BioSemi ActiveTwo",

--- a/moabb/datasets/ssvep_liu2020.py
+++ b/moabb/datasets/ssvep_liu2020.py
@@ -90,7 +90,6 @@ class Liu2020BETA(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="standard_1005",
             hardware="Synamps2 (Neuroscan)",

--- a/moabb/datasets/ssvep_liu2022.py
+++ b/moabb/datasets/ssvep_liu2022.py
@@ -158,7 +158,6 @@ class Liu2022EldBETA(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="standard_1005",
             hardware="Synamps2 (Neuroscan)",

--- a/moabb/datasets/ssvep_mamem.py
+++ b/moabb/datasets/ssvep_mamem.py
@@ -334,7 +334,6 @@ class MAMEM1(BaseMAMEM):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=256,
             channel_types={"eeg": 256},
             montage="GSN-HydroCel-256",
             hardware="EGI 300 Geodesic EEG System (GES 300)",
@@ -837,7 +836,6 @@ class MAMEM2(BaseMAMEM):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=256,
             channel_types={"eeg": 256},
             montage="GSN-HydroCel-256",
             hardware="EGI 300 Geodesic EEG System (GES 300)",
@@ -1341,7 +1339,6 @@ class MAMEM3(BaseMAMEM):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=128.0,
-            n_channels=14,
             channel_types={"eeg": 14},
             montage="10-20",
             hardware="EGI 300 Geodesic EEG System (GES 300)",

--- a/moabb/datasets/ssvep_nakanishi.py
+++ b/moabb/datasets/ssvep_nakanishi.py
@@ -54,7 +54,6 @@ class Nakanishi2015(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             hardware="Biosemi ActiveTwo",
             reference="CMS/DRL",

--- a/moabb/datasets/ssvep_wang.py
+++ b/moabb/datasets/ssvep_wang.py
@@ -113,7 +113,6 @@ class Wang2016(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="standard_1005",
             hardware="Synamps2 EEG system (Neuroscan, Inc.)",

--- a/moabb/datasets/ssvep_wang2021.py
+++ b/moabb/datasets/ssvep_wang2021.py
@@ -69,7 +69,6 @@ class Wang2021Combined(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=31,
             channel_types={"eeg": 31, "eog": 2},
             montage="standard_1005",
             hardware="eego mylab (ANT Neuro)",

--- a/moabb/datasets/stieger2021.py
+++ b/moabb/datasets/stieger2021.py
@@ -139,7 +139,6 @@ class Stieger2021(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62},
             montage="10-10",
             hardware="Neuroscan SynAmps RT amplifiers",

--- a/moabb/datasets/tavakolan2017.py
+++ b/moabb/datasets/tavakolan2017.py
@@ -111,7 +111,6 @@ class Tavakolan2017(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             montage="GSN-HydroCel-32",
             hardware="EGI Geodesic Net Amps 400 series",

--- a/moabb/datasets/thielen2015.py
+++ b/moabb/datasets/thielen2015.py
@@ -94,7 +94,6 @@ class Thielen2015(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=2048.0,
-            n_channels=64,
             channel_types={"eeg": 64},
             montage="standard_1020",
             hardware="Biosemi ActiveTwo",

--- a/moabb/datasets/thielen2021.py
+++ b/moabb/datasets/thielen2021.py
@@ -138,7 +138,6 @@ class Thielen2021(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=8,
             channel_types={"eeg": 8},
             montage="custom",
             hardware="Biosemi ActiveTwo",

--- a/moabb/datasets/triana_guzman2024.py
+++ b/moabb/datasets/triana_guzman2024.py
@@ -122,7 +122,6 @@ class TrianaGuzman2024(BaseBIDSDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=250.0,
-            n_channels=17,
             channel_types={"eeg": 17},
             montage="standard_1020",
             hardware="g.tec g.Nautilus PRO",

--- a/moabb/datasets/upper_limb.py
+++ b/moabb/datasets/upper_limb.py
@@ -76,7 +76,6 @@ class Ofner2017(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=512.0,
-            n_channels=61,
             channel_types={"eeg": 61, "eog": 3, "misc": 32},
             hardware="g.tec medical engineering GmbH",
             sensor_type="active",

--- a/moabb/datasets/wairagkar2018.py
+++ b/moabb/datasets/wairagkar2018.py
@@ -111,7 +111,6 @@ class Wairagkar2018(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1024.0,
-            n_channels=19,
             channel_types={"eeg": 19},
             montage="standard_1020",
             hardware="Deymed TruScan 32",

--- a/moabb/datasets/wang2026.py
+++ b/moabb/datasets/wang2026.py
@@ -124,7 +124,6 @@ _CHANNELS = [
 
 _ACQUISITION = AcquisitionMetadata(
     sampling_rate=_SFREQ,
-    n_channels=62,
     channel_types={"eeg": 62},
     sensors=list(_CHANNELS),
     reference="midway between Cz and CPz",

--- a/moabb/datasets/wu2020.py
+++ b/moabb/datasets/wu2020.py
@@ -78,7 +78,6 @@ class Wu2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=122,
             channel_types={"eeg": 122, "misc": 10},
             montage="standard_1005",
             hardware="Neuroscan SynAmps2",

--- a/moabb/datasets/yang2025.py
+++ b/moabb/datasets/yang2025.py
@@ -103,7 +103,6 @@ class Yang2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=59,
             channel_types={"eeg": 59, "ecg": 1, "eog": 4},
             montage="standard_1005",
             hardware="Neuracle NeuSen W",

--- a/moabb/datasets/yi2025.py
+++ b/moabb/datasets/yi2025.py
@@ -133,7 +133,6 @@ class Yi2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62},
             hardware="Neuroscan SynAmps2",
             reference="left mastoid (M1)",

--- a/moabb/datasets/zhang2017.py
+++ b/moabb/datasets/zhang2017.py
@@ -250,7 +250,6 @@ class Zhang2017(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=17,
             channel_types={"eeg": 17},
             montage="GSN-HydroCel-32",
             hardware="EGI Geodesic Net Amps 400 series (N400)",

--- a/moabb/datasets/zhang2025.py
+++ b/moabb/datasets/zhang2025.py
@@ -102,7 +102,6 @@ class Zhang2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=57,
             channel_types={"eeg": 57},
             montage="standard_1020",
             hardware="Neuracle Neusen",

--- a/moabb/datasets/zheng2020.py
+++ b/moabb/datasets/zheng2020.py
@@ -101,7 +101,6 @@ class Zheng2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=62,
             channel_types={"eeg": 62},
             montage="standard_1020",
             hardware="Neuroscan Synamps2",

--- a/moabb/datasets/zhou2020.py
+++ b/moabb/datasets/zhou2020.py
@@ -122,7 +122,6 @@ class Zhou2020(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=41,
             channel_types={"eeg": 41},
             montage="standard_1005",
             hardware="Neuroscan SynAmps2",

--- a/moabb/datasets/zuo2025.py
+++ b/moabb/datasets/zuo2025.py
@@ -284,7 +284,6 @@ class Zuo2025(BaseDataset):
     METADATA = DatasetMetadata(
         acquisition=AcquisitionMetadata(
             sampling_rate=500.0,
-            n_channels=30,
             channel_types={"eeg": 30},
             hardware="ZhenTec EEG system",
             reference="CPz",

--- a/moabb/tests/test_bids_enrichment.py
+++ b/moabb/tests/test_bids_enrichment.py
@@ -93,7 +93,7 @@ class TestEnrichRawInfoFromMetadata:
         raw = self._make_raw()
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}, line_freq=60.0
+                sampling_rate=256, channel_types={"eeg": 2}, line_freq=60.0
             ),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -106,9 +106,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_sex_all_male(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=5, gender={"male": 5}),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -118,9 +116,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_sex_all_female(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=5, gender={"female": 5}),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -130,9 +126,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_sex_mixed_not_set(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=10, gender={"male": 5, "female": 5}
             ),
@@ -145,9 +139,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_hand_all_right_dict(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=5, handedness={"right": 5}),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -157,9 +149,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_hand_string_right(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=5, handedness="right-handed"),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -169,9 +159,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_no_participants(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -181,9 +169,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_per_subject_sex(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=3, sexes=["male", "female", "male"]
             ),
@@ -196,9 +182,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_per_subject_handedness(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=3, handedness_list=["right", "left", "ambidextrous"]
             ),
@@ -216,9 +200,7 @@ class TestEnrichRawInfoFromMetadata:
     def test_per_subject_sex_overrides_aggregate(self):
         raw = self._make_raw()
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=3,
                 gender={"male": 3},  # aggregate says all male
@@ -244,7 +226,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 reference="left mastoid",
                 ground="AFz",
@@ -269,9 +250,7 @@ class TestBuildSidecarEnrichment:
 
     def test_filter_details_bandpass_dict(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             preprocessing=PreprocessingMetadata(
@@ -288,9 +267,7 @@ class TestBuildSidecarEnrichment:
 
     def test_filter_details_bandpass_list(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             preprocessing=PreprocessingMetadata(bandpass=[0.5, 100.0]),
@@ -302,9 +279,7 @@ class TestBuildSidecarEnrichment:
 
     def test_filter_details_individual_hp_lp(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             preprocessing=PreprocessingMetadata(highpass_hz=0.1, lowpass_hz=40.0),
@@ -316,9 +291,7 @@ class TestBuildSidecarEnrichment:
 
     def test_task_description(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(
                 paradigm="imagery", study_design="Four-class motor imagery"
@@ -329,9 +302,7 @@ class TestBuildSidecarEnrichment:
 
     def test_institution(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(
@@ -344,10 +315,7 @@ class TestBuildSidecarEnrichment:
     def test_montage_fallback(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256,
-                n_channels=22,
-                channel_types={"eeg": 22},
-                montage="custom_montage",
+                sampling_rate=256, channel_types={"eeg": 22}, montage="custom_montage"
             ),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -359,7 +327,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 cap_manufacturer="EasyCap",
                 cap_model="actiCAP snap",
@@ -373,9 +340,7 @@ class TestBuildSidecarEnrichment:
 
     def test_instructions(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(
                 paradigm="imagery", instructions="Imagine moving your left or right hand."
@@ -386,9 +351,7 @@ class TestBuildSidecarEnrichment:
 
     def test_cog_atlas_explicit(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(
                 paradigm="imagery",
@@ -403,9 +366,7 @@ class TestBuildSidecarEnrichment:
     def test_cog_atlas_fallback(self):
         # Motor imagery paradigm has a known fallback
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -417,9 +378,7 @@ class TestBuildSidecarEnrichment:
 
         # P300 paradigm has a known fallback
         metadata_p300 = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="p300"),
         )
@@ -431,9 +390,7 @@ class TestBuildSidecarEnrichment:
 
         # SSVEP has no fallback
         metadata_ssvep = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="ssvep"),
         )
@@ -442,9 +399,7 @@ class TestBuildSidecarEnrichment:
 
     def test_institution_address(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(
@@ -462,7 +417,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 sensor_type="Ag/AgCl",
                 # cap_manufacturer is None → should NOT fall back to sensor_type
@@ -477,7 +431,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 sensor_type="Ag/AgCl",
                 cap_manufacturer="EasyCap",
@@ -494,7 +447,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 filters="0.1-100 Hz bandpass",
             ),
@@ -509,7 +461,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 filters={"bandpass": [0.1, 100]},
             ),
@@ -524,7 +475,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 filters="0.1-100 Hz bandpass",
             ),
@@ -540,9 +490,7 @@ class TestBuildSidecarEnrichment:
     def test_filter_type_and_order_in_bandpass(self):
         """filter_type and filter_order enrich HardwareFilters Bandpass."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             preprocessing=PreprocessingMetadata(
@@ -557,9 +505,7 @@ class TestBuildSidecarEnrichment:
     def test_re_reference_fallback(self):
         """prep.re_reference used as EEGReference when acq.reference absent."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             preprocessing=PreprocessingMetadata(re_reference="average"),
@@ -571,10 +517,7 @@ class TestBuildSidecarEnrichment:
         """acq.reference takes priority over prep.re_reference."""
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256,
-                n_channels=22,
-                channel_types={"eeg": 22},
-                reference="left mastoid",
+                sampling_rate=256, channel_types={"eeg": 22}, reference="left mastoid"
             ),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -586,9 +529,7 @@ class TestBuildSidecarEnrichment:
     def test_preprocessing_steps_software_filters(self):
         """prep.preprocessing_steps builds SoftwareFilters dict."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             preprocessing=PreprocessingMetadata(
@@ -604,10 +545,7 @@ class TestBuildSidecarEnrichment:
         """acq.impedance_threshold_kohm scalar sets SubjectArtefactDescription."""
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256,
-                n_channels=22,
-                channel_types={"eeg": 22},
-                impedance_threshold_kohm=20,
+                sampling_rate=256, channel_types={"eeg": 22}, impedance_threshold_kohm=20
             ),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -620,7 +558,6 @@ class TestBuildSidecarEnrichment:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 impedance_threshold_kohm={"eeg": 20, "emg": 50},
             ),
@@ -636,9 +573,7 @@ class TestBuildSidecarEnrichment:
     def test_task_description_with_timing(self):
         """TaskDescription enriched with trial timing info."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(
                 paradigm="imagery",
@@ -659,9 +594,7 @@ class TestBuildSidecarEnrichment:
     def test_task_description_with_task_type(self):
         """TaskDescription prepended with task_type."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(
                 paradigm="imagery",
@@ -675,9 +608,7 @@ class TestBuildSidecarEnrichment:
     def test_task_description_with_ssvep_timing(self):
         """TaskDescription with SSVEP stimulus frequencies."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(
                 paradigm="ssvep", study_design="SSVEP BCI experiment"
@@ -694,9 +625,7 @@ class TestBuildSidecarEnrichment:
     def test_country_fallback_for_institution_address(self):
         """doc.country used as InstitutionAddress when address is absent."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(institution="TU Graz", country="Austria"),
@@ -707,9 +636,7 @@ class TestBuildSidecarEnrichment:
     def test_country_not_used_when_address_present(self):
         """doc.institution_address takes priority over doc.country."""
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(
@@ -746,9 +673,7 @@ class TestBuildDatasetDescriptionKwargs:
 
     def test_with_documentation(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(
@@ -772,9 +697,7 @@ class TestBuildDatasetDescriptionKwargs:
 
     def test_partial_documentation(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(license="MIT"),
@@ -793,9 +716,7 @@ class TestBuildDatasetDescriptionKwargs:
 
     def test_ethics_and_acknowledgements(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(
@@ -812,9 +733,7 @@ class TestBuildDatasetDescriptionKwargs:
 
     def test_source_datasets_with_url(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(
@@ -832,9 +751,7 @@ class TestBuildDatasetDescriptionKwargs:
 
     def test_publication_year_not_in_source_datasets(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(publication_year=2021),
@@ -846,9 +763,7 @@ class TestBuildDatasetDescriptionKwargs:
 
     def test_no_publication_year_no_url_keeps_default(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=22, channel_types={"eeg": 22}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 22}),
             participants=ParticipantMetadata(n_subjects=9),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(license="MIT"),
@@ -867,9 +782,7 @@ class TestBuildDatasetDescriptionKwargs:
 class TestUpdateParticipantsTsv:
     def test_no_tsv_file(self, tmp_path):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=3, ages=[25, 30, 35], health_status="healthy"
             ),
@@ -887,9 +800,7 @@ class TestUpdateParticipantsTsv:
             writer.writerow({"participant_id": "sub-1"})
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=1, ages=[25], health_status="healthy"
             ),
@@ -914,9 +825,7 @@ class TestUpdateParticipantsTsv:
             writer.writerow({"participant_id": "sub-1"})
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1, age_mean=27.5),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -938,9 +847,7 @@ class TestUpdateParticipantsTsv:
             writer.writerow({"participant_id": "sub-1", "age": "30"})
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=1, ages=[25], health_status="healthy"
             ),
@@ -964,9 +871,7 @@ class TestUpdateParticipantsTsv:
             writer.writerow({"participant_id": "sub-1"})
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=1, ages=[25], health_status="healthy"
             ),
@@ -990,9 +895,7 @@ class TestUpdateParticipantsTsv:
 
     def test_none_participants(self, tmp_path):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -1020,9 +923,7 @@ class TestUpdateParticipantsTsv:
             writer.writerow({"participant_id": "sub-2"})
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(
                 n_subjects=2, sexes=["male", "female"], handedness_list=["right", "left"]
             ),
@@ -1048,9 +949,7 @@ class TestUpdateParticipantsTsv:
             writer.writerow({"participant_id": "sub-1"})
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
         )
@@ -1089,7 +988,6 @@ class TestUpdateElectrodesTsv:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=2,
                 channel_types={"eeg": 2},
                 electrode_type="cup",
                 electrode_material="Ag/AgCl",
@@ -1112,10 +1010,7 @@ class TestUpdateElectrodesTsv:
     def test_no_electrodes_file(self, tmp_path):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256,
-                n_channels=2,
-                channel_types={"eeg": 2},
-                electrode_type="cup",
+                sampling_rate=256, channel_types={"eeg": 2}, electrode_type="cup"
             ),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -1147,7 +1042,6 @@ class TestUpdateElectrodesTsv:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=2,
                 channel_types={"eeg": 2},
                 electrode_type="cup",
                 electrode_material="Ag/AgCl",
@@ -1178,7 +1072,6 @@ class TestUpdateElectrodesTsv:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256,
-                n_channels=2,
                 channel_types={"eeg": 2},
                 sensor_type="Tin",
                 # electrode_material is None → should fall back to sensor_type
@@ -1218,9 +1111,7 @@ class TestBuildDatasetDescriptionKeywords:
 
     def test_adds_keywords(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(keywords=["BCI", "EEG", "imagery"]),
@@ -1230,9 +1121,7 @@ class TestBuildDatasetDescriptionKeywords:
 
     def test_keywords_from_tags(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
             tags=Tags(pathology=["healthy"], modality=["motor"], type=["imagery"]),
@@ -1248,9 +1137,7 @@ class TestBuildDatasetDescriptionKeywords:
 
     def test_bci_applications_merged_into_keywords(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
             tags=Tags(pathology=["healthy"], modality=["motor"], type=["imagery"]),
@@ -1266,9 +1153,7 @@ class TestBuildDatasetDescriptionKeywords:
 
     def test_bci_applications_not_merged_when_explicit_keywords(self):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(keywords=["BCI", "EEG"]),
@@ -1285,9 +1170,7 @@ class TestUpdateDatasetDescriptionExtra:
 
     def test_no_description_file(self, tmp_path):
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(publication_year=2020),
@@ -1301,9 +1184,7 @@ class TestUpdateDatasetDescriptionExtra:
             json.dump({"Name": "Test"}, f)
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(publication_year=2021, keywords=["BCI"]),
@@ -1320,9 +1201,7 @@ class TestUpdateDatasetDescriptionExtra:
             json.dump({"Name": "Test", "PublicationYear": 2019}, f)
 
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery"),
             documentation=DocumentationMetadata(publication_year=2021),
@@ -1399,9 +1278,7 @@ class TestBuildHedSidecarAnnotations:
     def test_metadata_override(self):
         custom_tags = {"left_hand": "Custom-tag, Left", "right_hand": "Custom-tag, Right"}
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery", hed_tags=custom_tags),
         )
@@ -1417,9 +1294,7 @@ class TestBuildHedSidecarAnnotations:
         """Partial hed_tags override merges with paradigm defaults."""
         custom_tags = {"left_hand": "Custom-tag, Left"}
         metadata = DatasetMetadata(
-            acquisition=AcquisitionMetadata(
-                sampling_rate=256, n_channels=2, channel_types={"eeg": 2}
-            ),
+            acquisition=AcquisitionMetadata(sampling_rate=256, channel_types={"eeg": 2}),
             participants=ParticipantMetadata(n_subjects=1),
             experiment=ExperimentMetadata(paradigm="imagery", hed_tags=custom_tags),
         )
@@ -1964,7 +1839,6 @@ class TestBuildReadme:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=512.0,
-                n_channels=64,
                 channel_types={"eeg": 60, "eog": 4},
                 hardware="BrainAmp DC",
                 reference="FCz",
@@ -1988,7 +1862,7 @@ class TestBuildReadme:
     def test_readme_with_participants(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(
                 n_subjects=20,
@@ -2015,7 +1889,7 @@ class TestBuildReadme:
     def test_readme_with_experiment(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(
@@ -2039,7 +1913,7 @@ class TestBuildReadme:
     def test_readme_with_documentation(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -2068,7 +1942,7 @@ class TestBuildReadme:
     def test_readme_with_preprocessing(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -2088,7 +1962,7 @@ class TestBuildReadme:
     def test_readme_with_signal_processing(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -2105,7 +1979,7 @@ class TestBuildReadme:
     def test_readme_with_cross_validation(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -2123,7 +1997,7 @@ class TestBuildReadme:
     def test_readme_with_bci_application(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -2143,7 +2017,7 @@ class TestBuildReadme:
     def test_readme_with_tags(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -2163,7 +2037,7 @@ class TestBuildReadme:
     def test_readme_with_paradigm_specific(self):
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="ssvep"),
@@ -2198,7 +2072,7 @@ class TestBuildReadme:
         """Sections with no populated fields should not appear."""
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+                sampling_rate=256.0, channel_types={"eeg": 32}
             ),
             participants=ParticipantMetadata(n_subjects=10),
             experiment=ExperimentMetadata(paradigm="imagery"),
@@ -2216,7 +2090,6 @@ class TestBuildReadme:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256.0,
-                n_channels=32,
                 channel_types={"eeg": 32},
                 hardware="n/a",
                 ground="n/a",
@@ -2239,7 +2112,7 @@ def _minimal_metadata(**overrides):
     """Build a DatasetMetadata with only required fields plus overrides."""
     kwargs = {
         "acquisition": AcquisitionMetadata(
-            sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
+            sampling_rate=256.0, channel_types={"eeg": 32}
         ),
         "participants": ParticipantMetadata(n_subjects=10),
         "experiment": ExperimentMetadata(paradigm="imagery"),
@@ -2269,7 +2142,6 @@ class TestReadmeAcquisitionFields:
         "field,value,expected",
         [
             ("sampling_rate", 512.0, "512.0 Hz"),
-            ("n_channels", 64, "64"),
             ("channel_types", {"eeg": 60, "eog": 4}, "eeg=60, eog=4"),
             ("sensors", ["Fp1", "Fp2"], "Fp1, Fp2"),
             ("sensor_type", "Ag/AgCl wet", "Ag/AgCl wet"),
@@ -2288,11 +2160,20 @@ class TestReadmeAcquisitionFields:
         ],
     )
     def test_field_present(self, field, value, expected):
-        kwargs = {"sampling_rate": 256.0, "n_channels": 32, "channel_types": {"eeg": 32}}
+        kwargs = {"sampling_rate": 256.0, "channel_types": {"eeg": 32}}
         kwargs[field] = value
         meta = _minimal_metadata(acquisition=AcquisitionMetadata(**kwargs))
         readme = _build_readme(_mock_ds(meta))
         assert expected in readme
+
+    def test_derived_n_channels_present(self):
+        """``n_channels`` is no longer a field, but the README still shows it."""
+        meta = _minimal_metadata(
+            acquisition=AcquisitionMetadata(
+                sampling_rate=256.0, channel_types={"eeg": 60, "eog": 4}
+            )
+        )
+        assert "64" in _build_readme(_mock_ds(meta))
 
 
 class TestReadmeAuxiliaryChannelsFields:
@@ -2317,7 +2198,6 @@ class TestReadmeAuxiliaryChannelsFields:
     def test_aux_field(self, aux_kwargs, expected):
         acq = AcquisitionMetadata(
             sampling_rate=256.0,
-            n_channels=32,
             channel_types={"eeg": 32},
             auxiliary_channels=AuxiliaryChannelsMetadata(**aux_kwargs),
         )

--- a/moabb/tests/test_datasets.py
+++ b/moabb/tests/test_datasets.py
@@ -519,7 +519,6 @@ class Test_Datasets:
             METADATA = DatasetMetadata(
                 acquisition=AcquisitionMetadata(
                     sampling_rate=256.0,
-                    n_channels=8,
                     channel_types={"eeg": 8},
                     hardware="BrainAmp",
                     sensor_type="Ag/AgCl",
@@ -593,7 +592,7 @@ class Test_Datasets:
 
             METADATA = DatasetMetadata(
                 acquisition=AcquisitionMetadata(
-                    sampling_rate=256.0, n_channels=8, channel_types={"eeg": 8}
+                    sampling_rate=256.0, channel_types={"eeg": 8}
                 ),
                 participants=ParticipantMetadata(n_subjects=4, health_status="healthy"),
                 experiment=ExperimentMetadata(paradigm="imagery"),

--- a/moabb/tests/test_metadata.py
+++ b/moabb/tests/test_metadata.py
@@ -40,7 +40,7 @@ class TestAcquisitionMetadata:
     def test_required_fields_only(self):
         """Test instantiation with only required fields."""
         acq = AcquisitionMetadata(
-            sampling_rate=512.0, n_channels=64, channel_types={"eeg": 60, "eog": 4}
+            sampling_rate=512.0, channel_types={"eeg": 60, "eog": 4}
         )
         assert acq.sampling_rate == 512.0
         assert acq.n_channels == 64
@@ -60,7 +60,6 @@ class TestAcquisitionMetadata:
         """Test instantiation with all fields."""
         acq = AcquisitionMetadata(
             sampling_rate=1000.0,
-            n_channels=128,
             channel_types={"eeg": 120, "eog": 4, "emg": 4},
             sensors=["Fp1", "Fp2", "F3", "F4"],
             sensor_type="Ag/AgCl wet",
@@ -83,12 +82,8 @@ class TestAcquisitionMetadata:
 
     def test_sensors_mutable_default(self):
         """Test that sensors default list is not shared between instances."""
-        acq1 = AcquisitionMetadata(
-            sampling_rate=512.0, n_channels=64, channel_types={"eeg": 64}
-        )
-        acq2 = AcquisitionMetadata(
-            sampling_rate=256.0, n_channels=32, channel_types={"eeg": 32}
-        )
+        acq1 = AcquisitionMetadata(sampling_rate=512.0, channel_types={"eeg": 64})
+        acq2 = AcquisitionMetadata(sampling_rate=256.0, channel_types={"eeg": 32})
         acq1.sensors.append("Cz")
         assert acq1.sensors == ["Cz"]
         assert acq2.sensors == []
@@ -214,7 +209,7 @@ class TestDatasetMetadata:
     def minimal_acquisition(self):
         """Create minimal AcquisitionMetadata for testing."""
         return AcquisitionMetadata(
-            sampling_rate=512.0, n_channels=64, channel_types={"eeg": 60, "eog": 4}
+            sampling_rate=512.0, channel_types={"eeg": 60, "eog": 4}
         )
 
     @pytest.fixture
@@ -282,7 +277,6 @@ class TestMetadataIntegration:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=512.0,
-                n_channels=22,
                 channel_types={"eeg": 22},
                 sensor_type="Ag/AgCl wet",
                 reference="left earlobe",
@@ -334,7 +328,6 @@ class TestMetadataIntegration:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=256.0,
-                n_channels=64,
                 channel_types={"eeg": 64},
                 hardware="BioSemi ActiveTwo",
                 reference="CMS/DRL",
@@ -358,7 +351,6 @@ class TestMetadataIntegration:
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
                 sampling_rate=250.0,
-                n_channels=8,
                 channel_types={"eeg": 8},
                 sensors=["PO7", "PO3", "POz", "PO4", "PO8", "O1", "Oz", "O2"],
             ),
@@ -473,7 +465,9 @@ class TestMetadataCatalog:
         """Test Dreyer2023 metadata."""
         metadata = get_dataset_metadata("Dreyer2023")
         assert metadata.participants.n_subjects == 87
-        assert metadata.acquisition.n_channels == 27
+        # 27 EEG + 2 EMG + 3 EOG. ``n_channels`` is the total, matching this
+        # dataset's own 32-entry ``sensors`` list.
+        assert metadata.acquisition.n_channels == 32
         assert metadata.documentation.country == "FR"  # ISO alpha-2 code
         assert "10.1038/s41597-023-02445-z" in metadata.documentation.doi
 
@@ -868,7 +862,7 @@ class TestParticipantsResolutionOrdering:
         tsv_path = self._write_participants_tsv(tmp_path, ["sub-1", "sub-2"])
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=128.0, n_channels=1, channel_types={"eeg": 1}
+                sampling_rate=128.0, channel_types={"eeg": 1}
             ),
             participants=ParticipantMetadata(
                 n_subjects=2, ages=[25, None], age_mean=44.0
@@ -887,7 +881,7 @@ class TestParticipantsResolutionOrdering:
         tsv_path = self._write_participants_tsv(tmp_path, ["sub-1", "sub-2"])
         metadata = DatasetMetadata(
             acquisition=AcquisitionMetadata(
-                sampling_rate=128.0, n_channels=1, channel_types={"eeg": 1}
+                sampling_rate=128.0, channel_types={"eeg": 1}
             ),
             participants=ParticipantMetadata(
                 n_subjects=2,


### PR DESCRIPTION
Split out of #1161 so the mechanical part is reviewable on its own. Net **−265 lines**.

## The problem

`AcquisitionMetadata` stored `n_channels` next to `channel_types`, which describes the same fact. The two could disagree, and for **34 of the 147** catalogued datasets they did.

The cause was not carelessness — **the field was being used with two different meanings**:

```python
Dreyer2023A.METADATA.acquisition
#   n_channels   = 27                                  <- EEG electrodes only
#   channel_types = {"eeg": 27, "emg": 2, "eog": 3}     <- 32
#   sensors       = [... 32 entries ...]                <- 32
```

**48 datasets declare more than one channel type**, so the two readings diverge for a third of the catalogue.

## The fix

Delete the field; derive it.

```python
@property
def n_channels(self) -> int:
    return sum(self.channel_types.values())
```

It now consistently means *every recorded channel* — the reading that each dataset's own `sensors` list and `test_n_channels_matches_raw_data` (which counts every non-`stim` channel) already assumed.

The 34 disagreements are not fixed so much as **made impossible**, which is why this adds no validator and no invariant test. `validate_metadata_against_dataset` needs no new assertion.

## What that removes

- **218 `n_channels=` arguments across 93 files**
- the enrichment branch in `metadata/__init__.py` whose only job was to backfill the value
- two `replace(...)` defaults that also disagreed with their own `channel_types`

## Behaviour change

For the 34 datasets that stored the EEG-only count, `n_channels` now reports the total. `Dreyer2023A` goes 27 → 32. One test asserted the old reading and now asserts the total; it is the only one in the suite that pinned a literal value for a multi-type dataset.

Documented under **API changes**, not Bugs: passing `n_channels=` to the constructor is no longer accepted.

## Verification

- `n_channels != sum(channel_types)`: **34 → 0**, and now unrepresentable
- every `AcquisitionMetadata(...)` call site still passes `sampling_rate` and `channel_types` — checked by AST across the package, 0 broken
- 1740 passed (the single failure, `test_lee2024_data_path_downloads_the_real_upstream_inventory`, is pre-existing on `develop`)
- `pre-commit` clean

Closes #1163.
