### PR TITLE
ENH: Make dataset bubble plot layouts reproducible

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -23,7 +23,7 @@ Version 1.7  (Source - GitHub)
 
 Enhancements
 ~~~~~~~~~~~~
-- None yet.
+- Make :func:`moabb.analysis.plotting.dataset_bubble_plot` layouts reproducible by default and add a ``random_state`` parameter for controlled alternative layouts.
 
 API changes
 ~~~~~~~~~~~

--- a/moabb/analysis/plotting.py
+++ b/moabb/analysis/plotting.py
@@ -1302,9 +1302,10 @@ def meta_analysis_plot(stats_df, alg1, alg2):  # noqa: C901
     return fig
 
 
-def _get_hexa_grid(n, diameter, center):
-    x = np.arange(n) - n // 2 + np.random.rand()  # TODO
-    y = np.arange(n) - n // 2 + np.random.rand()
+def _get_hexa_grid(n, diameter, center, random_state=0):
+    rng = np.random.default_rng(random_state)
+    x = np.arange(n) - n // 2 + rng.random()
+    y = np.arange(n) - n // 2 + rng.random()
     x, y = np.meshgrid(x, y)
     x = x.flatten()
     y = y.flatten()
@@ -1314,8 +1315,8 @@ def _get_hexa_grid(n, diameter, center):
     )
 
 
-def _get_bubble_coordinates(n, diameter, center):
-    x, y = _get_hexa_grid(n, diameter, center)
+def _get_bubble_coordinates(n, diameter, center, random_state=0):
+    x, y = _get_hexa_grid(n, diameter, center, random_state=random_state)
     dist = np.sqrt((x - center[0]) ** 2 + (y - center[1]) ** 2)
     dort_idx = dist.argsort()
     x = x[dort_idx]
@@ -1341,9 +1342,10 @@ def _plot_hexa_bubbles(
     shape: Literal["circle", "hexagon"] = "circle",
     gap: float = 0.0,
     gid: str | None = None,
+    random_state=0,
     **kwargs,
 ):
