### PR TITLE
Pre-release 1.7.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -124,7 +124,7 @@ authors:
   given-names: "Sylvain"
   orcid: "https://orcid.org/0000-0003-3027-8241"
 title: "Mother of all BCI Benchmarks"
-version: 1.7.0
+version: 1.7.1
 doi: 10.5281/zenodo.10034223
 date-released: 2026-08-31
 url: "https://github.com/NeuroTechX/moabb"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A.
 Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E.,
 Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H.,
 Bano, A., Singh, A., Sokolova, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A.,
-& Chevallier, S. (2026). Mother of all BCI Benchmarks (MOABB) (Version 1.7.0).
+& Chevallier, S. (2026). Mother of all BCI Benchmarks (MOABB) (Version 1.7.1).
 Zenodo. https://doi.org/10.5281/zenodo.10034223
 ```
 
@@ -220,7 +220,7 @@ Zenodo. https://doi.org/10.5281/zenodo.10034223
   title        = {Mother of all BCI Benchmarks},
   year         = 2026,
   publisher    = {Zenodo},
-  version      = {1.7.0},
+  version      = {1.7.1},
   url          = {https://github.com/NeuroTechX/moabb},
   doi          = {10.5281/zenodo.10034223},
 }

--- a/docs/source/cite.rst
+++ b/docs/source/cite.rst
@@ -8,7 +8,7 @@ Citing MOABB and related publications
 If you use MOABB in your experiments, please cite this library when
 publishing a paper to increase the visibility of open science initiatives:
 
--  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Sokolova, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.7.0). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
+-  Aristimunha, B., Carrara, I., Guetschel, P., Sedlar, S., Rodrigues, P., Sosulski, J., Narayanan, D., Bjareholt, E., Barthelemy, Q., Schirrmeister, R. T., Kobler, R., Kalunga, E., Darmet, L., Gregoire, C., Abdul Hussain, A., Gatti, R., Goncharenko, V., Andreev, A., Tates, A., Kojima, S., Thielen, J., Hajhassani, D., Graignic, P.-A., Begany, K., Leto, B., Davis, E., Munro, Z., Romani, M., Talar, B., Schrag, E., Kowshik, B., Badang, R. A., Xu, G., Polychroniadou, D., Lefundes da Silva, H., Bano, A., Singh, A., Sokolova, A., Rahimipour, M., Moreau, T., Roy, Y., Jayaram, V., Barachant, A., & Chevallier, S. (2026). Mother of all BCI Benchmarks (Version 1.7.1). Zenodo. `10.5281/zenodo.10034223 <https://doi.org/10.5281/zenodo.10034223>`__
 
 and here is the Bibtex version:
 
@@ -62,7 +62,7 @@ and here is the Bibtex version:
             title        = {Mother of all BCI Benchmarks},
             year         = 2026,
             publisher    = {Zenodo},
-            version      = {1.7.0},
+            version      = {1.7.1},
             url = {https://github.com/NeuroTechX/moabb},
             doi = {10.5281/zenodo.10034223},
     }

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -41,6 +41,29 @@ Code health
 ~~~~~~~~~~~
 - None yet.
 
+Version 1.7.1  (Stable - PyPi)
+-------------------------------
+
+Enhancements
+~~~~~~~~~~~~
+- None.
+
+API changes
+~~~~~~~~~~~
+- None.
+
+Requirements
+~~~~~~~~~~~~
+- None.
+
+Bugs
+~~~~
+- Let the ``"auto"`` download provider fall back when ``nemar-py`` leaks an ``httpx.TransportError``, such as a proxy failure, so locally cached upstream data remains usable when NEMAR is unreachable (by `Bruno Aristimunha`_).
+
+Code health
+~~~~~~~~~~~
+- None.
+
 Version 1.7  (Stable - PyPi)
 -----------------------------
 

