### PR TITLE
Use cached data before prefetching NEMAR

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -35,7 +35,7 @@ Requirements
 
 Bugs
 ~~~~
-- None yet.
+- Let :meth:`moabb.datasets.base.BaseDataset.get_data` use a complete processing cache before prefetching NEMAR, so cached data remains available when NEMAR or the network is unavailable (by `Bruno Aristimunha`_).
 
 Code health
 ~~~~~~~~~~~

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -887,7 +887,9 @@ class BaseDataset(metaclass=MetaclassDataset):
             if subject not in self.subject_list:
                 raise ValueError("Invalid subject {:d} given".format(subject))
 
-        self._prefetch_nemar_sourcedata(subjects)
+        self._prefetch_nemar_sourcedata(
+            self._subjects_without_cache(subjects, cache_config, process_pipeline)
+        )
 
         results = Parallel(n_jobs=n_jobs)(
             delayed(self._get_selected_subject_data)(
@@ -920,6 +922,32 @@ class BaseDataset(metaclass=MetaclassDataset):
                 or ((m := re.fullmatch(pat, k)) and m.group(1) in str_sessions)
             }
         return subject_data
+
+    def _subjects_without_cache(self, subjects, cache_config, process_pipeline):
+        """Return subjects whose source data must be loaded."""
+        if not cache_config.use:
+            return subjects
+
+        steps = list(process_pipeline.steps)
+        missing = []
+        for subject in subjects:
+            for end in range(len(steps), 0, -1):
+                cached_steps = steps[:end]
+                cache_type = cached_steps[-1][0]
+                if getattr(cache_config, f"overwrite_{cache_type.value}"):
+                    continue
+                interface = _interface_map[cache_type](
+                    self,
+                    subject,
+                    path=cache_config.path,
+                    process_pipeline=FixedPipeline(cached_steps),
+                    verbose=cache_config.verbose,
+                )
+                if interface._cache_paths():
+                    break
+            else:
+                missing.append(subject)
+        return missing
 
     def download(
         self,
@@ -1424,6 +1452,8 @@ class BaseDataset(metaclass=MetaclassDataset):
             sessions_data = None
             # Load and eventually overwrite:
             if len(cached_steps) == 0:  # last option: we don't use cache
+                if get_download_provider() == "nemar":
+                    self._prefetch_nemar_sourcedata([subject])
                 with active_sourcedata_store(self._sourcedata_store()):
                     sessions_data = self._get_single_subject_data(subject)
                 assert sessions_data is not None  # should not happen

--- a/moabb/datasets/base.py
+++ b/moabb/datasets/base.py
@@ -1452,7 +1452,7 @@ class BaseDataset(metaclass=MetaclassDataset):
             sessions_data = None
             # Load and eventually overwrite:
             if len(cached_steps) == 0:  # last option: we don't use cache
-                if get_download_provider() == "nemar":
+                if get_download_provider() != "upstream":
                     self._prefetch_nemar_sourcedata([subject])
                 with active_sourcedata_store(self._sourcedata_store()):
                     sessions_data = self._get_single_subject_data(subject)

--- a/moabb/datasets/bids_interface.py
+++ b/moabb/datasets/bids_interface.py
@@ -2337,13 +2337,28 @@ class BIDSInterfaceBase(abc.ABC):
         code_dir = self.root / "code"
         code_dir.mkdir(parents=True, exist_ok=True)
 
-        # Check for non-session-aware legacy lock files (backward compatibility)
-        legacy_lock_exists = (
-            self._migration_lock_file.exists() or self._legacy_lock_file.fpath.exists()
-        )
         # Ensure the legacy BIDSPath directory exists for mne_bids compatibility
         self._legacy_lock_file.mkdir(exist_ok=True)
 
+        paths = self._cache_paths()
+
+        if not paths:
+            log.info("No cache found at %s.", str(code_dir))
+            return None
+
+        sessions_data = {}
+        for path in paths:
+            session_moabb = path.session
+            session = sessions_data.setdefault(session_moabb, {})
+            run = self._load_file(path, preload=preload)
+            session[run_bids_to_moabb(path)] = run
+        log.info("Finished reading cache of %s", repr(self))
+        return sessions_data
+
+    def _cache_paths(self):
+        legacy_lock_exists = (
+            self._migration_lock_file.exists() or self._legacy_lock_file.fpath.exists()
+        )
         paths = mne_bids.find_matching_paths(
             root=self.root,
             subjects=subject_moabb_to_bids(self.subject),
@@ -2354,27 +2369,14 @@ class BIDSInterfaceBase(abc.ABC):
             suffixes=self._suffix,
         )
 
-        if not paths:
-            log.info("No cache found at %s.", str(code_dir))
-            return None
-
         # Check per-session lock files unless a legacy (non-session-aware) lock
         # file exists, which indicates the whole subject was already cached.
-        if not legacy_lock_exists:
+        if paths and not legacy_lock_exists:
             found_sessions = {path.session for path in paths}
             missing = [s for s in found_sessions if not self._lock_file(s).exists()]
             if missing:
-                log.info("No cache found at %s.", str(code_dir))
-                return None
-
-        sessions_data = {}
-        for path in paths:
-            session_moabb = path.session
-            session = sessions_data.setdefault(session_moabb, {})
-            run = self._load_file(path, preload=preload)
-            session[run_bids_to_moabb(path)] = run
-        log.info("Finished reading cache of %s", repr(self))
-        return sessions_data
+                return []
+        return paths
 
     def save(self, sessions_data):
         """Save the cache of the subject.

--- a/moabb/tests/test_download.py
+++ b/moabb/tests/test_download.py
@@ -1180,6 +1180,9 @@ def test_get_data_prefetches_the_requested_subjects(monkeypatch):
 
     fetched = []
     monkeypatch.setattr(
+        base_module, "nemar_sourcedata_is_local", lambda root, subject: subject in fetched
+    )
+    monkeypatch.setattr(
         dataset,
         "sourcedata_path",
         lambda subject=None, verbose=None: fetched.append(subject),
@@ -1210,8 +1213,9 @@ def test_get_data_uses_cache_before_nemar_prefetch(tmp_path, monkeypatch):
     assert list(dataset.get_data(subjects=[1], cache_config=cache_config)) == [1]
 
 
-def test_get_data_does_not_fall_through_if_pinned_cache_disappears(tmp_path, monkeypatch):
-    """A concurrent cache removal must not bypass a pinned NEMAR provider."""
+@pytest.mark.parametrize("provider", ["auto", "nemar"])
+def test_get_data_rechecks_nemar_if_cache_disappears(tmp_path, monkeypatch, provider):
+    """A concurrent cache removal must preserve NEMAR-first behavior."""
     dataset = FakeDataset(n_subjects=1, n_sessions=1, n_runs=1)
     dataset.nemar_id = "nm000341"
     cache_config = {"save_raw": True, "use": True, "path": tmp_path}
@@ -1219,7 +1223,7 @@ def test_get_data_does_not_fall_through_if_pinned_cache_disappears(tmp_path, mon
     monkeypatch.setattr(base_module, "get_download_provider", lambda: "upstream")
     dataset.get_data(subjects=[1], cache_config=cache_config)
 
-    monkeypatch.setattr(base_module, "get_download_provider", lambda: "nemar")
+    monkeypatch.setattr(base_module, "get_download_provider", lambda: provider)
     interface_class = base_module._interface_map[base_module.StepType.RAW]
     original_cache_paths = interface_class._cache_paths
 
@@ -1231,12 +1235,16 @@ def test_get_data_does_not_fall_through_if_pinned_cache_disappears(tmp_path, mon
 
     monkeypatch.setattr(interface_class, "_cache_paths", remove_after_check)
 
-    def offline(**kwargs):
-        raise dl.NemarDownloadError("NEMAR is offline")
+    class PrefetchCalled(Exception):
+        pass
 
-    monkeypatch.setattr(dataset, "sourcedata_path", offline)
+    def prefetch(subjects):
+        if subjects:
+            raise PrefetchCalled
 
-    with pytest.raises(dl.NemarDownloadError, match="NEMAR is offline"):
+    monkeypatch.setattr(dataset, "_prefetch_nemar_sourcedata", prefetch)
+
+    with pytest.raises(PrefetchCalled):
         dataset.get_data(subjects=[1], cache_config=cache_config)
 
 

--- a/moabb/tests/test_download.py
+++ b/moabb/tests/test_download.py
@@ -1191,6 +1191,55 @@ def test_get_data_prefetches_the_requested_subjects(monkeypatch):
     assert sorted(data) == [1, 3]
 
 
+def test_get_data_uses_cache_before_nemar_prefetch(tmp_path, monkeypatch):
+    """A complete processing cache must remain usable while NEMAR is offline."""
+    dataset = FakeDataset(n_subjects=1, n_sessions=1, n_runs=1)
+    dataset.nemar_id = "nm000341"
+    cache_config = {"save_raw": True, "use": True, "path": tmp_path}
+
+    monkeypatch.setattr(base_module, "get_download_provider", lambda: "upstream")
+    dataset.get_data(subjects=[1], cache_config=cache_config)
+
+    monkeypatch.setattr(base_module, "get_download_provider", lambda: "nemar")
+    monkeypatch.setattr(
+        dataset,
+        "sourcedata_path",
+        lambda **kwargs: pytest.fail("NEMAR was contacted for cached data"),
+    )
+
+    assert list(dataset.get_data(subjects=[1], cache_config=cache_config)) == [1]
+
+
+def test_get_data_does_not_fall_through_if_pinned_cache_disappears(tmp_path, monkeypatch):
+    """A concurrent cache removal must not bypass a pinned NEMAR provider."""
+    dataset = FakeDataset(n_subjects=1, n_sessions=1, n_runs=1)
+    dataset.nemar_id = "nm000341"
+    cache_config = {"save_raw": True, "use": True, "path": tmp_path}
+
+    monkeypatch.setattr(base_module, "get_download_provider", lambda: "upstream")
+    dataset.get_data(subjects=[1], cache_config=cache_config)
+
+    monkeypatch.setattr(base_module, "get_download_provider", lambda: "nemar")
+    interface_class = base_module._interface_map[base_module.StepType.RAW]
+    original_cache_paths = interface_class._cache_paths
+
+    def remove_after_check(interface):
+        paths = original_cache_paths(interface)
+        if paths:
+            interface.erase()
+        return paths
+
+    monkeypatch.setattr(interface_class, "_cache_paths", remove_after_check)
+
+    def offline(**kwargs):
+        raise dl.NemarDownloadError("NEMAR is offline")
+
+    monkeypatch.setattr(dataset, "sourcedata_path", offline)
+
+    with pytest.raises(dl.NemarDownloadError, match="NEMAR is offline"):
+        dataset.get_data(subjects=[1], cache_config=cache_config)
+
+
 def test_store_lookup_falls_back_to_url_tails_when_fname_differs(tmp_path, monkeypatch):
     """gh-1151 review: fname names the destination (experiment prefix, padded
     subject), the store keeps upstream names -- the URL tails must still hit."""


### PR DESCRIPTION
## Problem

`BaseDataset.get_data()` prefetched NEMAR before inspecting MOABB's processing cache. On an offline cluster, a complete raw/epochs/array cache therefore still paid for NEMAR retries; with the provider pinned to `nemar`, loading failed before the cache was read.

## Fix

- Reuse the BIDS cache path and lock checks without deserializing cached EEG twice.
- Prefetch NEMAR only for subjects that actually need source data, preserving the existing longest-cache-prefix and overwrite behavior.
- Recheck pinned-NEMAR policy at the actual source boundary so a concurrently removed cache cannot fall through to an upstream host.

No provider API or cache format changes.

## Verification

- Regression test observed failing before the fix and passing after it.
- `moabb/tests/test_download.py` excluding opt-in download tests: **214 passed, 2 skipped**.
- Cache/overwrite tests in `moabb/tests/test_datasets.py`: **4 passed**.
- All touched-file pre-commit hooks pass.
- Maximum-depth correctness, architecture, impact, and simplification review: **APPROVE; no blockers; lean already**.
- A repository-wide `pytest -q` run was attempted under an isolated MNE config but did not complete within five minutes and was interrupted while blocked in `threading.py`; it emitted no test failure before interruption.