### PR TITLE
Fix one-tailed Wilcoxon p-values in compute_pvals_wilcoxon

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -35,7 +35,7 @@ Requirements
 
 Bugs
 ~~~~
-- None yet.
+- Fix :func:`moabb.analysis.meta_analysis.compute_pvals_wilcoxon` reporting the wrong tail when the sign of the mean paired difference disagrees with the signed-rank statistic: the one-tailed p-value is now taken directly from ``scipy.stats.wilcoxon(..., alternative="greater")`` instead of halving the two-sided value and choosing the side from the mean (:gh:`1177` by `Azra Bano`_)
 
 Code health
 ~~~~~~~~~~~

--- a/moabb/analysis/meta_analysis.py
+++ b/moabb/analysis/meta_analysis.py
@@ -188,11 +188,13 @@ def compute_pvals_wilcoxon(df, order=None):
                     # method already yields.
                     out[i, j] = 0.5
                     continue
-                p = stats.wilcoxon(df.loc[:, pipe1], df.loc[:, pipe2])[1]
-                p /= 2
-                # we want the one-tailed p-value
-                if diffs.mean() < 0:
-                    p = 1 - p  # was in the other side of the distribution
+                # One-tailed p-value that pipe1 scores higher than pipe2. The
+                # direction of the signed-rank test is given by its rank sums,
+                # not by the sign of the mean difference, so ask SciPy for the
+                # one-sided test rather than halving the two-sided p-value.
+                p = stats.wilcoxon(
+                    df.loc[:, pipe1], df.loc[:, pipe2], alternative="greater"
+                )[1]
                 # Keep p strictly inside (0, 1) so Stouffer's method stays
                 # finite, as the permutation branch already does. The normal
                 # approximation can underflow to an exact 0, which the one-tailed

--- a/moabb/tests/test_analysis.py
+++ b/moabb/tests/test_analysis.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.stats as stats
 from matplotlib.pyplot import Figure
 
 import moabb.analysis.meta_analysis as ma
@@ -200,6 +201,26 @@ class TestStats:
         assert np.isfinite(pvals).all(), f"P-values must be finite {pvals}"
         assert pvals[0, 1] == 0.5, f"Indistinguishable pipelines give 0.5 {pvals}"
         assert pvals[1, 0] == 0.5, f"Indistinguishable pipelines give 0.5 {pvals}"
+
+    def test_wilcoxon_tail_follows_rank_sums_not_mean(self):
+        # pipeline_1 beats pipeline_2 on 6 of 7 subjects by a small margin and
+        # loses badly on the remaining one, so the mean difference is negative
+        # while the signed-rank statistic favours pipeline_1. The one-tailed
+        # p-value must follow the rank sums, not the sign of the mean. See
+        # issue #1176.
+        diffs = np.array([0.02, 0.02, 0.02, 0.02, 0.02, 0.02, -0.20])
+        df = pd.DataFrame({"pipeline_1": 0.7 + diffs, "pipeline_2": [0.7] * 7})
+        assert diffs.mean() < 0
+        pvals = ma.compute_pvals_wilcoxon(df)
+        expected_greater = stats.wilcoxon(
+            df["pipeline_1"], df["pipeline_2"], alternative="greater"
+        )[1]
+        expected_less = stats.wilcoxon(
+            df["pipeline_1"], df["pipeline_2"], alternative="less"
+        )[1]
+        assert np.isclose(pvals[0, 1], expected_greater), pvals
+        assert np.isclose(pvals[1, 0], expected_less), pvals
+        assert pvals[0, 1] < 0.5 < pvals[1, 0], pvals
 
     def test_wilcoxon_stays_inside_unit_interval(self):
         # Stouffer's method maps 0 and 1 to an infinite z-score, so the Wilcoxon


### PR DESCRIPTION
Fixes #1176

#### What was wrong

`compute_pvals_wilcoxon` built the one-tailed p-value from SciPy's two-sided signed-rank p-value: halve it, then put it on the "pipe1 > pipe2" side if the mean paired difference is positive, else on the other side (`1 - p/2`). The signed-rank test does not test the mean; its direction comes from the rank sums `W+`/`W-`, which disagree with the sign of the mean whenever a few large differences point one way and many small ones the other.

Example, 7 subjects, pipeline 1 wins on 6 by 0.02 and loses on one by 0.20 (SciPy 1.15.3):

| | current `develop` | `scipy.stats.wilcoxon(x, y, alternative=...)` |
|---|---|---|
| `pvals[pipeline_1, pipeline_2]` | 0.8203 | `"greater"`: 0.1797 |
| `pvals[pipeline_2, pipeline_1]` | 0.1797 | `"less"`: 0.9453 |

So the matrix said pipeline 2 was better (p = 0.18) when the signed-rank test says the opposite (p = 0.18 for pipeline 1). The values feed `compute_dataset_statistics` (every dataset with `>= perm_cutoff` subjects), `find_significant_differences` and the summary / meta-analysis plots. When mean and rank sums agree, the halved value still differs from the exact one-sided p by the point mass at the observed statistic (0.82 vs 0.95 above).

#### The fix

Ask SciPy for the one-sided test directly:

```python
p = stats.wilcoxon(df.loc[:, pipe1], df.loc[:, pipe2], alternative="greater")[1]
```

`alternative` exists since SciPy 1.5; moabb requires `scipy>=1.9.3`. The all-zero-differences guard (0.5) and the `(0, 1)` clipping from #1134 are unchanged. In the common case where mean and rank sums agree and the exact method is used, results change only by the point-mass term; with the normal approximation used for larger `n`, the two agree whenever the rank sums and the mean point the same way.

#### Verification (CPU only, Python 3.12, macOS arm64)

```
python -m pytest moabb/tests/test_analysis.py -k "TestStats or Corrected"   # 36 passed
# the new test test_wilcoxon_tail_follows_rank_sums_not_mean fails on develop:
#   assert np.isclose(pvals[0, 1], expected_greater)  ->  0.8203 vs 0.1797
ruff check / ruff format --check on the two changed files                  # clean
```

Also added a "Bugs" entry to `docs/source/whats_new.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