--- a/moabb/__init__.py
+++ b/moabb/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = "1.8.0dev0"
+__version__ = "1.7.1"
 
 from .benchmark import benchmark
 from .utils import (

--- a/moabb/datasets/download.py
+++ b/moabb/datasets/download.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 import nemar
 import pandas as pd
 import requests
+from httpx import TransportError
 from mne import get_config, set_config
 from mne.datasets.utils import _get_path
 from mne.utils import _url_to_local_path, verbose, warn
@@ -383,7 +384,7 @@ def nemar_dl(
             trust_existing=not force_update,
             **bids_filters,
         )
-    except (NemarError, OSError, ConnectionError, TimeoutError, ValueError) as exc:
+    except (NemarError, TransportError, OSError, ValueError) as exc:
         raise NemarDownloadError(f"Could not download NEMAR dataset {nemar_id}.") from exc
     return str(target_dir)
 
@@ -432,7 +433,7 @@ def _sourcedata_files_for_subject(target_dir, nemar_id, subject, force_update):
                 f"NEMAR dataset {nemar_id} publishes no sourcedata manifest -- "
                 "the original distribution is not mirrored there."
             ) from exc
-        except (NemarError, OSError, ConnectionError, TimeoutError, ValueError) as exc:
+        except (NemarError, TransportError, OSError, ValueError) as exc:
             raise NemarDownloadError(
                 f"Could not fetch the sourcedata manifest for {nemar_id}: {exc}"
             ) from exc
@@ -644,7 +645,7 @@ def nemar_sourcedata_dl(
         # subject is not in it" both arrive here rather than as a successful
         # empty download.
         raise NemarDownloadError(missing) from exc
-    except (NemarError, OSError, ConnectionError, TimeoutError, ValueError) as exc:
+    except (NemarError, TransportError, OSError, ValueError) as exc:
         # Transport, verification, or S3 failures are not evidence that the
         # deposit publishes no sourcedata -- report them as what they are.
         raise NemarDownloadError(

--- a/moabb/tests/test_download.py
+++ b/moabb/tests/test_download.py
@@ -10,6 +10,7 @@ import zipfile
 from pathlib import Path, PurePath
 from types import SimpleNamespace
 
+import httpx
 import mne
 import pytest
 from mne import get_config, set_config
@@ -1192,6 +1193,25 @@ def test_get_data_prefetches_the_requested_subjects(monkeypatch):
 
     assert fetched == [1, 3]
     assert sorted(data) == [1, 3]
+
+
+def test_get_data_auto_falls_back_from_nemar_proxy_error(
+    tmp_path, monkeypatch, _isolated_mne_config
+):
+    dataset = FakeDataset(n_subjects=1)
+    dataset.nemar_id = "nm000341"
+    set_download_dir(str(tmp_path))
+    monkeypatch.setattr(base_module, "get_download_provider", lambda: "auto")
+
+    def fail(**kwargs):
+        raise httpx.ProxyError("403 Forbidden")
+
+    monkeypatch.setattr(dl.nemar, "download", fail)
+
+    with pytest.warns(RuntimeWarning, match="own downloader"):
+        data = dataset.get_data(subjects=[1])
+
+    assert list(data) == [1]
 
 
 def test_get_data_uses_cache_before_nemar_prefetch(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- catch leaked `httpx.TransportError` exceptions at the NEMAR download boundaries
- preserve the `auto` provider fallback when NEMAR is unreachable through a proxy
- release the fix as MOABB 1.7.1

## Verification

- regression test fails with all transport catches reverted and passes with the fix restored
- supplied BNCI2014_001 MWE loads from disk for both `ConnectError` and `ProxyError`
- `pytest -q moabb/tests/test_download.py`
- `pre-commit run --files CITATION.cff README.md docs/source/cite.rst docs/source/whats_new.rst moabb/__init__.py moabb/datasets/download.py moabb/tests/test_download.py`
- wheel and sdist build successfully and pass `twine check`; isolated wheel import reports `1.7.1`

Upstream report: https://github.com/facebookresearch/neuroai/pull/226#issuecomment-5483774523
