### PR TITLE
Open the 1.8 development cycle

### DIFF
--- a/moabb/__init__.py
+++ b/moabb/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = "1.7.1"
+__version__ = "1.8.0dev0"
 
 from .benchmark import benchmark
 from .utils import (


### PR DESCRIPTION
Restore the development version after publishing MOABB 1.7.1.

Verification:
- importing `moabb` reports `1.8.0dev0`
- pre-commit hooks pass for `moabb/__init__.py`
