### PR TITLE
Pre-release 1.7.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -122,7 +122,7 @@ authors:
   given-names: "Sylvain"
   orcid: "https://orcid.org/0000-0003-3027-8241"
 title: "Mother of all BCI Benchmarks"
-version: 1.6.1
+version: 1.7.0
 doi: 10.5281/zenodo.10034223
-date-released: 2026-08-27
+date-released: 2026-08-31
 url: "https://github.com/NeuroTechX/moabb"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -104,6 +104,8 @@ authors:
   orcid: "https://orcid.org/0009-0007-2584-4639"
 - family-names: "Singh"
   given-names: "Aditya"
+- family-names: "Sokolova"
+  given-names: "Anna"
 - family-names: "Rahimipour"
   given-names: "Meysam"
 - family-names: "Moreau"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A.
 Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E.,
 Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H.,
 Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A.,
-& Chevallier, S. (2026). Mother of all BCI Benchmarks (MOABB) (Version 1.6.1).
+& Chevallier, S. (2026). Mother of all BCI Benchmarks (MOABB) (Version 1.7.0).
 Zenodo. https://doi.org/10.5281/zenodo.10034223
 ```
 
@@ -219,7 +219,7 @@ Zenodo. https://doi.org/10.5281/zenodo.10034223
   title        = {Mother of all BCI Benchmarks},
   year         = 2026,
   publisher    = {Zenodo},
-  version      = {1.6.1},
+  version      = {1.7.0},
   url          = {https://github.com/NeuroTechX/moabb},
   doi          = {10.5281/zenodo.10034223},
 }

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko
 Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A.,
 Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E.,
 Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H.,
-Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A.,
+Bano, A., Singh, A., Sokolova, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A.,
 & Chevallier, S. (2026). Mother of all BCI Benchmarks (MOABB) (Version 1.7.0).
 Zenodo. https://doi.org/10.5281/zenodo.10034223
 ```
@@ -210,6 +210,7 @@ Zenodo. https://doi.org/10.5281/zenodo.10034223
                   Lefundes da Silva, Henrique and
                   Bano, Azra and
                   Singh, Aditya and
+                  Sokolova, Anna and
                   Rahimipour, Meysam and
                   Moreau, Thomas and
                   Roy, Yannick and

--- a/docs/source/cite.rst
+++ b/docs/source/cite.rst
@@ -8,7 +8,7 @@ Citing MOABB and related publications
 If you use MOABB in your experiments, please cite this library when
 publishing a paper to increase the visibility of open science initiatives:
 
--  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.6.1). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
+-  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.7.0). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
 
 and here is the Bibtex version:
 
@@ -61,7 +61,7 @@ and here is the Bibtex version:
             title        = {Mother of all BCI Benchmarks},
             year         = 2026,
             publisher    = {Zenodo},
-            version      = {1.6.1},
+            version      = {1.7.0},
             url = {https://github.com/NeuroTechX/moabb},
             doi = {10.5281/zenodo.10034223},
     }

--- a/docs/source/cite.rst
+++ b/docs/source/cite.rst
@@ -8,7 +8,7 @@ Citing MOABB and related publications
 If you use MOABB in your experiments, please cite this library when
 publishing a paper to increase the visibility of open science initiatives:
 
--  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.7.0). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
+-  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Sokolova, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.7.0). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
 
 and here is the Bibtex version:
 
@@ -52,6 +52,7 @@ and here is the Bibtex version:
 	                      Lefundes da Silva, Henrique and
 	                      Bano, Azra and
 	                      Singh, Aditya and
+	                      Sokolova, Anna and
 	                      Rahimipour, Meysam and
 	                      Moreau, Thomas and
 	                      Roy, Yannick and

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -23,7 +23,7 @@ Version 1.8  (Source - GitHub)
 
 Enhancements
 ~~~~~~~~~~~~
-- Make :func:`moabb.analysis.plotting.dataset_bubble_plot` layouts reproducible by default and add a ``random_state`` parameter for controlled alternative layouts.
+- None yet.
 
 API changes
 ~~~~~~~~~~~
@@ -46,7 +46,7 @@ Version 1.7  (Stable - PyPi)
 
 Enhancements
 ~~~~~~~~~~~~
-- None.
+- Make :func:`moabb.analysis.plotting.dataset_bubble_plot` layouts reproducible by default and add a ``random_state`` parameter for controlled alternative layouts (:gh:`1168` by `Anna Sokolova`_).
 
 API changes
 ~~~~~~~~~~~
@@ -1033,3 +1033,4 @@ API changes
 .. _Michele Romani: https://github.com/BRomans
 .. _Barış Talar: https://github.com/baris-talar
 .. _Iain: https://github.com/NotAFlightRisk
+.. _Anna Sokolova: https://github.com/ZyntZ

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -18,7 +18,7 @@ What's new
 
 .. _current:
 
-Version 1.7  (Source - GitHub)
+Version 1.8  (Source - GitHub)
 -------------------------------
 
 Enhancements
@@ -35,11 +35,34 @@ Requirements
 
 Bugs
 ~~~~
-- Let :meth:`moabb.datasets.base.BaseDataset.get_data` use a complete processing cache before prefetching NEMAR, so cached data remains available when NEMAR or the network is unavailable (by `Bruno Aristimunha`_).
+- None yet.
 
 Code health
 ~~~~~~~~~~~
 - None yet.
+
+Version 1.7  (Stable - PyPi)
+-----------------------------
+
+Enhancements
+~~~~~~~~~~~~
+- None.
+
+API changes
+~~~~~~~~~~~
+- None.
+
+Requirements
+~~~~~~~~~~~~
+- None.
+
+Bugs
+~~~~
+- Let :meth:`moabb.datasets.base.BaseDataset.get_data` use a complete processing cache before prefetching NEMAR, so cached data remains available when NEMAR or the network is unavailable (by `Bruno Aristimunha`_).
+
+Code health
+~~~~~~~~~~~
+- None.
 
 Version 1.6.1  (Stable - PyPi)
 -------------------------------

--- a/moabb/__init__.py
+++ b/moabb/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = "1.7.0dev0"
+__version__ = "1.7.0"
 
 from .benchmark import benchmark
 from .utils import (


### PR DESCRIPTION
Release MOABB 1.7.0.

### Version
- `moabb.__version__`: `1.7.0dev0` → `1.7.0`
- update `CITATION.cff`, `README.md`, and `docs/source/cite.rst`
- set release date to 2026-08-31

### Changelog
- mark Version 1.7 as stable
- open the Version 1.8 development section
- include #1169: use cached processing data before NEMAR prefetch, including offline and concurrent-cache-removal behavior
- include #1168: make dataset bubble plot layouts reproducible, with contributor credit for Anna Sokolova

### Validation
- all CI checks for #1168 and #1169 passed on Ubuntu, macOS, and Windows
- plotting tests passed: 166 passed, 2 skipped
- pre-commit passed for all release files and merged plotting files
- `cffconvert --validate` passed
- wheel and sdist built successfully with version 1.7.0 metadata