-    x, y = _get_bubble_coordinates(n, diameter + gap, center)
+    x, y = _get_bubble_coordinates(n, diameter + gap, center, random_state=random_state)
     bubbles = [
         _plot_shape(shape, (xi, yi), radius=diameter / 2, **kwargs)
         for xi, yi in zip(x, y)
@@ -1463,6 +1465,7 @@ def dataset_bubble_plot(
     n_sessions: int | None = None,
     n_trials: int | None = None,
     trial_len: float | None = None,
+    random_state: int | np.random.Generator | None = 0,
 ):
     """Plot a bubble plot for a dataset.
 
@@ -1529,6 +1532,10 @@ def dataset_bubble_plot(
         Number of trials per session. Required if ``dataset`` is None.
     trial_len: float | None
         Duration of one trial, in seconds. Required if ``dataset`` is None.
+    random_state: int | numpy.random.Generator | None
+        Controls the small offset used to arrange subjects on the hexagonal grid.
+        The default, 0, produces reproducible layouts. Pass ``None`` for a fresh,
+        non-deterministic layout on each call.
     """
     p = sea.color_palette("tab10", 5)
     color_map = color_map or dict(zip(["imagery", "p300", "ssvep", "cvep", "rstate"], p))
@@ -1569,6 +1576,7 @@ def dataset_bubble_plot(
         shape=shape,
         gap=gap,
         gid=f"bubbles/{dataset_name}",
+        random_state=random_state,
     )
     if title:
         ax.text(

--- a/moabb/tests/test_plotting.py
+++ b/moabb/tests/test_plotting.py
@@ -2,13 +2,17 @@ import matplotlib
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib import pyplot as plt
 from matplotlib.pyplot import Figure
 
 
 matplotlib.use("Agg")
 
 from moabb.analysis.plotting import (
+    _get_bubble_coordinates,
     _get_dataset_parameters,
+    _get_hexa_grid,
+    dataset_bubble_plot,
     distribution_plot,
     paired_plot,
     score_plot,
@@ -71,3 +75,52 @@ def test_distribution_plot():
 def test_paired_plot():
     fig = paired_plot(_make_df(), "P0", "P1", chance_level="auto")
     assert isinstance(fig, Figure)
+
+
+def test_hexa_grid_is_reproducible():
+    x1, y1 = _get_hexa_grid(4, 1.0, (0.0, 0.0), random_state=42)
+    x2, y2 = _get_hexa_grid(4, 1.0, (0.0, 0.0), random_state=42)
+
+    np.testing.assert_array_equal(x1, x2)
+    np.testing.assert_array_equal(y1, y2)
+
+
+def test_hexa_grid_accepts_generator():
+    x1, y1 = _get_hexa_grid(4, 1.0, (0.0, 0.0), random_state=np.random.default_rng(42))
+    x2, y2 = _get_hexa_grid(4, 1.0, (0.0, 0.0), random_state=np.random.default_rng(42))
+
+    np.testing.assert_array_equal(x1, x2)
+    np.testing.assert_array_equal(y1, y2)
+
+
+def test_bubble_coordinates_change_with_seed():
+    x1, y1 = _get_bubble_coordinates(6, 1.0, (0.0, 0.0), random_state=1)
+    x2, y2 = _get_bubble_coordinates(6, 1.0, (0.0, 0.0), random_state=2)
+
+    assert not (np.array_equal(x1, x2) and np.array_equal(y1, y2))
+
+
+def test_dataset_bubble_plot_is_reproducible():
+    kwargs = {
+        "dataset_name": "TestDataset",
+        "paradigm": "imagery",
+        "n_subjects": 8,
+        "n_sessions": 1,
+        "n_trials": 100,
+        "trial_len": 2.0,
+        "legend": False,
+        "random_state": 42,
+    }
+    fig1, ax1 = plt.subplots()
+    dataset_bubble_plot(**kwargs, ax=ax1)
+    fig1.canvas.draw()
+    image1 = np.asarray(fig1.canvas.buffer_rgba()).copy()
+    plt.close(fig1)
+
+    fig2, ax2 = plt.subplots()
+    dataset_bubble_plot(**kwargs, ax=ax2)
+    fig2.canvas.draw()
+    image2 = np.asarray(fig2.canvas.buffer_rgba()).copy()
+    plt.close(fig2)
+
+    np.testing.assert_array_equal(image1, image2)


### PR DESCRIPTION
## Summary

This PR makes the subject layout generated by `dataset_bubble_plot`
reproducible.

The hexagonal grid previously used the global `np.random` state. As a
result, repeated calls with identical inputs could produce different
figures. This made generated dataset visualizations harder to reproduce
and prevented reliable image-level regression testing.

## Changes

- Add a `random_state` parameter to `dataset_bubble_plot`.
- Propagate it through the internal bubble-coordinate helpers.
- Use `numpy.random.default_rng` instead of the global NumPy random state.
- Use `random_state=0` by default to produce stable layouts.
- Accept an integer seed, a `numpy.random.Generator`, or `None`.
- Preserve explicitly non-deterministic layouts with `random_state=None`.
- Add tests covering:
  - repeatability with an integer seed;
  - support for `numpy.random.Generator`;
  - different coordinates for different seeds;
  - pixel-identical rendered figures for repeated calls.
- Add a changelog entry for MOABB 1.7.

## Motivation

MOABB is focused on reproducible BCI evaluation. Figures generated from
identical inputs should therefore also be reproducible. A local random
number generator additionally prevents unrelated calls to NumPy's global
RNG from changing the plot layout.

## Example

```python
from moabb.analysis.plotting import dataset_bubble_plot

# Reproducible default layout
dataset_bubble_plot(dataset)

# Reproducible alternative layout
dataset_bubble_plot(dataset, random_state=42)

# Fresh layout on every call
dataset_bubble_plot(dataset, random_state=None)