### PR TITLE
Pre-release 1.6.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -122,7 +122,7 @@ authors:
   given-names: "Sylvain"
   orcid: "https://orcid.org/0000-0003-3027-8241"
 title: "Mother of all BCI Benchmarks"
-version: 1.6.0
+version: 1.6.1
 doi: 10.5281/zenodo.10034223
-date-released: 2026-08-26
+date-released: 2026-08-27
 url: "https://github.com/NeuroTechX/moabb"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A.
 Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E.,
 Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H.,
 Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A.,
-& Chevallier, S. (2026). Mother of all BCI Benchmarks (MOABB) (Version 1.6.0).
+& Chevallier, S. (2026). Mother of all BCI Benchmarks (MOABB) (Version 1.6.1).
 Zenodo. https://doi.org/10.5281/zenodo.10034223
 ```
 
@@ -219,7 +219,7 @@ Zenodo. https://doi.org/10.5281/zenodo.10034223
   title        = {Mother of all BCI Benchmarks},
   year         = 2026,
   publisher    = {Zenodo},
-  version      = {1.6.0},
+  version      = {1.6.1},
   url          = {https://github.com/NeuroTechX/moabb},
   doi          = {10.5281/zenodo.10034223},
 }

--- a/docs/source/cite.rst
+++ b/docs/source/cite.rst
@@ -8,7 +8,7 @@ Citing MOABB and related publications
 If you use MOABB in your experiments, please cite this library when
 publishing a paper to increase the visibility of open science initiatives:
 
--  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.6.0). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
+-  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.6.1). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
 
 and here is the Bibtex version:
 
@@ -61,7 +61,7 @@ and here is the Bibtex version:
             title        = {Mother of all BCI Benchmarks},
             year         = 2026,
             publisher    = {Zenodo},
-            version      = {1.6.0},
+            version      = {1.6.1},
             url = {https://github.com/NeuroTechX/moabb},
             doi = {10.5281/zenodo.10034223},
     }

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -46,7 +46,7 @@ Version 1.6.1  (Stable - PyPi)
 
 Enhancements
 ~~~~~~~~~~~~
-- None yet.
+- None.
 
 API changes
 ~~~~~~~~~~~
@@ -54,7 +54,7 @@ API changes
 
 Requirements
 ~~~~~~~~~~~~
-- None yet.
+- None.
 
 Bugs
 ~~~~
@@ -68,7 +68,7 @@ Bugs
 
 Code health
 ~~~~~~~~~~~
-- None yet.
+- None.
 
 Version 1.6.0  (Stable - PyPi)
 -------------------------------

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -18,8 +18,31 @@ What's new
 
 .. _current:
 
-Version 1.6.1  (Source - GitHub)
----------------------------------
+Version 1.7  (Source - GitHub)
+-------------------------------
+
+Enhancements
+~~~~~~~~~~~~
+- None yet.
+
+API changes
+~~~~~~~~~~~
+- None yet.
+
+Requirements
+~~~~~~~~~~~~
+- None yet.
+
+Bugs
+~~~~
+- None yet.
+
+Code health
+~~~~~~~~~~~
+- None yet.
+
+Version 1.6.1  (Stable - PyPi)
+-------------------------------
 
 Enhancements
 ~~~~~~~~~~~~

--- a/moabb/__init__.py
+++ b/moabb/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = "1.6.1dev0"
+__version__ = "1.6.1"
 
 from .benchmark import benchmark
 from .utils import (


### PR DESCRIPTION
Bug-fix release.

### Version
`moabb.__version__` 1.6.1dev0 → **1.6.1**, propagated to `CITATION.cff` (+ `date-released: 2026-08-27`), `README.md` and `docs/source/cite.rst`. All five citation surfaces verified equal at 43 authors; `CITATION.cff` validates with `cffconvert`. The author list is unchanged — every entry in this release is by an existing author.

### Changelog
`Version 1.6.1 (Source - GitHub)` → `(Stable - PyPi)`, and a fresh `Version 1.7 (Source - GitHub)` section opened.

### What is in it

| | |
|---|---|
| #1161 | `BNCI2025_001` label leakage — 7 kinematic channels (target position, hand velocity) were typed `eeg` and picked as classifier features |
| #1161 | The `Rodrigues2017` / `Cattan2019_PHMD` / `Cattan2019_VR` montages :gh:`700` announced and never implemented |
| #1161 | `Cattan2019_PHMD` `interval` described 60 s relaxation blocks as 1 s |
| #1161 | NEMAR prefetch trusted any non-empty store, so a per-subject caller silently reached the upstream host |
| #1161 | `import moabb` mutated the caller's global matplotlib rcParams |
| #1161 | The monthly download job ran `pytest download.py` — a file that does not exist — and had failed every month since March |
| #1166 | `AcquisitionMetadata.n_channels` derived from `channel_types` instead of stored beside it; 34 datasets disagreed with themselves |

Closes #1162, #1163, #1165.